### PR TITLE
Add main menu and side navigation for role pages

### DIFF
--- a/lib/features/main_menu/main_menu_page.dart
+++ b/lib/features/main_menu/main_menu_page.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import 'package:admin/screens/main/main_screen.dart';
+import 'package:admin/screens/main/components/side_menu.dart';
 import '../preparacao/presentation/preparacao_page.dart';
 import '../operador/presentation/operador_page.dart';
 
@@ -10,6 +12,7 @@ class MainMenuPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Menu Principal')),
+      drawer: const SideMenu(),
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
@@ -22,7 +25,7 @@ class MainMenuPage extends StatelessWidget {
                   ),
                 );
               },
-              child: const Text('Área do Preparador'),
+              child: const Text('Preparador'),
             ),
             const SizedBox(height: 16),
             FilledButton(
@@ -33,14 +36,14 @@ class MainMenuPage extends StatelessWidget {
                   ),
                 );
               },
-              child: const Text('Área do Operador'),
+              child: const Text('Operador'),
             ),
             const SizedBox(height: 16),
             FilledButton(
               onPressed: () {
                 Navigator.of(context).push(
                   MaterialPageRoute(
-                    builder: (_) => const _SupervisaoPage(),
+                    builder: (_) => const MainScreen(),
                   ),
                 );
               },
@@ -49,18 +52,6 @@ class MainMenuPage extends StatelessWidget {
           ],
         ),
       ),
-    );
-  }
-}
-
-class _SupervisaoPage extends StatelessWidget {
-  const _SupervisaoPage();
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('Supervisão')),
-      body: const Center(child: Text('Em desenvolvimento')),
     );
   }
 }

--- a/lib/features/operador/presentation/operador_page.dart
+++ b/lib/features/operador/presentation/operador_page.dart
@@ -8,6 +8,7 @@ import 'package:http/http.dart' as http;
 
 import '../../preparacao/data/models.dart';
 import '../data/repository_provider.dart';
+import 'package:admin/screens/main/components/side_menu.dart';
 
 /// >>>>> Ajuste para o endereço/porta do seu Flask <<<<<
 const String kBaseUrl = 'http://192.168.0.241:5005';
@@ -221,6 +222,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
           )
         ],
       ),
+      drawer: const SideMenu(),
       body: SafeArea(
         child: Padding(
           padding: const EdgeInsets.all(16.0),

--- a/lib/features/preparacao/presentation/preparacao_page.dart
+++ b/lib/features/preparacao/presentation/preparacao_page.dart
@@ -8,6 +8,7 @@ import 'package:http/http.dart' as http;
 
 import 'package:admin/features/preparacao/data/models.dart';
 import 'package:admin/features/operador/data/repository_provider.dart';
+import 'package:admin/screens/main/components/side_menu.dart';
 
 /// Mesmo base URL usado no Operador
 const String kBaseUrl = 'http://192.168.0.241:5005';
@@ -255,6 +256,7 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
           )
         ],
       ),
+      drawer: const SideMenu(),
       body: SafeArea(
         child: Padding(
           padding: const EdgeInsets.all(16.0),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,6 @@
 import 'package:admin/constants.dart';
 import 'package:admin/controllers/menu_app_controller.dart';
-import 'package:admin/screens/main/main_screen.dart';
+import 'package:admin/features/main_menu/main_menu_page.dart';
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:provider/provider.dart';
@@ -28,7 +28,7 @@ class MyApp extends StatelessWidget {
             create: (context) => MenuAppController(),
           ),
         ],
-        child: MainScreen(),
+        child: const MainMenuPage(),
       ),
     );
   }

--- a/lib/screens/main/components/side_menu.dart
+++ b/lib/screens/main/components/side_menu.dart
@@ -3,8 +3,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 
 // Ajuste estes imports para o caminho correto no seu app:
-import '../../../features/preparacao/presentation/preparacao_page.dart';
-import '../../../features/operador/presentation/operador_page.dart';
+import 'package:admin/features/preparacao/presentation/preparacao_page.dart';
+import 'package:admin/features/operador/presentation/operador_page.dart';
+import 'package:admin/screens/main/main_screen.dart';
 
 class SideMenu extends StatelessWidget {
   const SideMenu({Key? key}) : super(key: key);
@@ -28,17 +29,21 @@ class SideMenu extends StatelessWidget {
             child: Image.asset("assets/images/logo.png"),
           ),
           DrawerListTile(
-            title: "Dashboard",
+            title: "Menu Principal",
             svgSrc: "assets/icons/menu_dashboard.svg",
             press: () {
-              // Volta para a rota raiz (onde está seu dashboard)
               Navigator.of(context).popUntil((route) => route.isFirst);
             },
+          ),
+          DrawerListTile(
+            title: "Supervisão",
+            svgSrc: "assets/icons/menu_dashboard.svg",
+            press: () => _go(context, const MainScreen()),
           ),
 
           // ====== SEÇÕES DO SEU SISTEMA ======
           DrawerListTile(
-            title: "Preparação",
+            title: "Preparador",
             svgSrc: "assets/icons/menu_task.svg",
             press: () => _go(context, const PreparacaoPage()),
           ),


### PR DESCRIPTION
## Summary
- Introduce main menu landing page with links to Preparador, Operador and Supervisão areas
- Extend drawer menu with navigation entries for Menu Principal, Supervisão, Preparador and Operador
- Enable drawer navigation on Preparador and Operador screens

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aca983e6508331a2d679bf084a9a9a