### PR TITLE
feat: add reports view to dashboard

### DIFF
--- a/lib/models/report.dart
+++ b/lib/models/report.dart
@@ -1,0 +1,33 @@
+import 'dart:convert';
+
+/// Simple model representing a report record returned from the backend.
+class Report {
+  final String os;
+  final String partnumber;
+  final String operacao;
+  final String status;
+  final String createdAt;
+
+  Report({
+    required this.os,
+    required this.partnumber,
+    required this.operacao,
+    required this.status,
+    required this.createdAt,
+  });
+
+  factory Report.fromJson(Map<String, dynamic> json) {
+    return Report(
+      os: json['os']?.toString() ?? '',
+      partnumber: json['partnumber']?.toString() ?? '',
+      operacao: json['operacao']?.toString() ?? '',
+      status: json['status_geral']?.toString() ?? '',
+      createdAt: json['created_at']?.toString() ?? '',
+    );
+  }
+
+  static List<Report> listFromResponse(String body) {
+    final List<dynamic> data = jsonDecode(body) as List<dynamic>;
+    return data.map((e) => Report.fromJson(e as Map<String, dynamic>)).toList();
+  }
+}

--- a/lib/screens/dashboard/components/reports_table.dart
+++ b/lib/screens/dashboard/components/reports_table.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+
+import '../../../constants.dart';
+import '../../../models/report.dart';
+import '../../../services/report_service.dart';
+
+/// Widget that displays a table with reports fetched from the backend.
+class ReportsTable extends StatelessWidget {
+  const ReportsTable({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final service = ReportService();
+    return FutureBuilder<List<Report>>(
+      future: service.fetchReports(),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        final reports = snapshot.data ?? [];
+        if (reports.isEmpty) {
+          return Container(
+            padding: const EdgeInsets.all(defaultPadding),
+            decoration: BoxDecoration(
+              color: secondaryColor,
+              borderRadius: const BorderRadius.all(Radius.circular(10)),
+            ),
+            child: const Text('Nenhum relatório encontrado'),
+          );
+        }
+        return Container(
+          padding: const EdgeInsets.all(defaultPadding),
+          decoration: BoxDecoration(
+            color: secondaryColor,
+            borderRadius: const BorderRadius.all(Radius.circular(10)),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('Relatórios', style: Theme.of(context).textTheme.titleMedium),
+              SizedBox(
+                width: double.infinity,
+                child: DataTable(
+                  columnSpacing: defaultPadding,
+                  columns: const [
+                    DataColumn(label: Text('O.S')),
+                    DataColumn(label: Text('Partnumber')),
+                    DataColumn(label: Text('Status')),
+                  ],
+                  rows: reports
+                      .map(
+                        (r) => DataRow(cells: [
+                          DataCell(Text(r.os)),
+                          DataCell(Text(r.partnumber)),
+                          DataCell(Text(r.status)),
+                        ]),
+                      )
+                      .toList(),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/screens/dashboard/dashboard_screen.dart
+++ b/lib/screens/dashboard/dashboard_screen.dart
@@ -6,6 +6,7 @@ import '../../constants.dart';
 import 'components/header.dart';
 
 import 'components/recent_files.dart';
+import 'components/reports_table.dart';
 import 'components/storage_details.dart';
 
 class DashboardScreen extends StatelessWidget {
@@ -29,6 +30,8 @@ class DashboardScreen extends StatelessWidget {
                       MyFiles(),
                       SizedBox(height: defaultPadding),
                       RecentFiles(),
+                      SizedBox(height: defaultPadding),
+                      ReportsTable(),
                       if (Responsive.isMobile(context))
                         SizedBox(height: defaultPadding),
                       if (Responsive.isMobile(context)) StorageDetails(),

--- a/lib/services/report_service.dart
+++ b/lib/services/report_service.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:http/http.dart' as http;
+
+import '../models/report.dart';
+
+/// Service responsible for fetching reports from the backend API.
+class ReportService {
+  ReportService({http.Client? client, String? baseUrl})
+      : _client = client ?? http.Client(),
+        _baseUrl = baseUrl ?? dotenv.env['API_BASE_URL'] ?? 'http://localhost:5000';
+
+  final http.Client _client;
+  final String _baseUrl;
+
+  /// Fetches the list of reports from `/reports` endpoint.
+  Future<List<Report>> fetchReports() async {
+    try {
+      final uri = Uri.parse('$_baseUrl/reports');
+      final response = await _client.get(uri);
+      if (response.statusCode == 200) {
+        return Report.listFromResponse(response.body);
+      }
+    } catch (_) {
+      // Ignore errors and return empty list
+    }
+    return [];
+  }
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,30 +1,11 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility that Flutter provides. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:admin/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(MyApp());
-
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+  testWidgets('renders main menu', (tester) async {
+    await tester.pumpWidget(const ProviderScope(child: MyApp()));
+    expect(find.text('Menu Principal'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- add Report model and service to load reports from backend
- display reports table in dashboard
- update widget test for main menu

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b06e0c4d408331bfc35c24b31b753d