### PR TITLE
Add SQL report execution helper and context-aware menu

### DIFF
--- a/app_db.py
+++ b/app_db.py
@@ -73,6 +73,18 @@ def _conn_db(dbname: Optional[str] = None):
         charset="utf8mb4",
     )
 
+def _run_sql_report(sql_path: str, dbname: str = DB_NAME):
+    """Lê um arquivo .sql contendo um SELECT e retorna o resultado."""
+    sql_file = Path(sql_path)
+    if not sql_file.exists():
+        raise FileNotFoundError(f"Arquivo SQL não encontrado: {sql_path}")
+    query = sql_file.read_text(encoding="utf-8")
+    with _conn_db(dbname) as conn:
+        with conn.cursor() as cur:
+            cur.execute(query)
+            rows = cur.fetchall()
+    return rows
+
 def _ensure_schema():
     """Garante que o banco e as tabelas principais existam (sem DDL agressivo)."""
     # Cria o database, se não existir
@@ -887,6 +899,35 @@ def operador_listar():
         return jsonify(rows)
     except Exception as e:
         return jsonify({"error": f"Falha ao consultar amostragens: {e}"}), 500
+
+@app.route("/reports")
+def listar_relatorios():
+    try:
+        with _conn_db(DB_NAME) as c:
+            with c.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT os, partnumber, operacao, status_geral, created_at
+                    FROM preparador_liberacao
+                    ORDER BY created_at DESC
+                    LIMIT 200
+                    """
+                )
+                rows = cur.fetchall()
+        return jsonify(rows)
+    except Exception as e:
+        return jsonify({"error": f"Falha ao consultar relatórios: {e}"}), 500
+
+@app.route("/relatorios/sql")
+def relatorio_sql():
+    path = request.args.get("path")
+    if not path:
+        return jsonify({"error": "parâmetro 'path' obrigatório"}), 400
+    try:
+        rows = _run_sql_report(path)
+        return jsonify(rows)
+    except Exception as e:
+        return jsonify({"error": f"Falha ao executar relatório: {e}"}), 500
 
 @app.route("/health")
 def health():

--- a/lib/features/cadastro_itens/presentation/cadastro_itens_page.dart
+++ b/lib/features/cadastro_itens/presentation/cadastro_itens_page.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+import 'package:admin/screens/main/components/side_menu.dart';
+
+class CadastroItensPage extends StatelessWidget {
+  const CadastroItensPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Cadastro de novos itens')),
+      drawer: const SideMenu(current: SideMenuSection.dashboard),
+      body: const Center(child: Text('Cadastro de novos itens')),
+    );
+  }
+}

--- a/lib/features/cadastro_preparadores/presentation/cadastro_preparadores_page.dart
+++ b/lib/features/cadastro_preparadores/presentation/cadastro_preparadores_page.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+import 'package:admin/screens/main/components/side_menu.dart';
+
+class CadastroPreparadoresPage extends StatelessWidget {
+  const CadastroPreparadoresPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Cadastro de Preparadores')),
+      drawer: const SideMenu(current: SideMenuSection.dashboard),
+      body: const Center(child: Text('Cadastro de Preparadores')),
+    );
+  }
+}

--- a/lib/features/main_menu/main_menu_page.dart
+++ b/lib/features/main_menu/main_menu_page.dart
@@ -12,7 +12,7 @@ class MainMenuPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Menu Principal')),
-      drawer: const SideMenu(),
+      drawer: const SideMenu(current: SideMenuSection.mainMenu),
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/features/operador/presentation/operador_page.dart
+++ b/lib/features/operador/presentation/operador_page.dart
@@ -224,7 +224,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
           )
         ],
       ),
-      drawer: const SideMenu(),
+      drawer: const SideMenu(current: SideMenuSection.operador),
       body: SafeArea(
         child: Padding(
           padding: const EdgeInsets.all(16.0),

--- a/lib/features/preparacao/presentation/preparacao_page.dart
+++ b/lib/features/preparacao/presentation/preparacao_page.dart
@@ -257,7 +257,7 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
           )
         ],
       ),
-      drawer: const SideMenu(),
+      drawer: const SideMenu(current: SideMenuSection.preparador),
       body: SafeArea(
         child: Padding(
           padding: const EdgeInsets.all(16.0),

--- a/lib/screens/main/components/side_menu.dart
+++ b/lib/screens/main/components/side_menu.dart
@@ -4,10 +4,16 @@ import 'package:flutter_svg/flutter_svg.dart';
 
 import 'package:admin/features/preparacao/presentation/preparacao_page.dart';
 import 'package:admin/features/operador/presentation/operador_page.dart';
+import 'package:admin/features/cadastro_itens/presentation/cadastro_itens_page.dart';
+import 'package:admin/features/cadastro_preparadores/presentation/cadastro_preparadores_page.dart';
 import 'package:admin/screens/main/main_screen.dart';
 
+enum SideMenuSection { mainMenu, dashboard, preparador, operador }
+
 class SideMenu extends StatelessWidget {
-  const SideMenu({super.key});
+  const SideMenu({super.key, required this.current});
+
+  final SideMenuSection current;
 
   void _navigate(BuildContext context, Widget page) {
     final navigator = Navigator.of(context, rootNavigator: true);
@@ -27,17 +33,51 @@ class SideMenu extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Drawer(
-      child: ListView(
-        children: [
-          DrawerHeader(
-            child: Image.asset('assets/images/logo.png'),
+    final items = <Widget>[
+      DrawerListTile(
+        title: 'Menu Principal',
+        svgSrc: 'assets/icons/menu_dashboard.svg',
+        press: () => _goHome(context),
+      ),
+    ];
+
+    switch (current) {
+      case SideMenuSection.dashboard:
+        items.addAll([
+          DrawerListTile(
+            title: 'Cadastro de novos itens',
+            svgSrc: 'assets/icons/menu_store.svg',
+            press: () => _navigate(context, const CadastroItensPage()),
           ),
           DrawerListTile(
-            title: 'Menu Principal',
-            svgSrc: 'assets/icons/menu_dashboard.svg',
-            press: () => _goHome(context),
+            title: 'Cadastro de Preparadores',
+            svgSrc: 'assets/icons/menu_profile.svg',
+            press: () =>
+                _navigate(context, const CadastroPreparadoresPage()),
           ),
+        ]);
+        break;
+      case SideMenuSection.preparador:
+        items.add(
+          DrawerListTile(
+            title: 'Operador',
+            svgSrc: 'assets/icons/menu_profile.svg',
+            press: () => _navigate(context, const OperadorPage()),
+          ),
+        );
+        break;
+      case SideMenuSection.operador:
+        items.add(
+          DrawerListTile(
+            title: 'Preparador',
+            svgSrc: 'assets/icons/menu_setting.svg',
+            press: () => _navigate(context, const PreparacaoPage()),
+          ),
+        );
+        break;
+      case SideMenuSection.mainMenu:
+      default:
+        items.addAll([
           DrawerListTile(
             title: 'Preparador',
             svgSrc: 'assets/icons/menu_setting.svg',
@@ -53,8 +93,16 @@ class SideMenu extends StatelessWidget {
             svgSrc: 'assets/icons/menu_task.svg',
             press: () => _navigate(context, MainScreen()),
           ),
+        ]);
+    }
 
-
+    return Drawer(
+      child: ListView(
+        children: [
+          DrawerHeader(
+            child: Image.asset('assets/images/logo.png'),
+          ),
+          ...items,
         ],
       ),
     );

--- a/lib/screens/main/main_screen.dart
+++ b/lib/screens/main/main_screen.dart
@@ -11,7 +11,7 @@ class MainScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       key: context.read<MenuAppController>().scaffoldKey,
-      drawer: SideMenu(),
+      drawer: const SideMenu(current: SideMenuSection.dashboard),
       body: SafeArea(
         child: Row(
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -21,7 +21,7 @@ class MainScreen extends StatelessWidget {
               Expanded(
                 // default flex = 1
                 // and it takes 1/6 part of the screen
-                child: SideMenu(),
+                child: SideMenu(current: SideMenuSection.dashboard),
               ),
             Expanded(
               // It takes 5/6 part of the screen


### PR DESCRIPTION
## Summary
- add helper to run SQL report files
- expose `/relatorios/sql` endpoint to serve query results
- add `/reports` endpoint for Flutter dashboard
- make Flutter side menu context-aware with dashboard registration links and cross-navigation between preparador and operador screens

## Testing
- `flutter test` *(fails: command not found)*
- `pytest`
- `python -m py_compile app_db.py`


------
https://chatgpt.com/codex/tasks/task_e_68b07bdf9d20833198b68ab393e28fea