### PR TITLE
fix: normalize angle limits

### DIFF
--- a/lib/features/operador/data/models.dart
+++ b/lib/features/operador/data/models.dart
@@ -216,6 +216,19 @@ class MedidaItem {
       }
     }
 
+    // Correção para ângulos: registros podem vir com min/max negativos ou
+    // invertidos (ex.: -17, 13 representando 13°–17°). Normaliza para
+    // valores absolutos ordenados quando tratar-se de ângulo.
+    final tituloNorm = _normalizeLower(titulo);
+    final isAngulo =
+        (uni != null && RegExp(r'[°º]').hasMatch(uni)) || tituloNorm.contains('angulo');
+    if (isAngulo && minimo != null && maximo != null) {
+      final vals = [minimo!.abs(), maximo!.abs()]
+        ..sort();
+      minimo = vals.first;
+      maximo = vals.last;
+    }
+
     // Se faixaTexto veio vazio, monta automaticamente a partir de min/max/unidade
     final faixaOut = (faixa.isNotEmpty) ? faixa : _makeFaixaTexto(minimo, maximo, uni);
 

--- a/lib/features/preparacao/data/models.dart
+++ b/lib/features/preparacao/data/models.dart
@@ -216,6 +216,19 @@ class MedidaItem {
       }
     }
 
+    // Correção para ângulos: alguns registros vêm com min/max negativos ou
+    // invertidos (ex.: -17, 13 representando 13°–17°). Normaliza para
+    // valores absolutos e ordenados quando o item é um ângulo.
+    final tituloNorm = _normalizeLower(titulo);
+    final isAngulo =
+        (uni != null && RegExp(r'[°º]').hasMatch(uni)) || tituloNorm.contains('angulo');
+    if (isAngulo && minimo != null && maximo != null) {
+      final vals = [minimo!.abs(), maximo!.abs()]
+        ..sort();
+      minimo = vals.first;
+      maximo = vals.last;
+    }
+
     // Se faixaTexto veio vazio, monta automaticamente a partir de min/max/unidade
     final faixaOut = (faixa.isNotEmpty) ? faixa : _makeFaixaTexto(minimo, maximo, uni);
 


### PR DESCRIPTION
## Summary
- normalize angle min/max values read from backend so angles within tolerance classify correctly

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b184a427a0833191be98833db5db72