### PR TITLE
Handle not-found measures without freezing

### DIFF
--- a/lib/features/preparacao/data/api_medidas_repository.dart
+++ b/lib/features/preparacao/data/api_medidas_repository.dart
@@ -56,6 +56,14 @@ class ApiMedidasRepository implements MedidasRepository {
     if (kDebugMode) debugPrint('GET $uri');
 
     final resp = await _client.get(uri).timeout(const Duration(seconds: 15));
+
+    // Se a peça/operacao não existir, alguns backends retornam 404 ou 204.
+    // Nesses casos consideramos como lista vazia para exibir a mensagem
+    // "Nenhuma medida encontrada" em vez de erro genérico.
+    if (resp.statusCode == 404 || resp.statusCode == 204) {
+      return <MedidaItem>[];
+    }
+
     if (resp.statusCode != 200) {
       throw Exception('Falha ao buscar medidas (${resp.statusCode}): ${resp.body}');
     }


### PR DESCRIPTION
## Summary
- Treat 404/204 API responses as no measures found to avoid hanging on unknown parts

## Testing
- `apt-get update`
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b189d8d5f08331935e17ae3fba0894