### PR TITLE
Normalize part and operation codes

### DIFF
--- a/app_db.py
+++ b/app_db.py
@@ -265,14 +265,18 @@ def _norm(text):
     return (str(text or "")).strip()
 
 
+def _strip_leading_zeros(t: str) -> str:
+    t = re.sub(r"^0+", "", t)
+    return t or "0"
+
+
 def _norm_part(text):
-    """Normaliza o partnumber removendo espaços extras."""
-    return _norm(text)
+    """Normaliza o partnumber removendo espaços extras e zeros à esquerda."""
+    return _strip_leading_zeros(_norm(text))
 
 
 def _norm_op(text):
-    t = _norm(text)
-    return t.zfill(3) if t.isdigit() else t
+    return _strip_leading_zeros(_norm(text))
 
 
 def _to_float(s):
@@ -401,26 +405,19 @@ def _medidas_preparador_db(part: str, op: str):
     part = _norm_part(part)
     op = _norm_op(op)
     rows = []
-    candidates = [part]
-    if part.isdigit():
-        pad = part.zfill(12)
-        if pad != part:
-            candidates.append(pad)
     with _conn_db(DB_NAME) as c:
         with c.cursor() as cur:
-            for p in candidates:
-                cur.execute(
-                    """
-                    SELECT idx_medida, titulo, faixa_texto, instrumento, minimo, maximo
-                    FROM for07_norm
-                    WHERE partnumber=%s AND operacao=%s
-                    ORDER BY idx_medida
-                    """,
-                    (p, op),
-                )
-                rows = cur.fetchall()
-                if rows:
-                    break
+            cur.execute(
+                """
+                SELECT idx_medida, titulo, faixa_texto, instrumento, minimo, maximo
+                FROM for07_norm
+                WHERE TRIM(LEADING '0' FROM partnumber)=TRIM(LEADING '0' FROM %s)
+                  AND TRIM(LEADING '0' FROM operacao)=TRIM(LEADING '0' FROM %s)
+                ORDER BY idx_medida
+                """,
+                (part, op),
+            )
+            rows = cur.fetchall()
     medidas = []
     for row in rows:
         titulo = row.get("titulo") or ""
@@ -459,28 +456,21 @@ def _medidas_operador_db(part: str, op: str):
     part = _norm_part(part)
     op = _norm_op(op)
     rows = []
-    candidates = [part]
-    if part.isdigit():
-        pad = part.zfill(12)
-        if pad != part:
-            candidates.append(pad)
     with _conn_db(DB_NAME) as c:
         with c.cursor() as cur:
-            for p in candidates:
-                cur.execute(
-                    """
-                    SELECT idx_medida, titulo, faixa_texto, minimo, maximo,
-                           periodicidade, instrumento,
-                           reprovada_abaixo, alerta_abaixo, alerta_acima, reprovada_acima
-                    FROM for09_norm
-                    WHERE partnumber=%s AND operacao=%s
-                    ORDER BY idx_medida
-                    """,
-                    (p, op),
-                )
-                rows = cur.fetchall()
-                if rows:
-                    break
+            cur.execute(
+                """
+                SELECT idx_medida, titulo, faixa_texto, minimo, maximo,
+                       periodicidade, instrumento,
+                       reprovada_abaixo, alerta_abaixo, alerta_acima, reprovada_acima
+                FROM for09_norm
+                WHERE TRIM(LEADING '0' FROM partnumber)=TRIM(LEADING '0' FROM %s)
+                  AND TRIM(LEADING '0' FROM operacao)=TRIM(LEADING '0' FROM %s)
+                ORDER BY idx_medida
+                """,
+                (part, op),
+            )
+            rows = cur.fetchall()
     medidas = []
     for row in rows:
         titulo = row.get("titulo") or ""
@@ -547,7 +537,9 @@ def _maquina_liberada(conn, os_num: str, part: str, op: str) -> Tuple[bool, str,
             """
             SELECT status_geral
             FROM preparador_liberacao
-            WHERE os=%s AND partnumber=%s AND operacao=%s
+            WHERE os=%s
+              AND TRIM(LEADING '0' FROM partnumber)=TRIM(LEADING '0' FROM %s)
+              AND TRIM(LEADING '0' FROM operacao)=TRIM(LEADING '0' FROM %s)
             ORDER BY id DESC LIMIT 1
             """,
             (os_num, part, op),
@@ -565,7 +557,9 @@ def _maquina_liberada(conn, os_num: str, part: str, op: str) -> Tuple[bool, str,
             """
             SELECT id
             FROM preparador_registro
-            WHERE os=%s AND partnumber=%s AND operacao=%s
+            WHERE os=%s
+              AND TRIM(LEADING '0' FROM partnumber)=TRIM(LEADING '0' FROM %s)
+              AND TRIM(LEADING '0' FROM operacao)=TRIM(LEADING '0' FROM %s)
             ORDER BY created_at DESC, id DESC LIMIT 1
             """,
             (os_num, part, op),
@@ -633,7 +627,7 @@ def supervisor_registros():
         with _conn_db(DB_NAME) as c:
             with c.cursor() as cur:
                 cur.execute(
-                    f"SELECT * FROM {tabela} WHERE partnumber=%s AND operacao=%s ORDER BY idx_medida",
+                    f"SELECT * FROM {tabela} WHERE TRIM(LEADING '0' FROM partnumber)=TRIM(LEADING '0' FROM %s) AND TRIM(LEADING '0' FROM operacao)=TRIM(LEADING '0' FROM %s) ORDER BY idx_medida",
                     (part, op),
                 )
                 rows = cur.fetchall()
@@ -664,7 +658,7 @@ def supervisor_inserir():
                             400,
                         )
                     cur.execute(
-                        f"SELECT COALESCE(MAX(idx_medida),0)+1 FROM {tabela} WHERE partnumber=%s AND operacao=%s",
+                        f"SELECT COALESCE(MAX(idx_medida),0)+1 FROM {tabela} WHERE TRIM(LEADING '0' FROM partnumber)=TRIM(LEADING '0' FROM %s) AND TRIM(LEADING '0' FROM operacao)=TRIM(LEADING '0' FROM %s)",
                         (part, op),
                     )
                     dados["idx_medida"] = cur.fetchone()[0]
@@ -703,13 +697,13 @@ def supervisor_atualizar():
         with _conn_db(DB_NAME) as c:
             with c.cursor() as cur:
                 cur.execute(
-                    f"SELECT * FROM {tabela} WHERE partnumber=%s AND operacao=%s AND idx_medida=%s",
+                    f"SELECT * FROM {tabela} WHERE TRIM(LEADING '0' FROM partnumber)=TRIM(LEADING '0' FROM %s) AND TRIM(LEADING '0' FROM operacao)=TRIM(LEADING '0' FROM %s) AND idx_medida=%s",
                     (part, op, idx),
                 )
                 antes = cur.fetchone()
                 set_sql = ", ".join([f"{k}=%s" for k in updates.keys()])
                 cur.execute(
-                    f"UPDATE {tabela} SET {set_sql} WHERE partnumber=%s AND operacao=%s AND idx_medida=%s",
+                    f"UPDATE {tabela} SET {set_sql} WHERE TRIM(LEADING '0' FROM partnumber)=TRIM(LEADING '0' FROM %s) AND TRIM(LEADING '0' FROM operacao)=TRIM(LEADING '0' FROM %s) AND idx_medida=%s",
                     list(updates.values()) + [part, op, idx],
                 )
                 _log_supervisao(
@@ -904,7 +898,9 @@ def resultado_preparador():
                 cur.execute(
                     """
                     SELECT id FROM preparador_liberacao
-                    WHERE os=%s AND partnumber=%s AND operacao=%s
+                    WHERE os=%s
+                      AND TRIM(LEADING '0' FROM partnumber)=TRIM(LEADING '0' FROM %s)
+                      AND TRIM(LEADING '0' FROM operacao)=TRIM(LEADING '0' FROM %s)
                     ORDER BY id DESC LIMIT 1
                     """,
                     (os_num, part, op),
@@ -1116,10 +1112,10 @@ def operador_listar():
         where.append("a.os = %s")
         params.append(os_num)
     if part:
-        where.append("a.partnumber = %s")
+        where.append("TRIM(LEADING '0' FROM a.partnumber) = TRIM(LEADING '0' FROM %s)")
         params.append(part)
     if op:
-        where.append("a.operacao = %s")
+        where.append("TRIM(LEADING '0' FROM a.operacao) = TRIM(LEADING '0' FROM %s)")
         params.append(op)
 
     sql = """

--- a/lib/features/operador/data/models.dart
+++ b/lib/features/operador/data/models.dart
@@ -1,6 +1,8 @@
 // lib/features/preparacao/data/models.dart
 import 'dart:convert';
 
+import 'package:admin/utils/string_utils.dart';
+
 enum StatusMedida { ok, alerta, reprovadaAcima, reprovadaAbaixo, pendente }
 
 StatusMedida statusFromString(String? s) {
@@ -282,8 +284,8 @@ class PreparacaoResultado {
 
   Map<String, dynamic> toMap() => {
     're': re,
-    'partnumber': partnumber,
-    'operacao': operacao,
+    'partnumber': normalizeCode(partnumber),
+    'operacao': normalizeCode(operacao),
     'medidas': medidas.map((e) => e.toMap()).toList(),
   };
 

--- a/lib/features/operador/presentation/operador_page.dart
+++ b/lib/features/operador/presentation/operador_page.dart
@@ -11,6 +11,7 @@ import 'package:http/http.dart' as http;
 import '../../preparacao/data/models.dart';
 import '../data/repository_provider.dart';
 import 'package:admin/screens/main/components/side_menu.dart';
+import 'package:admin/utils/string_utils.dart';
 
 /// >>>>> Ajuste para o endereço/porta do seu Flask <<<<<
 const String kBaseUrl = 'http://192.168.0.241:5005';
@@ -156,8 +157,8 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
     final body = jsonEncode({
       're': _reCtrl.text.trim(),
       'os': _osCtrl.text.trim(),
-      'partnumber': _partCtrl.text.trim(),
-      'operacao': _opCtrl.text.trim(),
+      'partnumber': normalizeCode(_partCtrl.text),
+      'operacao': normalizeCode(_opCtrl.text),
       // >>> chave correta no backend:
       'itens': itens,
     });
@@ -207,8 +208,8 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
     final body = jsonEncode({
       're': _reCtrl.text.trim(),
       'os': _osCtrl.text.trim(),
-      'partnumber': _partCtrl.text.trim(),
-      'operacao': _opCtrl.text.trim(),
+      'partnumber': normalizeCode(_partCtrl.text),
+      'operacao': normalizeCode(_opCtrl.text),
     });
 
     final uri = Uri.parse('$kBaseUrl/operador/fim_jornada');
@@ -419,8 +420,8 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                             await ref
                                 .read(medidasOperadorControllerProvider.notifier)
                                 .carregar(
-                              partnumber: _partCtrl.text.trim(),
-                              operacao: _opCtrl.text.trim(),
+                              partnumber: normalizeCode(_partCtrl.text),
+                              operacao: normalizeCode(_opCtrl.text),
                             );
                           }
                         },

--- a/lib/features/preparacao/data/api_medidas_repository.dart
+++ b/lib/features/preparacao/data/api_medidas_repository.dart
@@ -4,6 +4,8 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:http/http.dart' as http;
 
+import 'package:admin/utils/string_utils.dart';
+
 import 'medidas_repository.dart';
 import 'models.dart';
 
@@ -49,8 +51,8 @@ class ApiMedidasRepository implements MedidasRepository {
   }) async {
     // Se seu Flask espera "peca" em vez de "partnumber", troque a chave abaixo.
     final uri = _buildUri(medidasPath, {
-      'partnumber': partnumber,
-      'operacao': operacao,
+      'partnumber': normalizeCode(partnumber),
+      'operacao': normalizeCode(operacao),
     });
 
     if (kDebugMode) debugPrint('GET $uri');

--- a/lib/features/preparacao/data/models.dart
+++ b/lib/features/preparacao/data/models.dart
@@ -1,6 +1,8 @@
 // lib/features/preparacao/data/models.dart
 import 'dart:convert';
 
+import 'package:admin/utils/string_utils.dart';
+
 enum StatusMedida { ok, alerta, reprovadaAcima, reprovadaAbaixo, pendente }
 
 StatusMedida statusFromString(String? s) {
@@ -282,8 +284,8 @@ class PreparacaoResultado {
 
   Map<String, dynamic> toMap() => {
     're': re,
-    'partnumber': partnumber,
-    'operacao': operacao,
+    'partnumber': normalizeCode(partnumber),
+    'operacao': normalizeCode(operacao),
     'medidas': medidas.map((e) => e.toMap()).toList(),
   };
 

--- a/lib/features/preparacao/presentation/preparacao_page.dart
+++ b/lib/features/preparacao/presentation/preparacao_page.dart
@@ -10,6 +10,7 @@ import 'package:http/http.dart' as http;
 import 'package:admin/features/preparacao/data/models.dart';
 import 'package:admin/features/operador/data/repository_provider.dart';
 import 'package:admin/screens/main/components/side_menu.dart';
+import 'package:admin/utils/string_utils.dart';
 
 /// Mesmo base URL usado no Operador
 const String kBaseUrl = 'http://192.168.0.241:5005';
@@ -207,8 +208,8 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
     final body = jsonEncode({
       're': _reCtrl.text.trim(),
       'os': _osCtrl.text.trim(),
-      'partnumber': _partCtrl.text.trim(),
-      'operacao': _opCtrl.text.trim(),
+      'partnumber': normalizeCode(_partCtrl.text),
+      'operacao': normalizeCode(_opCtrl.text),
       'itens': itens,
     });
 
@@ -389,8 +390,8 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
                             await ref
                                 .read(medidasPreparadorControllerProvider.notifier)
                                 .carregar(
-                              partnumber: _partCtrl.text.trim(),
-                              operacao: _opCtrl.text.trim(),
+                              partnumber: normalizeCode(_partCtrl.text),
+                              operacao: normalizeCode(_opCtrl.text),
                             );
                           }
                         },

--- a/lib/services/supervisao_service.dart
+++ b/lib/services/supervisao_service.dart
@@ -3,6 +3,8 @@ import 'dart:convert';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:http/http.dart' as http;
 
+import 'package:admin/utils/string_utils.dart';
+
 class SupervisaoService {
   SupervisaoService({http.Client? client, String? baseUrl})
       : _client = client ?? http.Client(),
@@ -24,7 +26,7 @@ class SupervisaoService {
   Future<List<Map<String, dynamic>>> fetchRegistros(
       String tabela, String part, String op) async {
     final uri = Uri.parse(
-        '$_baseUrl/supervisor/registros?tabela=$tabela&partnumber=$part&operacao=$op');
+        '$_baseUrl/supervisor/registros?tabela=$tabela&partnumber=${normalizeCode(part)}&operacao=${normalizeCode(op)}');
     final resp = await _client.get(uri);
     if (resp.statusCode == 200) {
       final data = jsonDecode(resp.body) as List;
@@ -35,17 +37,31 @@ class SupervisaoService {
 
   Future<bool> inserir(String tabela, Map<String, dynamic> dados) async {
     final uri = Uri.parse('$_baseUrl/supervisor/registros?tabela=$tabela');
+    final map = Map<String, dynamic>.from(dados);
+    if (map.containsKey('partnumber')) {
+      map['partnumber'] = normalizeCode(map['partnumber'].toString());
+    }
+    if (map.containsKey('operacao')) {
+      map['operacao'] = normalizeCode(map['operacao'].toString());
+    }
     final resp = await _client.post(uri,
         headers: {'Content-Type': 'application/json'},
-        body: jsonEncode(dados));
+        body: jsonEncode(map));
     return resp.statusCode == 200;
   }
 
   Future<bool> atualizar(String tabela, Map<String, dynamic> dados) async {
     final uri = Uri.parse('$_baseUrl/supervisor/registros?tabela=$tabela');
+    final map = Map<String, dynamic>.from(dados);
+    if (map.containsKey('partnumber')) {
+      map['partnumber'] = normalizeCode(map['partnumber'].toString());
+    }
+    if (map.containsKey('operacao')) {
+      map['operacao'] = normalizeCode(map['operacao'].toString());
+    }
     final resp = await _client.put(uri,
         headers: {'Content-Type': 'application/json'},
-        body: jsonEncode(dados));
+        body: jsonEncode(map));
     return resp.statusCode == 200;
   }
 }

--- a/lib/utils/string_utils.dart
+++ b/lib/utils/string_utils.dart
@@ -1,0 +1,9 @@
+/// Utility functions for string normalization.
+///
+/// Removes leading zeros from numeric-like strings so that
+/// values like "020" and "20" are treated equivalently.
+String normalizeCode(String value) {
+  final trimmed = value.trim();
+  final normalized = trimmed.replaceFirst(RegExp(r'^0+'), '');
+  return normalized.isEmpty ? '0' : normalized;
+}


### PR DESCRIPTION
## Summary
- Add utility to strip leading zeros from part numbers and operations
- Normalize these codes in services, repositories and UI submissions
- Adjust backend queries to compare fields without leading zeros

## Testing
- `python -m py_compile app_db.py`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b19bfeee848331866b295184b5444e