### PR TITLE
Fix empty code normalization

### DIFF
--- a/app_db.py
+++ b/app_db.py
@@ -266,8 +266,8 @@ def _norm(text):
 
 
 def _strip_leading_zeros(t: str) -> str:
-    t = re.sub(r"^0+", "", t)
-    return t or "0"
+    t = re.sub(r"^0+", "", t or "")
+    return t
 
 
 def _norm_part(text):

--- a/lib/utils/string_utils.dart
+++ b/lib/utils/string_utils.dart
@@ -5,5 +5,5 @@
 String normalizeCode(String value) {
   final trimmed = value.trim();
   final normalized = trimmed.replaceFirst(RegExp(r'^0+'), '');
-  return normalized.isEmpty ? '0' : normalized;
+  return normalized;
 }


### PR DESCRIPTION
## Summary
- Return empty string for missing codes instead of "0" in Python utility `_strip_leading_zeros`
- Align Dart `normalizeCode` to stop defaulting to "0" when input is empty

## Testing
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b1ac24dddc833183be86e6c9cd7208