### PR TITLE
feat: show detailed release history and export reports

### DIFF
--- a/lib/features/export_relatorios/presentation/export_relatorios_page.dart
+++ b/lib/features/export_relatorios/presentation/export_relatorios_page.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+
+import '../../../screens/main/components/side_menu.dart';
+import '../../../services/report_service.dart';
+
+/// Page that allows the user to export reports to an Excel file.
+class ExportRelatoriosPage extends StatefulWidget {
+  const ExportRelatoriosPage({super.key});
+
+  @override
+  State<ExportRelatoriosPage> createState() => _ExportRelatoriosPageState();
+}
+
+class _ExportRelatoriosPageState extends State<ExportRelatoriosPage> {
+  final _osController = TextEditingController();
+  String _tipo = 'FOR07';
+  bool _loading = false;
+
+  @override
+  void dispose() {
+    _osController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _exportar() async {
+    setState(() => _loading = true);
+    final ok = await ReportService()
+        .exportToExcel(os: _osController.text, tipo: _tipo);
+    if (!mounted) return;
+    setState(() => _loading = false);
+    final msg = ok ? 'Relatório salvo com sucesso' : 'Falha ao exportar';
+    ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(msg)));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Exportar relatórios')),
+      drawer: const SideMenu(current: SideMenuSection.mainMenu),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            TextField(
+              controller: _osController,
+              decoration: const InputDecoration(labelText: 'O.S'),
+            ),
+            const SizedBox(height: 16),
+            DropdownButton<String>(
+              value: _tipo,
+              items: const [
+                DropdownMenuItem(value: 'FOR07', child: Text('FOR07')),
+                DropdownMenuItem(value: 'FOR09', child: Text('FOR09')),
+              ],
+              onChanged: (v) {
+                if (v != null) setState(() => _tipo = v);
+              },
+            ),
+            const SizedBox(height: 24),
+            FilledButton(
+              onPressed: _loading ? null : _exportar,
+              child: _loading
+                  ? const SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Text('Exportar'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/models/report.dart
+++ b/lib/models/report.dart
@@ -8,12 +8,20 @@ class Report {
   final String status;
   final String createdAt;
 
+  /// Registration number (RE) of the preparer who handled this report.
+  final String rePreparador;
+
+  /// Registration number (RE) of the operator who handled this report.
+  final String reOperador;
+
   Report({
     required this.os,
     required this.partnumber,
     required this.operacao,
     required this.status,
     required this.createdAt,
+    this.rePreparador = '',
+    this.reOperador = '',
   });
 
   factory Report.fromJson(Map<String, dynamic> json) {
@@ -23,6 +31,8 @@ class Report {
       operacao: json['operacao']?.toString() ?? '',
       status: json['status_geral']?.toString() ?? '',
       createdAt: json['created_at']?.toString() ?? '',
+      rePreparador: json['re_preparador']?.toString() ?? '',
+      reOperador: json['re_operador']?.toString() ?? '',
     );
   }
 

--- a/lib/screens/dashboard/components/recent_files.dart
+++ b/lib/screens/dashboard/components/recent_files.dart
@@ -4,10 +4,11 @@ import '../../../constants.dart';
 import '../../../models/report.dart';
 import '../../../services/report_service.dart';
 
+/// Displays the last machine releases performed by the preparer.
 class RecentFiles extends StatelessWidget {
   const RecentFiles({Key? key}) : super(key: key);
 
-  Future<List<Report>> _loadReports() => ReportService().fetchReports();
+  Future<List<Report>> _loadReports() => ReportService().fetchPreparerReleases();
 
   @override
   Widget build(BuildContext context) {
@@ -28,7 +29,7 @@ class RecentFiles extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Text(
-                'Últimas O.S',
+                'Últimas liberações (Preparador)',
                 style: Theme.of(context).textTheme.titleMedium,
               ),
               SizedBox(
@@ -37,14 +38,16 @@ class RecentFiles extends StatelessWidget {
                   columnSpacing: defaultPadding,
                   columns: const [
                     DataColumn(label: Text('O.S')),
-                    DataColumn(label: Text('Operação')),
+                    DataColumn(label: Text('Código da peça')),
+                    DataColumn(label: Text('RE Preparador')),
                     DataColumn(label: Text('Status')),
                   ],
                   rows: reports
                       .map(
                         (report) => DataRow(cells: [
                           DataCell(Text(report.os)),
-                          DataCell(Text(report.operacao)),
+                          DataCell(Text(report.partnumber)),
+                          DataCell(Text(report.rePreparador)),
                           DataCell(Text(report.status)),
                         ]),
                       )

--- a/lib/screens/dashboard/components/reports_table.dart
+++ b/lib/screens/dashboard/components/reports_table.dart
@@ -12,7 +12,7 @@ class ReportsTable extends StatelessWidget {
   Widget build(BuildContext context) {
     final service = ReportService();
     return FutureBuilder<List<Report>>(
-      future: service.fetchReports(),
+      future: service.fetchOperatorReleases(),
       builder: (context, snapshot) {
         if (snapshot.connectionState == ConnectionState.waiting) {
           return const Center(child: CircularProgressIndicator());
@@ -37,14 +37,16 @@ class ReportsTable extends StatelessWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Text('Relatórios', style: Theme.of(context).textTheme.titleMedium),
+              Text('Relatórios (Operador)',
+                  style: Theme.of(context).textTheme.titleMedium),
               SizedBox(
                 width: double.infinity,
                 child: DataTable(
                   columnSpacing: defaultPadding,
                   columns: const [
                     DataColumn(label: Text('O.S')),
-                    DataColumn(label: Text('Partnumber')),
+                    DataColumn(label: Text('Código da peça')),
+                    DataColumn(label: Text('RE Operador')),
                     DataColumn(label: Text('Status')),
                   ],
                   rows: reports
@@ -52,6 +54,7 @@ class ReportsTable extends StatelessWidget {
                         (r) => DataRow(cells: [
                           DataCell(Text(r.os)),
                           DataCell(Text(r.partnumber)),
+                          DataCell(Text(r.reOperador)),
                           DataCell(Text(r.status)),
                         ]),
                       )

--- a/lib/screens/main/components/side_menu.dart
+++ b/lib/screens/main/components/side_menu.dart
@@ -6,6 +6,7 @@ import 'package:admin/features/preparacao/presentation/preparacao_page.dart';
 import 'package:admin/features/operador/presentation/operador_page.dart';
 import 'package:admin/features/cadastro_itens/presentation/cadastro_itens_page.dart';
 import 'package:admin/features/cadastro_preparadores/presentation/cadastro_preparadores_page.dart';
+import 'package:admin/features/export_relatorios/presentation/export_relatorios_page.dart';
 import 'package:admin/screens/main/main_screen.dart';
 
 enum SideMenuSection { mainMenu, dashboard, preparador, operador }
@@ -38,6 +39,11 @@ class SideMenu extends StatelessWidget {
         title: 'Menu Principal',
         svgSrc: 'assets/icons/menu_dashboard.svg',
         press: () => _goHome(context),
+      ),
+      DrawerListTile(
+        title: 'Exportar relatórios',
+        svgSrc: 'assets/icons/menu_doc.svg',
+        press: () => _navigate(context, const ExportRelatoriosPage()),
       ),
     ];
 

--- a/lib/services/report_service.dart
+++ b/lib/services/report_service.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:http/http.dart' as http;
 
@@ -24,5 +26,46 @@ class ReportService {
       // Ignore errors and return empty list
     }
     return [];
+  }
+
+  /// Fetch releases performed by preparers.
+  Future<List<Report>> fetchPreparerReleases() async {
+    try {
+      final uri = Uri.parse('$_baseUrl/reports/preparador');
+      final response = await _client.get(uri);
+      if (response.statusCode == 200) {
+        return Report.listFromResponse(response.body);
+      }
+    } catch (_) {}
+    return [];
+  }
+
+  /// Fetch releases performed by operators.
+  Future<List<Report>> fetchOperatorReleases() async {
+    try {
+      final uri = Uri.parse('$_baseUrl/reports/operador');
+      final response = await _client.get(uri);
+      if (response.statusCode == 200) {
+        return Report.listFromResponse(response.body);
+      }
+    } catch (_) {}
+    return [];
+  }
+
+  /// Downloads the Excel report for a given OS and type.
+  /// Returns `true` if the file was saved successfully.
+  Future<bool> exportToExcel({required String os, required String tipo}) async {
+    try {
+      final uri = Uri.parse('$_baseUrl/reports/export?os=$os&type=$tipo');
+      final response = await _client.get(uri);
+      if (response.statusCode == 200) {
+        final file = File('relatorio_${os}_$tipo.xlsx');
+        await file.writeAsBytes(response.bodyBytes);
+        return true;
+      }
+    } catch (_) {
+      // Ignore errors
+    }
+    return false;
   }
 }


### PR DESCRIPTION
## Summary
- track preparer and operator registration numbers in report model
- display preparer and operator release history on dashboard
- add Excel report export page and link from side menu

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1bd7fb8248331b28c14d02bdaae03