### PR TITLE
Fix FOR09 export and restrict report export menu

### DIFF
--- a/app_db.py
+++ b/app_db.py
@@ -1306,22 +1306,37 @@ def exportar_relatorio_excel():
                     cur.execute(
                         """
                         SELECT a.os, a.partnumber, a.operacao, a.re_operador,
-                               CASE
-                                 WHEN SUM(CASE WHEN LOWER(i.status)='reprovado' THEN 1 ELSE 0 END) > 0 THEN 'reprovado'
-                                 WHEN SUM(CASE WHEN LOWER(i.status)='ok' THEN 1 ELSE 0 END) = COUNT(i.id) THEN 'aprovado'
-                                 ELSE 'pendente'
-                               END AS status_geral,
-                               a.created_at
+                               i.idx_medida, i.titulo, i.instrumento, i.faixa_texto,
+                               i.minimo, i.maximo, i.unidade, i.periodicidade,
+                               i.tolerancias, i.escolha, i.status, i.observacao,
+                               i.created_at
                         FROM operador_amostragem a
-                        LEFT JOIN operador_amostragem_item i ON i.amostragem_id = a.id
+                        JOIN operador_amostragem_item i ON i.amostragem_id = a.id
                         WHERE a.os=%s
-                        GROUP BY a.id
-                        ORDER BY a.created_at DESC
+                        ORDER BY a.created_at DESC, i.idx_medida ASC
                         """,
                         (os_num,),
                     )
                     rows = cur.fetchall()
-                    headers = ["os", "partnumber", "operacao", "re_operador", "status_geral", "created_at"]
+                    headers = [
+                        "os",
+                        "partnumber",
+                        "operacao",
+                        "re_operador",
+                        "idx_medida",
+                        "titulo",
+                        "instrumento",
+                        "faixa_texto",
+                        "minimo",
+                        "maximo",
+                        "unidade",
+                        "periodicidade",
+                        "tolerancias",
+                        "escolha",
+                        "status",
+                        "observacao",
+                        "created_at",
+                    ]
 
         wb = Workbook()
         ws = wb.active

--- a/lib/features/export_relatorios/presentation/export_relatorios_page.dart
+++ b/lib/features/export_relatorios/presentation/export_relatorios_page.dart
@@ -36,7 +36,7 @@ class _ExportRelatoriosPageState extends State<ExportRelatoriosPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Exportar relatórios')),
-      drawer: const SideMenu(current: SideMenuSection.mainMenu),
+      drawer: const SideMenu(current: SideMenuSection.dashboard),
       body: Padding(
         padding: const EdgeInsets.all(16),
         child: Column(

--- a/lib/screens/main/components/side_menu.dart
+++ b/lib/screens/main/components/side_menu.dart
@@ -40,12 +40,17 @@ class SideMenu extends StatelessWidget {
         svgSrc: 'assets/icons/menu_dashboard.svg',
         press: () => _goHome(context),
       ),
-      DrawerListTile(
-        title: 'Exportar relatórios',
-        svgSrc: 'assets/icons/menu_doc.svg',
-        press: () => _navigate(context, const ExportRelatoriosPage()),
-      ),
     ];
+
+    if (current == SideMenuSection.dashboard) {
+      items.add(
+        DrawerListTile(
+          title: 'Exportar relatórios',
+          svgSrc: 'assets/icons/menu_doc.svg',
+          press: () => _navigate(context, const ExportRelatoriosPage()),
+        ),
+      );
+    }
 
     switch (current) {
       case SideMenuSection.dashboard:
@@ -58,8 +63,7 @@ class SideMenu extends StatelessWidget {
           DrawerListTile(
             title: 'Cadastro de Preparadores',
             svgSrc: 'assets/icons/menu_profile.svg',
-            press: () =>
-                _navigate(context, const CadastroPreparadoresPage()),
+            press: () => _navigate(context, const CadastroPreparadoresPage()),
           ),
         ]);
         break;


### PR DESCRIPTION
## Summary
- Export FOR09 report based on operator sampling items
- Show report export option only from dashboard menu

## Testing
- `python -m py_compile app_db.py`
- `flutter test` *(fails: The current Dart SDK version is 3.2.3. Because admin requires SDK version ^3.8.1, version solving failed.)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c2ee61648331a03871e58c737d6d