### PR TITLE
Include item index when registering operator sampling

### DIFF
--- a/lib/features/operador/presentation/operador_page.dart
+++ b/lib/features/operador/presentation/operador_page.dart
@@ -142,8 +142,12 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
     }
 
     // Monta itens no formato que o backend espera
-    final itens = medidas.map((m) {
+    final itens = <Map<String, dynamic>>[];
+    for (var i = 0; i < medidas.length; i++) {
+      final m = medidas[i];
       final map = m.toMap();
+      // índice esperado pelo backend
+      map['indice'] = i;
       // backend espera 'min'/'max' e não 'minimo'/'maximo'
       map['min'] = m.minimo;
       map['max'] = m.maximo;
@@ -151,8 +155,8 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
       map['escolha'] = m.medicao ?? '';
       // status como string
       map['status'] = statusToString(m.status);
-      return map;
-    }).toList();
+      itens.add(map);
+    }
 
     final body = jsonEncode({
       're': _reCtrl.text.trim(),


### PR DESCRIPTION
## Summary
- Add `indice` field to each measurement item when registering operator sampling so backend can store unique entries

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c6f394048331837c1e824c755c61