### PR TITLE
Add operator sampling progression report to dashboard

### DIFF
--- a/lib/screens/dashboard/components/operator_report_chart.dart
+++ b/lib/screens/dashboard/components/operator_report_chart.dart
@@ -1,0 +1,165 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+
+import '../../../constants.dart';
+import '../../../models/report.dart';
+import '../../../services/report_service.dart';
+
+/// Displays a line chart showing the progression of operator samplings.
+/// The user must provide an OS number to fetch the report. End-of-shift
+/// and OS closing events are highlighted in the chart.
+class OperatorReportChart extends StatefulWidget {
+  const OperatorReportChart({super.key});
+
+  @override
+  State<OperatorReportChart> createState() => _OperatorReportChartState();
+}
+
+class _OperatorReportChartState extends State<OperatorReportChart> {
+  final _osCtrl = TextEditingController();
+  Future<List<Report>>? _future;
+
+  @override
+  void dispose() {
+    _osCtrl.dispose();
+    super.dispose();
+  }
+
+  void _fetch() {
+    final os = _osCtrl.text.trim();
+    if (os.isEmpty) return;
+    final service = ReportService();
+    setState(() {
+      _future = service.fetchOperatorReleasesByOs(os);
+    });
+  }
+
+  double _statusToValue(String status) {
+    switch (status.toLowerCase()) {
+      case 'alerta':
+        return 1;
+      case 'reprovada':
+      case 'reprovada acima':
+      case 'reprovada abaixo':
+        return 2;
+      default:
+        return 0; // "boa" or any other status
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(defaultPadding),
+      decoration: BoxDecoration(
+        color: secondaryColor,
+        borderRadius: const BorderRadius.all(Radius.circular(10)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('Progresso das Amostragens',
+              style: Theme.of(context).textTheme.titleMedium),
+          const SizedBox(height: defaultPadding),
+          Row(
+            children: [
+              Expanded(
+                child: TextField(
+                  controller: _osCtrl,
+                  decoration: const InputDecoration(
+                    labelText: 'Número da OS',
+                    border: OutlineInputBorder(),
+                  ),
+                ),
+              ),
+              const SizedBox(width: defaultPadding),
+              ElevatedButton(onPressed: _fetch, child: const Text('Buscar')),
+            ],
+          ),
+          const SizedBox(height: defaultPadding),
+          FutureBuilder<List<Report>>(
+            future: _future,
+            builder: (context, snapshot) {
+              if (_future == null) {
+                return const Text(
+                    'Informe o número da OS para visualizar o gráfico.');
+              }
+              if (snapshot.connectionState == ConnectionState.waiting) {
+                return const Center(child: CircularProgressIndicator());
+              }
+              final data = snapshot.data ?? [];
+              if (data.isEmpty) {
+                return const Text('Nenhum dado encontrado para a OS.');
+              }
+
+              final spots = <FlSpot>[];
+              final verticalLines = <VerticalLine>[];
+
+              for (var i = 0; i < data.length; i++) {
+                final r = data[i];
+                final status = r.status.toLowerCase();
+                spots.add(FlSpot(i.toDouble(), _statusToValue(status)));
+                if (status.contains('fim') && status.contains('jornada')) {
+                  verticalLines.add(VerticalLine(
+                      x: i.toDouble(),
+                      color: Colors.orange,
+                      strokeWidth: 2));
+                } else if (status.contains('encerrar') ||
+                    status.contains('encerramento')) {
+                  verticalLines.add(VerticalLine(
+                      x: i.toDouble(),
+                      color: Colors.red,
+                      strokeWidth: 2));
+                }
+              }
+
+              return SizedBox(
+                height: 200,
+                child: LineChart(
+                  LineChartData(
+                    minY: 0,
+                    maxY: 2,
+                    titlesData: FlTitlesData(
+                      leftTitles: AxisTitles(
+                        sideTitles: SideTitles(
+                          showTitles: true,
+                          getTitlesWidget: (value, meta) {
+                            switch (value.toInt()) {
+                              case 0:
+                                return const Text('Boa');
+                              case 1:
+                                return const Text('Alerta');
+                              case 2:
+                                return const Text('Reprovada');
+                            }
+                            return const SizedBox.shrink();
+                          },
+                        ),
+                      ),
+                      bottomTitles: AxisTitles(
+                        sideTitles: SideTitles(showTitles: false),
+                      ),
+                      topTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+                      rightTitles:
+                          AxisTitles(sideTitles: SideTitles(showTitles: false)),
+                    ),
+                    lineBarsData: [
+                      LineChartBarData(
+                        spots: spots,
+                        isCurved: false,
+                        barWidth: 3,
+                        color: Colors.blue,
+                        dotData: FlDotData(show: true),
+                      )
+                    ],
+                    extraLinesData: ExtraLinesData(verticalLines: verticalLines),
+                  ),
+                ),
+              );
+            },
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/dashboard/dashboard_screen.dart
+++ b/lib/screens/dashboard/dashboard_screen.dart
@@ -8,6 +8,7 @@ import 'components/header.dart';
 import 'components/recent_files.dart';
 import 'components/reports_table.dart';
 import 'components/storage_details.dart';
+import 'components/operator_report_chart.dart';
 
 class DashboardScreen extends StatelessWidget {
   @override
@@ -33,6 +34,8 @@ class DashboardScreen extends StatelessWidget {
                       SizedBox(height: defaultPadding),
 
                       ReportsTable(),
+                      SizedBox(height: defaultPadding),
+                      OperatorReportChart(),
                       if (Responsive.isMobile(context))
                         SizedBox(height: defaultPadding),
                       if (Responsive.isMobile(context)) StorageDetails(),

--- a/lib/services/report_service.dart
+++ b/lib/services/report_service.dart
@@ -52,6 +52,18 @@ class ReportService {
     return [];
   }
 
+  /// Fetch releases performed by operators for a specific OS.
+  Future<List<Report>> fetchOperatorReleasesByOs(String os) async {
+    try {
+      final uri = Uri.parse('$_baseUrl/reports/operador?os=$os');
+      final response = await _client.get(uri);
+      if (response.statusCode == 200) {
+        return Report.listFromResponse(response.body);
+      }
+    } catch (_) {}
+    return [];
+  }
+
   /// Downloads the Excel report for a given OS and type.
   /// Returns `true` if the file was saved successfully.
   Future<bool> exportToExcel({required String os, required String tipo}) async {


### PR DESCRIPTION
## Summary
- add service method to fetch operator releases by OS
- introduce operator report chart with OS filter and status progression
- wire chart into dashboard

## Testing
- `dart format lib/services/report_service.dart lib/screens/dashboard/components/operator_report_chart.dart lib/screens/dashboard/dashboard_screen.dart` *(command not found)*
- `flutter analyze` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ca3a029883319da244465265aac7