### PR TITLE
Handle go/no-go sides with unified aprovado/reprovado status

### DIFF
--- a/app_db.py
+++ b/app_db.py
@@ -586,7 +586,7 @@ def _maquina_liberada(conn, os_num: str, part: str, op: str) -> Tuple[bool, str,
         cur.execute(
             """
             SELECT
-              SUM(CASE WHEN LOWER(COALESCE(status,''))='ok' THEN 1 ELSE 0 END) AS ok_cnt,
+              SUM(CASE WHEN LOWER(COALESCE(status,'')) LIKE '%aprovado%' THEN 1 ELSE 0 END) AS aprov_cnt,
               COUNT(*) AS total
             FROM preparador_registro_item
             WHERE registro_id=%s
@@ -594,19 +594,19 @@ def _maquina_liberada(conn, os_num: str, part: str, op: str) -> Tuple[bool, str,
             (reg_id,),
         )
         stats = cur.fetchone() or {}
-        ok_cnt = int(stats.get("ok_cnt") or 0)
+        aprov_cnt = int(stats.get("aprov_cnt") or 0)
         total = int(stats.get("total") or 0)
-        if total > 0 and ok_cnt == total:
+        if total > 0 and aprov_cnt == total:
             return (
                 True,
                 "preparador_registro",
-                f"registro_id={reg_id}; {ok_cnt}/{total} OK",
+                f"registro_id={reg_id}; {aprov_cnt}/{total} aprovadas",
             )
         else:
             return (
                 False,
                 "preparador_registro",
-                f"registro_id={reg_id}; {ok_cnt}/{total} OK",
+                f"registro_id={reg_id}; {aprov_cnt}/{total} aprovadas",
             )
 
 
@@ -808,7 +808,7 @@ def resultado_preparador():
           "faixaTexto": "...",
           "min": 1.23, "max": 4.56, "unidade": "mm",
           "medicao": "1.30",
-          "status": "ok|reprovada_acima|reprovada_abaixo|alerta|pendente",
+          "status": "aprovado|reprovado|pendente",
           "observacao": ""
         }, ...
       ]
@@ -908,8 +908,15 @@ def resultado_preparador():
                     all_status.append(status)
 
                 # Consolida liberação
-                has_reprov = any(s.startswith("reprovada") for s in all_status)
-                all_ok = len(all_status) > 0 and all(s == "ok" for s in all_status)
+                has_reprov = any(
+                    "reprovado" in parte
+                    for s in all_status
+                    for parte in s.split("|")
+                )
+                all_ok = len(all_status) > 0 and all(
+                    all(parte.strip() == "aprovado" for parte in s.split("|"))
+                    for s in all_status
+                )
                 status_geral = (
                     "liberada"
                     if all_ok
@@ -1002,7 +1009,7 @@ def operador_registrar():
           "indice": 0, "titulo": "...", "instrumento": "...",
           "faixaTexto": "...", "min": 1.23, "max": 4.56, "unidade": "mm",
           "periodicidade": "5 peças", "tolerancias": [..],
-          "escolha": "OK", "status": "ok|reprovada_acima|reprovada_abaixo|alerta",
+          "escolha": "OK", "status": "aprovado|reprovado",
           "observacao": "..."
         }, ...
       ]
@@ -1271,8 +1278,8 @@ def listar_relatorios_operador():
                     f"""
                     SELECT a.os, a.partnumber, a.operacao, a.re_operador,
                            CASE
-                             WHEN SUM(CASE WHEN LOWER(i.status)='reprovado' THEN 1 ELSE 0 END) > 0 THEN 'reprovado'
-                             WHEN SUM(CASE WHEN LOWER(i.status)='ok' THEN 1 ELSE 0 END) = COUNT(i.id) THEN 'aprovado'
+                             WHEN SUM(CASE WHEN LOWER(i.status) LIKE '%reprovado%' THEN 1 ELSE 0 END) > 0 THEN 'reprovado'
+                             WHEN SUM(CASE WHEN LOWER(i.status) LIKE '%aprovado%' THEN 1 ELSE 0 END) = COUNT(i.id) THEN 'aprovado'
                              ELSE 'pendente'
                            END AS status_geral,
                            a.created_at
@@ -1418,14 +1425,14 @@ def _mensagem_bloqueio(
     if fonte == "preparador_registro":
         import re
 
-        m = re.search(r"(\d+)\s*/\s*(\d+)", det)  # ex.: "3/4 OK"
+        m = re.search(r"(\d+)\s*/\s*(\d+)", det)  # ex.: "3/4 aprovadas"
         if m:
-            ok_cnt, total = m.group(1), m.group(2)
+            aprov_cnt, total = m.group(1), m.group(2)
             return (
                 base
-                + f"\nProgresso do registro do Preparador: {ok_cnt}/{total} medidas OK. Aguarde até todas estarem OK."
+                + f"\nProgresso do registro do Preparador: {aprov_cnt}/{total} medidas aprovadas. Aguarde até todas estarem aprovadas."
             )
-        return base + "\nO registro do Preparador ainda não está 100% OK."
+        return base + "\nO registro do Preparador ainda não está 100% aprovado."
 
     return base
 

--- a/lib/features/operador/data/models.dart
+++ b/lib/features/operador/data/models.dart
@@ -8,12 +8,14 @@ enum StatusMedida { ok, alerta, reprovadaAcima, reprovadaAbaixo, pendente }
 StatusMedida statusFromString(String? s) {
   switch ((s ?? '').toLowerCase()) {
     case 'ok':
+    case 'aprovado':
       return StatusMedida.ok;
     case 'alerta':
       return StatusMedida.alerta;
     case 'reprovada_acima':
     case 'acima':
     case 'reprovada':
+    case 'reprovado':
       return StatusMedida.reprovadaAcima;
     case 'reprovada_abaixo':
     case 'abaixo':
@@ -26,13 +28,11 @@ StatusMedida statusFromString(String? s) {
 String statusToString(StatusMedida s) {
   switch (s) {
     case StatusMedida.ok:
-      return 'ok';
     case StatusMedida.alerta:
-      return 'alerta';
+      return 'aprovado';
     case StatusMedida.reprovadaAcima:
-      return 'reprovada_acima';
     case StatusMedida.reprovadaAbaixo:
-      return 'reprovada_abaixo';
+      return 'reprovado';
     case StatusMedida.pendente:
       return 'pendente';
   }

--- a/lib/features/operador/presentation/operador_page.dart
+++ b/lib/features/operador/presentation/operador_page.dart
@@ -153,8 +153,27 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
       map['max'] = m.maximo;
       // escolha = texto selecionado (OK / Aprovado / Reprovado / pílula etc.)
       map['escolha'] = m.medicao ?? '';
-      // status como string
-      map['status'] = statusToString(m.status);
+      // status como string (sempre "aprovado"/"reprovado" e tampão inclui os dois lados)
+      String status;
+      final med = m.medicao ?? '';
+      if (med.contains('Lado passa') && med.contains('Lado não passa')) {
+        // Tampão: avalia cada lado separadamente
+        var passa = 'aprovado';
+        var naoPassa = 'aprovado';
+        for (final part in med.split('|')) {
+          final p = part.trim();
+          if (p.startsWith('Lado passa') && p.endsWith('Reprovado')) {
+            passa = 'reprovado';
+          }
+          if (p.startsWith('Lado não passa') && p.endsWith('Reprovado')) {
+            naoPassa = 'reprovado';
+          }
+        }
+        status = '$passa|$naoPassa';
+      } else {
+        status = statusToString(m.status);
+      }
+      map['status'] = status;
       itens.add(map);
     }
 
@@ -562,6 +581,33 @@ class _MeasurementTile extends StatelessWidget {
         _containsAny(inst, ['tamp', 'tampao', 'tampão', 'tampa']);
   }
 
+  Set<String> _partsFromMedicao(String? medicao) =>
+      (medicao ?? '')
+          .split('|')
+          .map((s) => s.trim())
+          .where((s) => s.isNotEmpty)
+          .toSet();
+
+  String _joinParts(Set<String> parts) => parts.join(' | ');
+
+  StatusMedida _statusFromParts(Set<String> parts) {
+    final hasPassa = parts.any((p) => p.startsWith('Lado passa'));
+    final hasNaoPassa =
+        parts.any((p) => p.startsWith('Lado não passa'));
+    if (hasPassa && hasNaoPassa) {
+      final passaReprovado = parts.contains('Lado passa — Reprovado');
+      final naoPassaReprovado =
+          parts.contains('Lado não passa — Reprovado');
+      if (passaReprovado && naoPassaReprovado) {
+        return StatusMedida.reprovadaAcima;
+      }
+      if (passaReprovado) return StatusMedida.reprovadaAbaixo;
+      if (naoPassaReprovado) return StatusMedida.reprovadaAcima;
+      return StatusMedida.ok;
+    }
+    return StatusMedida.pendente;
+  }
+
   double? _toDoubleNum(dynamic v) {
     if (v == null) return null;
     if (v is num) return v.toDouble();
@@ -685,46 +731,65 @@ class _MeasurementTile extends StatelessWidget {
           ]
           // Modo 2: Tampão (4 botões)
           else if (_isTampao) ...[
-            Wrap(
-              spacing: 8,
-              runSpacing: 8,
-              children: [
-                _pill(
-                  text: 'Lado passa — Aprovado',
-                  bg: Colors.green.shade200,
-                  border: Colors.green.shade600,
-                  fg: Colors.green.shade900,
-                  selected: item.medicao == 'Lado passa — Aprovado',
-                  onTap: () =>
-                      onSelect(StatusMedida.ok, 'Lado passa — Aprovado'),
-                ),
-                _pill(
-                  text: 'Lado passa — Reprovado',
-                  bg: Colors.red.shade100,
-                  border: Colors.red.shade400,
-                  selected: item.medicao == 'Lado passa — Reprovado',
-                  onTap: () => onSelect(
-                      StatusMedida.reprovadaAcima, 'Lado passa — Reprovado'),
-                ),
-                _pill(
-                  text: 'Lado não passa — Aprovado',
-                  bg: Colors.green.shade200,
-                  border: Colors.green.shade600,
-                  fg: Colors.green.shade900,
-                  selected: item.medicao == 'Lado não passa — Aprovado',
-                  onTap: () => onSelect(
-                      StatusMedida.ok, 'Lado não passa — Aprovado'),
-                ),
-                _pill(
-                  text: 'Lado não passa — Reprovado',
-                  bg: Colors.red.shade100,
-                  border: Colors.red.shade400,
-                  selected: item.medicao == 'Lado não passa — Reprovado',
-                  onTap: () => onSelect(StatusMedida.reprovadaAcima,
-                      'Lado não passa — Reprovado'),
-                ),
-              ],
-            ),
+            Builder(builder: (context) {
+              final parts = _partsFromMedicao(item.medicao);
+              return Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: [
+                  _pill(
+                    text: 'Lado passa — Aprovado',
+                    bg: Colors.green.shade200,
+                    border: Colors.green.shade600,
+                    fg: Colors.green.shade900,
+                    selected: parts.contains('Lado passa — Aprovado'),
+                    onTap: () {
+                      final p = _partsFromMedicao(item.medicao);
+                      p.removeWhere((e) => e.startsWith('Lado passa'));
+                      p.add('Lado passa — Aprovado');
+                      onSelect(_statusFromParts(p), _joinParts(p));
+                    },
+                  ),
+                  _pill(
+                    text: 'Lado passa — Reprovado',
+                    bg: Colors.red.shade100,
+                    border: Colors.red.shade400,
+                    selected: parts.contains('Lado passa — Reprovado'),
+                    onTap: () {
+                      final p = _partsFromMedicao(item.medicao);
+                      p.removeWhere((e) => e.startsWith('Lado passa'));
+                      p.add('Lado passa — Reprovado');
+                      onSelect(_statusFromParts(p), _joinParts(p));
+                    },
+                  ),
+                  _pill(
+                    text: 'Lado não passa — Aprovado',
+                    bg: Colors.green.shade200,
+                    border: Colors.green.shade600,
+                    fg: Colors.green.shade900,
+                    selected: parts.contains('Lado não passa — Aprovado'),
+                    onTap: () {
+                      final p = _partsFromMedicao(item.medicao);
+                      p.removeWhere((e) => e.startsWith('Lado não passa'));
+                      p.add('Lado não passa — Aprovado');
+                      onSelect(_statusFromParts(p), _joinParts(p));
+                    },
+                  ),
+                  _pill(
+                    text: 'Lado não passa — Reprovado',
+                    bg: Colors.red.shade100,
+                    border: Colors.red.shade400,
+                    selected: parts.contains('Lado não passa — Reprovado'),
+                    onTap: () {
+                      final p = _partsFromMedicao(item.medicao);
+                      p.removeWhere((e) => e.startsWith('Lado não passa'));
+                      p.add('Lado não passa — Reprovado');
+                      onSelect(_statusFromParts(p), _joinParts(p));
+                    },
+                  ),
+                ],
+              );
+            }),
           ]
           // Modo 3: Pílulas de tolerância + OK
           else ...[

--- a/lib/features/preparacao/data/models.dart
+++ b/lib/features/preparacao/data/models.dart
@@ -8,12 +8,14 @@ enum StatusMedida { ok, alerta, reprovadaAcima, reprovadaAbaixo, pendente }
 StatusMedida statusFromString(String? s) {
   switch ((s ?? '').toLowerCase()) {
     case 'ok':
+    case 'aprovado':
       return StatusMedida.ok;
     case 'alerta':
       return StatusMedida.alerta;
     case 'reprovada_acima':
     case 'acima':
     case 'reprovada':
+    case 'reprovado':
       return StatusMedida.reprovadaAcima;
     case 'reprovada_abaixo':
     case 'abaixo':
@@ -26,13 +28,11 @@ StatusMedida statusFromString(String? s) {
 String statusToString(StatusMedida s) {
   switch (s) {
     case StatusMedida.ok:
-      return 'ok';
     case StatusMedida.alerta:
-      return 'alerta';
+      return 'aprovado';
     case StatusMedida.reprovadaAcima:
-      return 'reprovada_acima';
     case StatusMedida.reprovadaAbaixo:
-      return 'reprovada_abaixo';
+      return 'reprovado';
     case StatusMedida.pendente:
       return 'pendente';
   }

--- a/lib/features/preparacao/presentation/preparacao_page.dart
+++ b/lib/features/preparacao/presentation/preparacao_page.dart
@@ -145,13 +145,11 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
   String statusToString(StatusMedida st) {
     switch (st) {
       case StatusMedida.ok:
-        return 'ok';
-      case StatusMedida.reprovadaAbaixo:
-        return 'reprovada_abaixo';
-      case StatusMedida.reprovadaAcima:
-        return 'reprovada_acima';
       case StatusMedida.alerta:
-        return 'alerta';
+        return 'aprovado';
+      case StatusMedida.reprovadaAbaixo:
+      case StatusMedida.reprovadaAcima:
+        return 'reprovado';
       case StatusMedida.pendente:
         return 'pendente';
     }

--- a/lib/screens/dashboard/components/operator_report_chart.dart
+++ b/lib/screens/dashboard/components/operator_report_chart.dart
@@ -35,19 +35,10 @@ class _OperatorReportChartState extends State<OperatorReportChart> {
   }
 
   double _statusToValue(String status) {
-    switch (status.toLowerCase()) {
-      case 'pendente':
-        return 1;
-      case 'reprovado':
-
-      case 'reprovada':
-      case 'reprovada acima':
-      case 'reprovada abaixo':
-        return 2;
-      default:
-        return 0; // "aprovado" or any other status treated as bom
-
-    }
+    final st = status.toLowerCase();
+    if (st == 'pendente') return 1;
+    if (st.contains('reprovado')) return 2;
+    return 0; // "aprovado" or any other status treated as bom
   }
 
   @override


### PR DESCRIPTION
## Summary
- Join tampão pass and no-pass selections into a dual status string
- Map all measurement statuses to simple `aprovado`/`reprovado` codes
- Update backend and dashboard logic to interpret the new status values

## Testing
- `python -m py_compile app_db.py`
- `dart format lib/features/operador/data/models.dart lib/features/preparacao/data/models.dart lib/features/preparacao/presentation/preparacao_page.dart lib/features/operador/presentation/operador_page.dart lib/screens/dashboard/components/operator_report_chart.dart` *(fails: command not found: dart)*
- `flutter test` *(fails: command not found: flutter)*
- `pytest` *(passes: no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_68b1cd8008748331b1107422ba91e737