### PR TITLE
Restrict tampão dual status and preserve legacy codes

### DIFF
--- a/app_db.py
+++ b/app_db.py
@@ -586,7 +586,8 @@ def _maquina_liberada(conn, os_num: str, part: str, op: str) -> Tuple[bool, str,
         cur.execute(
             """
             SELECT
-              SUM(CASE WHEN LOWER(COALESCE(status,''))='ok' THEN 1 ELSE 0 END) AS ok_cnt,
+              SUM(CASE WHEN LOWER(COALESCE(status,''))='ok' OR LOWER(COALESCE(status,'')) LIKE '%aprovado%'
+                      THEN 1 ELSE 0 END) AS ok_cnt,
               COUNT(*) AS total
             FROM preparador_registro_item
             WHERE registro_id=%s
@@ -600,13 +601,13 @@ def _maquina_liberada(conn, os_num: str, part: str, op: str) -> Tuple[bool, str,
             return (
                 True,
                 "preparador_registro",
-                f"registro_id={reg_id}; {ok_cnt}/{total} OK",
+                f"registro_id={reg_id}; {ok_cnt}/{total} aprovadas",
             )
         else:
             return (
                 False,
                 "preparador_registro",
-                f"registro_id={reg_id}; {ok_cnt}/{total} OK",
+                f"registro_id={reg_id}; {ok_cnt}/{total} aprovadas",
             )
 
 
@@ -808,11 +809,13 @@ def resultado_preparador():
           "faixaTexto": "...",
           "min": 1.23, "max": 4.56, "unidade": "mm",
           "medicao": "1.30",
-          "status": "ok|reprovada_acima|reprovada_abaixo|alerta|pendente",
+          "status": "ok|reprovada_acima|reprovada_abaixo|alerta_acima|alerta_abaixo|alerta|pendente",
           "observacao": ""
         }, ...
       ]
     }
+    (Para medições de tampão, o campo `status` envia os dois lados como
+    "aprovado|reprovado".)
     """
     payload = request.get_json(silent=True) or {}
     print(f"[DEBUG] /preparador/resultado recebido: {payload}", flush=True)
@@ -908,8 +911,14 @@ def resultado_preparador():
                     all_status.append(status)
 
                 # Consolida liberação
-                has_reprov = any(s.startswith("reprovada") for s in all_status)
-                all_ok = len(all_status) > 0 and all(s == "ok" for s in all_status)
+                has_reprov = any(
+                    any(parte.strip().startswith("reprov") for parte in s.split("|"))
+                    for s in all_status
+                )
+                all_ok = len(all_status) > 0 and all(
+                    all(parte.strip() in ("ok", "aprovado") for parte in s.split("|"))
+                    for s in all_status
+                )
                 status_geral = (
                     "liberada"
                     if all_ok
@@ -1002,11 +1011,13 @@ def operador_registrar():
           "indice": 0, "titulo": "...", "instrumento": "...",
           "faixaTexto": "...", "min": 1.23, "max": 4.56, "unidade": "mm",
           "periodicidade": "5 peças", "tolerancias": [..],
-          "escolha": "OK", "status": "ok|reprovada_acima|reprovada_abaixo|alerta",
+          "escolha": "OK", "status": "ok|reprovada_acima|reprovada_abaixo|alerta_acima|alerta_abaixo|alerta",
           "observacao": "..."
         }, ...
       ]
     }
+    (Para medições de tampão, o campo `status` envia os dois lados como
+    "aprovado|reprovado".)
     """
     payload = request.get_json(silent=True) or {}
 
@@ -1271,8 +1282,8 @@ def listar_relatorios_operador():
                     f"""
                     SELECT a.os, a.partnumber, a.operacao, a.re_operador,
                            CASE
-                             WHEN SUM(CASE WHEN LOWER(i.status)='reprovado' THEN 1 ELSE 0 END) > 0 THEN 'reprovado'
-                             WHEN SUM(CASE WHEN LOWER(i.status)='ok' THEN 1 ELSE 0 END) = COUNT(i.id) THEN 'aprovado'
+                             WHEN SUM(CASE WHEN LOWER(i.status) LIKE '%reprov%' THEN 1 ELSE 0 END) > 0 THEN 'reprovado'
+                             WHEN SUM(CASE WHEN LOWER(i.status) LIKE '%aprov%' OR LOWER(i.status) = 'ok' THEN 1 ELSE 0 END) = COUNT(i.id) THEN 'aprovado'
                              ELSE 'pendente'
                            END AS status_geral,
                            a.created_at
@@ -1418,14 +1429,14 @@ def _mensagem_bloqueio(
     if fonte == "preparador_registro":
         import re
 
-        m = re.search(r"(\d+)\s*/\s*(\d+)", det)  # ex.: "3/4 OK"
+        m = re.search(r"(\d+)\s*/\s*(\d+)", det)  # ex.: "3/4 aprovadas"
         if m:
-            ok_cnt, total = m.group(1), m.group(2)
+            aprov_cnt, total = m.group(1), m.group(2)
             return (
                 base
-                + f"\nProgresso do registro do Preparador: {ok_cnt}/{total} medidas OK. Aguarde até todas estarem OK."
+                + f"\nProgresso do registro do Preparador: {aprov_cnt}/{total} medidas aprovadas. Aguarde até todas estarem aprovadas."
             )
-        return base + "\nO registro do Preparador ainda não está 100% OK."
+        return base + "\nO registro do Preparador ainda não está 100% aprovado."
 
     return base
 

--- a/lib/features/operador/data/models.dart
+++ b/lib/features/operador/data/models.dart
@@ -3,17 +3,33 @@ import 'dart:convert';
 
 import 'package:admin/utils/string_utils.dart';
 
-enum StatusMedida { ok, alerta, reprovadaAcima, reprovadaAbaixo, pendente }
+enum StatusMedida {
+  ok,
+  alertaAcima,
+  alertaAbaixo,
+  alerta,
+  reprovadaAcima,
+  reprovadaAbaixo,
+  pendente
+}
 
 StatusMedida statusFromString(String? s) {
   switch ((s ?? '').toLowerCase()) {
     case 'ok':
+    case 'aprovado':
       return StatusMedida.ok;
     case 'alerta':
       return StatusMedida.alerta;
+    case 'alerta_acima':
+    case 'alerta acima':
+      return StatusMedida.alertaAcima;
+    case 'alerta_abaixo':
+    case 'alerta abaixo':
+      return StatusMedida.alertaAbaixo;
     case 'reprovada_acima':
     case 'acima':
     case 'reprovada':
+    case 'reprovado':
       return StatusMedida.reprovadaAcima;
     case 'reprovada_abaixo':
     case 'abaixo':
@@ -27,6 +43,10 @@ String statusToString(StatusMedida s) {
   switch (s) {
     case StatusMedida.ok:
       return 'ok';
+    case StatusMedida.alertaAcima:
+      return 'alerta_acima';
+    case StatusMedida.alertaAbaixo:
+      return 'alerta_abaixo';
     case StatusMedida.alerta:
       return 'alerta';
     case StatusMedida.reprovadaAcima:

--- a/lib/features/operador/presentation/operador_page.dart
+++ b/lib/features/operador/presentation/operador_page.dart
@@ -153,8 +153,27 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
       map['max'] = m.maximo;
       // escolha = texto selecionado (OK / Aprovado / Reprovado / pílula etc.)
       map['escolha'] = m.medicao ?? '';
-      // status como string
-      map['status'] = statusToString(m.status);
+      // status como string; tampão envia "aprovado|reprovado" com ambos os lados
+      String status;
+      final med = m.medicao ?? '';
+      if (med.contains('Lado passa') && med.contains('Lado não passa')) {
+        // Tampão: avalia cada lado separadamente
+        var passa = 'aprovado';
+        var naoPassa = 'aprovado';
+        for (final part in med.split('|')) {
+          final p = part.trim();
+          if (p.startsWith('Lado passa') && p.endsWith('Reprovado')) {
+            passa = 'reprovado';
+          }
+          if (p.startsWith('Lado não passa') && p.endsWith('Reprovado')) {
+            naoPassa = 'reprovado';
+          }
+        }
+        status = '$passa|$naoPassa';
+      } else {
+        status = statusToString(m.status);
+      }
+      map['status'] = status;
       itens.add(map);
     }
 
@@ -562,6 +581,33 @@ class _MeasurementTile extends StatelessWidget {
         _containsAny(inst, ['tamp', 'tampao', 'tampão', 'tampa']);
   }
 
+  Set<String> _partsFromMedicao(String? medicao) =>
+      (medicao ?? '')
+          .split('|')
+          .map((s) => s.trim())
+          .where((s) => s.isNotEmpty)
+          .toSet();
+
+  String _joinParts(Set<String> parts) => parts.join(' | ');
+
+  StatusMedida _statusFromParts(Set<String> parts) {
+    final hasPassa = parts.any((p) => p.startsWith('Lado passa'));
+    final hasNaoPassa =
+        parts.any((p) => p.startsWith('Lado não passa'));
+    if (hasPassa && hasNaoPassa) {
+      final passaReprovado = parts.contains('Lado passa — Reprovado');
+      final naoPassaReprovado =
+          parts.contains('Lado não passa — Reprovado');
+      if (passaReprovado && naoPassaReprovado) {
+        return StatusMedida.reprovadaAcima;
+      }
+      if (passaReprovado) return StatusMedida.reprovadaAbaixo;
+      if (naoPassaReprovado) return StatusMedida.reprovadaAcima;
+      return StatusMedida.ok;
+    }
+    return StatusMedida.pendente;
+  }
+
   double? _toDoubleNum(dynamic v) {
     if (v == null) return null;
     if (v is num) return v.toDouble();
@@ -627,15 +673,6 @@ class _MeasurementTile extends StatelessWidget {
 
     // NÃO usar ?? [] se tolerancias for não-nulo (evita dead_null_aware_expression)
     final tolerancias = item.tolerancias;
-    final tolVals = <double>[];
-    for (final t in tolerancias) {
-      final d = _toDoubleNum(t);
-      if (d != null) tolVals.add(d);
-    }
-    tolVals.sort();
-
-    final minEdge = item.minimo ?? (tolVals.isNotEmpty ? tolVals.first : null);
-    final maxEdge = item.maximo ?? (tolVals.isNotEmpty ? tolVals.last : null);
 
     // ------- UI -------
     return Card(
@@ -685,46 +722,65 @@ class _MeasurementTile extends StatelessWidget {
           ]
           // Modo 2: Tampão (4 botões)
           else if (_isTampao) ...[
-            Wrap(
-              spacing: 8,
-              runSpacing: 8,
-              children: [
-                _pill(
-                  text: 'Lado passa — Aprovado',
-                  bg: Colors.green.shade200,
-                  border: Colors.green.shade600,
-                  fg: Colors.green.shade900,
-                  selected: item.medicao == 'Lado passa — Aprovado',
-                  onTap: () =>
-                      onSelect(StatusMedida.ok, 'Lado passa — Aprovado'),
-                ),
-                _pill(
-                  text: 'Lado passa — Reprovado',
-                  bg: Colors.red.shade100,
-                  border: Colors.red.shade400,
-                  selected: item.medicao == 'Lado passa — Reprovado',
-                  onTap: () => onSelect(
-                      StatusMedida.reprovadaAcima, 'Lado passa — Reprovado'),
-                ),
-                _pill(
-                  text: 'Lado não passa — Aprovado',
-                  bg: Colors.green.shade200,
-                  border: Colors.green.shade600,
-                  fg: Colors.green.shade900,
-                  selected: item.medicao == 'Lado não passa — Aprovado',
-                  onTap: () => onSelect(
-                      StatusMedida.ok, 'Lado não passa — Aprovado'),
-                ),
-                _pill(
-                  text: 'Lado não passa — Reprovado',
-                  bg: Colors.red.shade100,
-                  border: Colors.red.shade400,
-                  selected: item.medicao == 'Lado não passa — Reprovado',
-                  onTap: () => onSelect(StatusMedida.reprovadaAcima,
-                      'Lado não passa — Reprovado'),
-                ),
-              ],
-            ),
+            Builder(builder: (context) {
+              final parts = _partsFromMedicao(item.medicao);
+              return Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: [
+                  _pill(
+                    text: 'Lado passa — Aprovado',
+                    bg: Colors.green.shade200,
+                    border: Colors.green.shade600,
+                    fg: Colors.green.shade900,
+                    selected: parts.contains('Lado passa — Aprovado'),
+                    onTap: () {
+                      final p = _partsFromMedicao(item.medicao);
+                      p.removeWhere((e) => e.startsWith('Lado passa'));
+                      p.add('Lado passa — Aprovado');
+                      onSelect(_statusFromParts(p), _joinParts(p));
+                    },
+                  ),
+                  _pill(
+                    text: 'Lado passa — Reprovado',
+                    bg: Colors.red.shade100,
+                    border: Colors.red.shade400,
+                    selected: parts.contains('Lado passa — Reprovado'),
+                    onTap: () {
+                      final p = _partsFromMedicao(item.medicao);
+                      p.removeWhere((e) => e.startsWith('Lado passa'));
+                      p.add('Lado passa — Reprovado');
+                      onSelect(_statusFromParts(p), _joinParts(p));
+                    },
+                  ),
+                  _pill(
+                    text: 'Lado não passa — Aprovado',
+                    bg: Colors.green.shade200,
+                    border: Colors.green.shade600,
+                    fg: Colors.green.shade900,
+                    selected: parts.contains('Lado não passa — Aprovado'),
+                    onTap: () {
+                      final p = _partsFromMedicao(item.medicao);
+                      p.removeWhere((e) => e.startsWith('Lado não passa'));
+                      p.add('Lado não passa — Aprovado');
+                      onSelect(_statusFromParts(p), _joinParts(p));
+                    },
+                  ),
+                  _pill(
+                    text: 'Lado não passa — Reprovado',
+                    bg: Colors.red.shade100,
+                    border: Colors.red.shade400,
+                    selected: parts.contains('Lado não passa — Reprovado'),
+                    onTap: () {
+                      final p = _partsFromMedicao(item.medicao);
+                      p.removeWhere((e) => e.startsWith('Lado não passa'));
+                      p.add('Lado não passa — Reprovado');
+                      onSelect(_statusFromParts(p), _joinParts(p));
+                    },
+                  ),
+                ],
+              );
+            }),
           ]
           // Modo 3: Pílulas de tolerância + OK
           else ...[
@@ -732,23 +788,44 @@ class _MeasurementTile extends StatelessWidget {
                 builder: (context) {
                   final chips = <Widget>[];
 
-                  // Monta as 4 pílulas coloridas
-                  for (final raw in tolerancias) {
+                  // Monta as 4 pílulas coloridas na ordem recebida
+                  for (var i = 0; i < tolerancias.length; i++) {
+                    final raw = tolerancias[i];
                     final d = _toDoubleNum(raw);
-                    // default amarelo
-                    Color bg = Colors.amber.shade100;
-                    Color bd = Colors.amber.shade400;
-                    if (d != null &&
-                        ((minEdge != null && _near(d, minEdge)) ||
-                            (maxEdge != null && _near(d, maxEdge)))) {
-                      bg = Colors.red.shade100; // extremos
-                      bd = Colors.red.shade400;
+
+                    // Define cores e status conforme a posição
+                    StatusMedida st;
+                    Color bg;
+                    Color bd;
+                    switch (i) {
+                      case 0:
+                        st = StatusMedida.reprovadaAbaixo;
+                        bg = Colors.red.shade100;
+                        bd = Colors.red.shade400;
+                        break;
+                      case 1:
+                        st = StatusMedida.alertaAbaixo;
+                        bg = Colors.amber.shade100;
+                        bd = Colors.amber.shade400;
+                        break;
+                      case 2:
+                        st = StatusMedida.alertaAcima;
+                        bg = Colors.amber.shade100;
+                        bd = Colors.amber.shade400;
+                        break;
+                      case 3:
+                        st = StatusMedida.reprovadaAcima;
+                        bg = Colors.red.shade100;
+                        bd = Colors.red.shade400;
+                        break;
+                      default:
+                        st = StatusMedida.alerta;
+                        bg = Colors.amber.shade100;
+                        bd = Colors.amber.shade400;
                     }
 
-                    final label = d != null
-                        ? d.toStringAsFixed(2)
-                        : raw.toString();
-
+                    final label =
+                        d != null ? d.toStringAsFixed(2) : raw.toString();
                     final selected = item.medicao == label;
 
                     chips.add(_pill(
@@ -756,20 +833,7 @@ class _MeasurementTile extends StatelessWidget {
                       bg: bg,
                       border: bd,
                       selected: selected,
-                      onTap: () {
-                        // Seleciona a tolerância: classifica
-                        StatusMedida st = StatusMedida.alerta;
-                        if (d != null) {
-                          if (minEdge != null && _near(d, minEdge)) {
-                            st = StatusMedida.reprovadaAbaixo;
-                          } else if (maxEdge != null && _near(d, maxEdge)) {
-                            st = StatusMedida.reprovadaAcima;
-                          } else {
-                            st = StatusMedida.alerta;
-                          }
-                        }
-                        onSelect(st, label);
-                      },
+                      onTap: () => onSelect(st, label),
                     ));
                   }
 

--- a/lib/features/preparacao/data/models.dart
+++ b/lib/features/preparacao/data/models.dart
@@ -3,17 +3,33 @@ import 'dart:convert';
 
 import 'package:admin/utils/string_utils.dart';
 
-enum StatusMedida { ok, alerta, reprovadaAcima, reprovadaAbaixo, pendente }
+enum StatusMedida {
+  ok,
+  alertaAcima,
+  alertaAbaixo,
+  alerta,
+  reprovadaAcima,
+  reprovadaAbaixo,
+  pendente
+}
 
 StatusMedida statusFromString(String? s) {
   switch ((s ?? '').toLowerCase()) {
     case 'ok':
+    case 'aprovado':
       return StatusMedida.ok;
     case 'alerta':
       return StatusMedida.alerta;
+    case 'alerta_acima':
+    case 'alerta acima':
+      return StatusMedida.alertaAcima;
+    case 'alerta_abaixo':
+    case 'alerta abaixo':
+      return StatusMedida.alertaAbaixo;
     case 'reprovada_acima':
     case 'acima':
     case 'reprovada':
+    case 'reprovado':
       return StatusMedida.reprovadaAcima;
     case 'reprovada_abaixo':
     case 'abaixo':
@@ -27,6 +43,10 @@ String statusToString(StatusMedida s) {
   switch (s) {
     case StatusMedida.ok:
       return 'ok';
+    case StatusMedida.alertaAcima:
+      return 'alerta_acima';
+    case StatusMedida.alertaAbaixo:
+      return 'alerta_abaixo';
     case StatusMedida.alerta:
       return 'alerta';
     case StatusMedida.reprovadaAcima:

--- a/lib/features/preparacao/presentation/preparacao_page.dart
+++ b/lib/features/preparacao/presentation/preparacao_page.dart
@@ -150,6 +150,10 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
         return 'reprovada_abaixo';
       case StatusMedida.reprovadaAcima:
         return 'reprovada_acima';
+      case StatusMedida.alertaAbaixo:
+        return 'alerta_abaixo';
+      case StatusMedida.alertaAcima:
+        return 'alerta_acima';
       case StatusMedida.alerta:
         return 'alerta';
       case StatusMedida.pendente:
@@ -522,6 +526,8 @@ class _MeasurementTilePrepState extends State<_MeasurementTilePrep> {
         return Colors.red.shade400;
       case StatusMedida.reprovadaAcima:
         return Colors.red.shade400;
+      case StatusMedida.alertaAbaixo:
+      case StatusMedida.alertaAcima:
       case StatusMedida.alerta:
         return Colors.amber.shade700;
       case StatusMedida.pendente:

--- a/lib/screens/dashboard/components/operator_report_chart.dart
+++ b/lib/screens/dashboard/components/operator_report_chart.dart
@@ -35,18 +35,25 @@ class _OperatorReportChartState extends State<OperatorReportChart> {
   }
 
   double _statusToValue(String status) {
-    switch (status.toLowerCase()) {
+    final st = status.toLowerCase();
+    switch (st) {
       case 'pendente':
         return 1;
+      case 'alerta':
+      case 'alerta_acima':
+      case 'alerta_abaixo':
+        return 1;
       case 'reprovado':
-
       case 'reprovada':
       case 'reprovada acima':
+      case 'reprovada_acima':
       case 'reprovada abaixo':
+      case 'reprovada_abaixo':
         return 2;
       default:
-        return 0; // "aprovado" or any other status treated as bom
-
+        if (st.contains('reprovado')) return 2; // covers "aprovado|reprovado"
+        if (st.contains('alerta')) return 1;
+        return 0; // "ok"/"aprovado" treated como bom
     }
   }
 


### PR DESCRIPTION
## Summary
- Ensure tampão measurements send combined `aprovado|reprovado` strings while other items keep legacy statuses
- Restore original status mapping in front-end models and backend consolidation logic
- Update operator dashboard chart to recognize legacy and combined reprovado statuses
- Map five-option tolerance selections to `reprovada_abaixo`, `alerta_abaixo`, `ok`, `alerta_acima`, and `reprovada_acima`

## Testing
- `python -m py_compile app_db.py`
- `dart format lib/features/operador/data/models.dart lib/features/preparacao/data/models.dart lib/features/preparacao/presentation/preparacao_page.dart lib/features/operador/presentation/operador_page.dart lib/screens/dashboard/components/operator_report_chart.dart` *(fails: command not found: dart)*
- `flutter test` *(fails: command not found: flutter)*
- `pytest` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_68b1cd8008748331b1107422ba91e737