### PR TITLE
Add finalization workflow and update production closure

### DIFF
--- a/app_db.py
+++ b/app_db.py
@@ -970,6 +970,153 @@ def resultado_preparador():
         return jsonify({"error": f"Falha ao inserir registro do preparador: {e}"}), 500
 
 
+# ========= Finalização da OS pelo Preparador =========
+@app.route("/preparador/finalizar_os", methods=["POST"])
+def preparador_finalizar_os():
+    payload = request.get_json(silent=True) or {}
+    print(f"[DEBUG] /preparador/finalizar_os recebido: {payload}", flush=True)
+
+    os_num = _norm(payload.get("os"))
+    re_prep = _norm(payload.get("re"))
+    part = _norm_part(payload.get("partnumber"))
+    op = _norm_op(payload.get("operacao"))
+    itens = payload.get("itens", [])
+
+    if not os_num or not re_prep or not part or not op:
+        return (
+            jsonify(
+                {"error": "Campos 'os', 're', 'partnumber' e 'operacao' são obrigatórios"}
+            ),
+            400,
+        )
+    if not isinstance(itens, list) or len(itens) == 0:
+        return (
+            jsonify({"error": "Lista 'itens' é obrigatória e não pode ser vazia"}),
+            400,
+        )
+
+    try:
+        with _conn_db(DB_NAME) as c:
+            with c.cursor() as cur:
+                cur.execute(
+                    "SELECT status FROM ordem_servico WHERE os=%s", (os_num,)
+                )
+                st = (cur.fetchone() or {}).get("status", "").lower()
+                if st == "encerrada":
+                    return (
+                        jsonify({"code": "ja_finalizada", "error": "OS já finalizada."}),
+                        409,
+                    )
+                if st != "fim_prod":
+                    return (
+                        jsonify(
+                            {
+                                "code": "producao_nao_encerrada",
+                                "error": "Produção não encerrada pelo operador.",
+                            }
+                        ),
+                        409,
+                    )
+
+                cur.execute(
+                    "INSERT IGNORE INTO ordem_servico (os) VALUES (%s)", (os_num,)
+                )
+
+                cur.execute(
+                    """
+                    INSERT INTO preparador_registro (os, partnumber, operacao, re_preparador)
+                    VALUES (%s, %s, %s, %s)
+                    """,
+                    (os_num, part, op, re_prep),
+                )
+                registro_id = cur.lastrowid
+
+                all_status = []
+                for it in itens:
+                    idx = int(it.get("indice", 0))
+                    titulo = _norm(it.get("titulo"))
+                    faixa_texto = _norm(it.get("faixaTexto"))
+                    minimo = it.get("min")
+                    maximo = it.get("max")
+                    unidade = _norm(it.get("unidade"))
+                    medicao = _norm(it.get("medicao"))
+                    status = _norm(it.get("status")).lower()
+                    observacao = _norm(it.get("observacao"))
+
+                    cur.execute(
+                        """
+                        INSERT INTO preparador_registro_item
+                          (registro_id, idx_medida, titulo, faixa_texto, minimo, maximo, unidade,
+                           medicao, status, observacao)
+                        VALUES
+                          (%s, %s, %s, %s, %s, %s, %s,
+                           %s, %s, %s)
+                        """,
+                        (
+                            registro_id,
+                            idx,
+                            titulo,
+                            faixa_texto,
+                            minimo,
+                            maximo,
+                            unidade,
+                            medicao,
+                            status,
+                            observacao,
+                        ),
+                    )
+                    all_status.append(status)
+
+                has_reprov = any(
+                    any(parte.strip().startswith("reprov") for parte in s.split("|"))
+                    for s in all_status
+                )
+                all_ok = len(all_status) > 0 and all(
+                    all(parte.strip() in ("ok", "aprovado") for parte in s.split("|"))
+                    for s in all_status
+                )
+                status_geral = (
+                    "finalizada"
+                    if all_ok
+                    else ("reprovada" if has_reprov else "pendente")
+                )
+
+                cur.execute(
+                    """
+                    UPDATE preparador_liberacao
+                    SET re_preparador=%s, status_geral=%s
+                    WHERE os=%s
+                      AND TRIM(LEADING '0' FROM TRIM(partnumber))=%s
+                      AND TRIM(LEADING '0' FROM TRIM(operacao))=%s
+                    ORDER BY id DESC LIMIT 1
+                    """,
+                    (re_prep, status_geral, os_num, part, op),
+                )
+                if cur.rowcount == 0:
+                    cur.execute(
+                        """
+                        INSERT INTO preparador_liberacao
+                          (os, partnumber, operacao, re_preparador, status_geral)
+                        VALUES (%s, %s, %s, %s, %s)
+                        """,
+                        (os_num, part, op, re_prep, status_geral),
+                    )
+
+                cur.execute(
+                    "UPDATE ordem_servico SET status='encerrada' WHERE os=%s",
+                    (os_num,),
+                )
+            c.commit()
+
+        return jsonify(
+            {
+                "status": "ok",
+                "registro_id": registro_id,
+                "status_geral": status_geral,
+            }
+        )
+    except Exception as e:
+        return jsonify({"error": f"Falha ao finalizar OS: {e}"}), 500
 # ========= CHECAGEM (para UI) =========
 @app.route("/operador/pode")
 def operador_pode():
@@ -1206,8 +1353,8 @@ def operador_fim_jornada():
         return jsonify({"error": f"Falha ao registrar fim de jornada: {e}"}), 500
 
 
-@app.route("/operador/encerrar_os", methods=["POST"])
-def operador_encerrar_os():
+@app.route("/operador/encerrar_producao", methods=["POST"])
+def operador_encerrar_producao():
     payload = request.get_json(silent=True) or {}
     os_num = _norm(payload.get("os"))
     if not os_num:
@@ -1224,14 +1371,15 @@ def operador_encerrar_os():
                         400,
                     )
                 cur.execute(
-                    "UPDATE ordem_servico SET status='encerrada' WHERE os=%s", (os_num,)
+                    "UPDATE ordem_servico SET status='fim_prod' WHERE os=%s",
+                    (os_num,),
                 )
                 if cur.rowcount == 0:
                     return jsonify({"error": "OS não encontrada"}), 404
             c.commit()
         return jsonify({"status": "ok"})
     except Exception as e:
-        return jsonify({"error": f"Falha ao encerrar OS: {e}"}), 500
+        return jsonify({"error": f"Falha ao encerrar produção: {e}"}), 500
 
 
 

--- a/lib/features/finalizar_os/presentation/finalizar_os_page.dart
+++ b/lib/features/finalizar_os/presentation/finalizar_os_page.dart
@@ -1,0 +1,616 @@
+// lib/features/finalizar_os/presentation/finalizar_os_page.dart
+import 'dart:io';
+import 'dart:convert';
+import 'package:flutter/services.dart';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:http/http.dart' as http;
+
+import 'package:admin/features/preparacao/data/models.dart';
+import 'package:admin/features/preparacao/data/repository_provider.dart';
+import 'package:admin/screens/main/components/side_menu.dart';
+import 'package:admin/utils/string_utils.dart';
+
+/// Mesmo base URL usado no Operador
+const String kBaseUrl = 'http://192.168.0.241:5005';
+
+class FinalizarOsPage extends ConsumerStatefulWidget {
+  const FinalizarOsPage({super.key});
+
+  @override
+  ConsumerState<FinalizarOsPage> createState() => _FinalizarOsPageState();
+}
+
+final medidasFinalizadorControllerProvider =
+    StateNotifierProvider.autoDispose<MedidasFinalizadorController,
+    AsyncValue<List<MedidaItem>>>((ref) {
+  return MedidasFinalizadorController(ref);
+});
+
+class MedidasFinalizadorController
+    extends StateNotifier<AsyncValue<List<MedidaItem>>> {
+  final Ref _ref;
+  MedidasFinalizadorController(this._ref) : super(const AsyncValue.data([]));
+
+  Future<void> carregar({
+    required String partnumber,
+    required String operacao,
+  }) async {
+    state = const AsyncValue.loading();
+    try {
+      final repo = _ref.read(finalizadorRepositoryProvider);
+      final itens =
+      await repo.getMedidas(partnumber: partnumber, operacao: operacao);
+
+      // Zera status/medição – sem copyWith
+      final normalizados = itens
+          .map((m) => MedidaItem(
+        titulo: m.titulo,
+        faixaTexto: m.faixaTexto,
+        minimo: m.minimo,
+        maximo: m.maximo,
+        unidade: m.unidade,
+        status: StatusMedida.pendente,
+        medicao: null,
+        observacao: m.observacao,
+        periodicidade: m.periodicidade,
+        instrumento: m.instrumento,
+        tolerancias: m.tolerancias,
+      ))
+          .toList();
+
+      state = AsyncValue.data(normalizados);
+    } catch (e, st) {
+      state = AsyncValue.error(e, st);
+    }
+  }
+
+  void setStatusAndMedicao(int index, StatusMedida status, String? medicao) {
+    final current = [...(state.value ?? const <MedidaItem>[])];
+    if (index < 0 || index >= current.length) return;
+    final old = current[index];
+    current[index] = MedidaItem(
+      titulo: old.titulo,
+      faixaTexto: old.faixaTexto,
+      minimo: old.minimo,
+      maximo: old.maximo,
+      unidade: old.unidade,
+      status: status,
+      medicao: medicao,
+      observacao: old.observacao,
+      periodicidade: old.periodicidade,
+      instrumento: old.instrumento,
+      tolerancias: old.tolerancias,
+    );
+    state = AsyncValue.data(current);
+  }
+
+  void resetSelecoes() {
+    final current = [...(state.value ?? const <MedidaItem>[])];
+    for (var i = 0; i < current.length; i++) {
+      final old = current[i];
+      current[i] = MedidaItem(
+        titulo: old.titulo,
+        faixaTexto: old.faixaTexto,
+        minimo: old.minimo,
+        maximo: old.maximo,
+        unidade: old.unidade,
+        status: StatusMedida.pendente,
+        medicao: null,
+        observacao: old.observacao,
+        periodicidade: old.periodicidade,
+        instrumento: old.instrumento,
+        tolerancias: old.tolerancias,
+      );
+    }
+    state = AsyncValue.data(current);
+  }
+}
+
+class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
+  final _formKey = GlobalKey<FormState>();
+  final _reCtrl = TextEditingController();   // <<< RE
+  final _osCtrl = TextEditingController();   // <<< OS
+  final _partCtrl = TextEditingController();
+  final _opCtrl = TextEditingController();
+
+  bool _registrando = false;
+  bool _osFinalizada = false;
+
+  void _resetFinalizada() {
+    if (_osFinalizada) setState(() => _osFinalizada = false);
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _osCtrl.addListener(_resetFinalizada);
+    _partCtrl.addListener(_resetFinalizada);
+    _opCtrl.addListener(_resetFinalizada);
+  }
+
+  @override
+  void dispose() {
+    _osCtrl.removeListener(_resetFinalizada);
+    _partCtrl.removeListener(_resetFinalizada);
+    _opCtrl.removeListener(_resetFinalizada);
+    _reCtrl.dispose();
+    _osCtrl.dispose();
+    _partCtrl.dispose();
+    _opCtrl.dispose();
+    super.dispose();
+  }
+
+  String statusToString(StatusMedida st) {
+    switch (st) {
+      case StatusMedida.ok:
+      case StatusMedida.alerta:
+        return 'aprovado';
+      case StatusMedida.reprovadaAbaixo:
+      case StatusMedida.reprovadaAcima:
+
+        return 'reprovada_acima';
+      case StatusMedida.alertaAbaixo:
+        return 'alerta_abaixo';
+      case StatusMedida.alertaAcima:
+        return 'alerta_acima';
+      case StatusMedida.pendente:
+        return 'pendente';
+    }
+  }
+
+  Future<void> _registrarFinalizacao() async {
+    final medidas = ref.read(medidasFinalizadorControllerProvider).value ?? [];
+
+    // Valida RE / OS
+    if (_reCtrl.text.trim().isEmpty || _osCtrl.text.trim().isEmpty) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Preencha RE e O.S. para registrar.')),
+      );
+      return;
+    }
+
+    // Todas respondidas? (para Preparador, cada item precisa de medição)
+    final faltando = <int>[];
+    for (var i = 0; i < medidas.length; i++) {
+      final m = medidas[i];
+      if ((m.medicao == null || m.medicao!.isEmpty) ||
+          m.status == StatusMedida.pendente) {
+        faltando.add(i);
+      }
+    }
+    if (faltando.isNotEmpty) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Faltam ${faltando.length} medições para preencher.'),
+        ),
+      );
+      return;
+    }
+
+    // Monta payload
+    final itens = <Map<String, dynamic>>[];
+    for (var i = 0; i < medidas.length; i++) {
+      final m = medidas[i];
+      itens.add({
+        'indice': i,
+        'titulo': m.titulo,
+        'faixaTexto': m.faixaTexto,
+        'min': m.minimo,
+        'max': m.maximo,
+        'unidade': m.unidade,
+        'medicao': m.medicao, // valor digitado
+        'status': statusToString(m.status),
+        'observacao': m.observacao ?? '',
+      });
+    }
+
+    final body = jsonEncode({
+      're': _reCtrl.text.trim(),
+      'os': _osCtrl.text.trim(),
+      'partnumber': normalizeCode(_partCtrl.text),
+      'operacao': normalizeCode(_opCtrl.text),
+      'itens': itens,
+    });
+
+    final uri = Uri.parse('$kBaseUrl/preparador/finalizar_os');
+
+    setState(() => _registrando = true);
+    try {
+      final resp = await http
+          .post(uri, headers: {'Content-Type': 'application/json'}, body: body)
+          .timeout(const Duration(seconds: 25));
+
+      if (!mounted) return;
+
+      if (resp.statusCode == 200) {
+        final data = jsonDecode(resp.body);
+        final statusGeral =
+            (data['status_geral'] ?? '').toString().toLowerCase();
+        if (statusGeral.isNotEmpty) {
+          setState(() => _osFinalizada = true);
+        }
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('OS finalizada com sucesso!')),
+        );
+        ref
+            .read(medidasFinalizadorControllerProvider.notifier)
+            .resetSelecoes();
+      } else if (resp.statusCode == 409) {
+        final data = jsonDecode(resp.body);
+        if ((data['code'] ?? '') == 'ja_finalizada') {
+          setState(() => _osFinalizada = true);
+        }
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Falha ao registrar: ${data['error'] ?? resp.body}')),
+        );
+      } else {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Falha ao registrar: ${resp.statusCode} ${resp.body}'),
+          ),
+        );
+      }
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Erro ao registrar: $e')),
+      );
+    } finally {
+      if (mounted) setState(() => _registrando = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final medidasAsync = ref.watch(medidasFinalizadorControllerProvider);
+    final medidas = medidasAsync.value ?? [];
+
+    // Pode registrar quando: RE e OS preenchidos + todas as medições preenchidas
+    final reOk = _reCtrl.text.trim().isNotEmpty;
+    final osOk = _osCtrl.text.trim().isNotEmpty;
+    final todasOk = medidas.isNotEmpty &&
+        medidas.every((m) =>
+            (m.medicao ?? '').isNotEmpty &&
+                m.status != StatusMedida.pendente);
+    final podeRegistrar =
+        reOk && osOk && todasOk && !_registrando && !_osFinalizada;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Finalizar OS'),
+        actions: [
+          Padding(
+            padding: const EdgeInsets.only(right: 12.0),
+            child: Center(
+              child: Text(
+                Platform.isWindows ? 'Windows: leitura direta/API' : 'Android: via API',
+                style: const TextStyle(fontSize: 12),
+              ),
+            ),
+          )
+        ],
+      ),
+      drawer: const SideMenu(current: SideMenuSection.finalizar),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            children: [
+              Form(
+                key: _formKey,
+                child: Column(
+                  children: [
+                    Row(
+                      children: [
+                        Expanded(
+                          child: TextFormField(
+                            controller: _reCtrl,
+                            textInputAction: TextInputAction.next,
+                            keyboardType: TextInputType.number,
+                            inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                            decoration: const InputDecoration(
+                              labelText: 'R.E. do Preparador', // ajuste o texto se for Operador
+                              border: OutlineInputBorder(),
+                            ),
+                            validator: (v) {
+                              final s = (v ?? '').trim();
+                              if (s.isEmpty) return 'Obrigatório';
+                              if (!RegExp(r'^\d+$').hasMatch(s)) return 'Apenas números';
+                              return null;
+                            },
+                          ),
+                        ),
+                        const SizedBox(width: 12),
+                        SizedBox(
+                          width: 140, // igual ao campo Operação
+                          child: TextFormField(
+                            controller: _osCtrl,
+                            textInputAction: TextInputAction.next,
+                            keyboardType: TextInputType.number,
+                            inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                            decoration: const InputDecoration(
+                              labelText: 'O.S.',
+                              border: OutlineInputBorder(),
+                            ),
+                            validator: (v) {
+                              final s = (v ?? '').trim();
+                              if (s.isEmpty) return 'Obrigatório';
+                              if (!RegExp(r'^\d+$').hasMatch(s)) return 'Apenas números';
+                              return null;
+                            },
+                          ),
+                        ),
+                      ],
+                    ),
+
+                    const SizedBox(height: 12),
+
+                    // ---------- PartNumber + Operação (Operação só números) ----------
+                    Row(
+                      children: [
+                        Expanded(
+                          child: TextFormField(
+                            controller: _partCtrl,
+                            textInputAction: TextInputAction.next,
+                            decoration: const InputDecoration(
+                              labelText: 'Código da peça (PartNumber)',
+                              border: OutlineInputBorder(),
+                            ),
+                            validator: (v) =>
+                            (v == null || v.trim().isEmpty) ? 'Obrigatório' : null,
+                          ),
+                        ),
+                        const SizedBox(width: 12),
+                        SizedBox(
+                          width: 140,
+                          child: TextFormField(
+                            controller: _opCtrl,
+                            keyboardType: TextInputType.number,
+                            inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                            decoration: const InputDecoration(
+                              labelText: 'Operação',
+                              border: OutlineInputBorder(),
+                            ),
+                            validator: (v) {
+                              final s = (v ?? '').trim();
+                              if (s.isEmpty) return 'Obrigatório';
+                              if (!RegExp(r'^\d+$').hasMatch(s)) return 'Apenas números';
+                              return null;
+                            },
+                          ),
+                        ),
+                      ],
+                    ),
+
+                    const SizedBox(height: 12),
+                    SizedBox(
+                      width: double.infinity,
+                      child: FilledButton.icon(
+                        onPressed: () async {
+                          if (_formKey.currentState!.validate()) {
+                            FocusScope.of(context).unfocus();
+                            await ref
+                                .read(medidasFinalizadorControllerProvider.notifier)
+                                .carregar(
+                              partnumber: normalizeCode(_partCtrl.text),
+                              operacao: normalizeCode(_opCtrl.text),
+                            );
+                          }
+                        },
+                        icon: const Icon(Icons.search),
+                        label: const Text('Carregar medidas'),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 16),
+              Expanded(
+                child: medidasAsync.when(
+                  data: (list) {
+                    if (list.isEmpty) {
+                      return const Center(
+                        child: Text('Nenhuma medida encontrada para a chave informada.'),
+                      );
+                    }
+                    return ListView.separated(
+                      itemCount: list.length,
+                      separatorBuilder: (_, __) => const SizedBox(height: 8),
+                      itemBuilder: (context, index) {
+                        final item = list[index];
+                        return _MeasurementTilePrep(
+                          index: index,
+                          item: item,
+                          onChanged: (status, valor) => ref
+                              .read(medidasFinalizadorControllerProvider.notifier)
+                              .setStatusAndMedicao(index, status, valor),
+                        );
+                      },
+                    );
+                  },
+                  loading: () => const Center(child: CircularProgressIndicator()),
+                  error: (e, _) => Center(
+                    child: Text('Erro ao carregar:\n${e.toString()}'),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 10),
+              SizedBox(
+                width: double.infinity,
+                child: FilledButton.icon(
+                  onPressed: podeRegistrar ? _registrarFinalizacao : null,
+                  icon: _registrando
+                      ? const SizedBox(
+                          width: 18,
+                          height: 18,
+                          child: CircularProgressIndicator(strokeWidth: 2))
+                      : const Icon(Icons.save_outlined),
+                  label: const Text('Finalizar OS'),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _MeasurementTilePrep extends StatefulWidget {
+  final int index;
+  final MedidaItem item;
+  final void Function(StatusMedida status, String valor) onChanged;
+
+  const _MeasurementTilePrep({
+    required this.index,
+    required this.item,
+    required this.onChanged,
+  });
+
+  @override
+  State<_MeasurementTilePrep> createState() => _MeasurementTilePrepState();
+}
+
+class _MeasurementTilePrepState extends State<_MeasurementTilePrep> {
+  final _ctrl = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _setTextFromParent(widget.item.medicao);
+  }
+
+  @override
+  void didUpdateWidget(covariant _MeasurementTilePrep oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // só atualiza o controller quando o valor vindo do pai REALMENTE mudou
+    if (oldWidget.item.medicao != widget.item.medicao) {
+      _setTextFromParent(widget.item.medicao);
+    }
+  }
+
+  void _setTextFromParent(String? txt) {
+    final newText = (txt ?? '');
+    if (newText == _ctrl.text) return; // evita sobrescrever e mexer no cursor à toa
+    _ctrl.value = TextEditingValue(
+      text: newText,
+      // cursor no final do texto (sem selecionar tudo)
+      selection: TextSelection.collapsed(offset: newText.length),
+      composing: TextRange.empty,
+    );
+  }
+
+  @override
+  void dispose() {
+    _ctrl.dispose();
+    super.dispose();
+  }
+
+  double? _toDouble(String? s) {
+    if (s == null || s.trim().isEmpty) return null;
+    return double.tryParse(s.replaceAll(',', '.'));
+  }
+
+  StatusMedida _classifica(double? v, double? min, double? max) {
+    if (v == null) return StatusMedida.pendente;
+    if (min != null && v < min) return StatusMedida.reprovadaAbaixo;
+    if (max != null && v > max) return StatusMedida.reprovadaAcima;
+    return StatusMedida.ok;
+  }
+
+  Color _statusColor(StatusMedida st) {
+    switch (st) {
+      case StatusMedida.ok:
+        return Colors.green.shade600;
+      case StatusMedida.reprovadaAbaixo:
+        return Colors.red.shade400;
+      case StatusMedida.reprovadaAcima:
+        return Colors.red.shade400;
+      case StatusMedida.alertaAbaixo:
+      case StatusMedida.alertaAcima:
+        return Colors.amber.shade700;
+      case StatusMedida.pendente:
+        return Colors.grey;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final m = widget.item;
+
+    String subtitulo = m.faixaTexto;
+    if (subtitulo.isEmpty && (m.minimo != null || m.maximo != null)) {
+      final minStr = m.minimo?.toStringAsFixed(2) ?? '';
+      final maxStr = m.maximo?.toStringAsFixed(2) ?? '';
+      final uni = (m.unidade ?? '').isNotEmpty ? ' ${m.unidade}' : '';
+      if (minStr.isNotEmpty && maxStr.isNotEmpty) {
+        subtitulo = '$minStr – $maxStr$uni';
+      } else if (minStr.isNotEmpty) {
+        subtitulo = '≥ $minStr$uni';
+      } else if (maxStr.isNotEmpty) {
+        subtitulo = '≤ $maxStr$uni';
+      }
+    }
+
+    final vNum = _toDouble(_ctrl.text);
+    final st = _classifica(vNum, m.minimo, m.maximo);
+
+    return Card(
+      elevation: 0.5,
+      child: Padding(
+        padding: const EdgeInsets.all(12.0),
+        child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+          Row(
+            children: [
+              Container(
+                width: 10,
+                height: 10,
+                decoration:
+                BoxDecoration(color: _statusColor(st), shape: BoxShape.circle),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(m.titulo.isEmpty ? '(sem título)' : m.titulo,
+                    style: Theme.of(context).textTheme.titleMedium),
+              ),
+            ],
+          ),
+          if (subtitulo.isNotEmpty) ...[
+            const SizedBox(height: 4),
+            Text(subtitulo, style: Theme.of(context).textTheme.bodyMedium),
+          ],
+          const SizedBox(height: 10),
+          TextField(
+            controller: _ctrl,
+            keyboardType: const TextInputType.numberWithOptions(
+              decimal: true,
+              signed: false,
+            ),
+            decoration: InputDecoration(
+              labelText: 'Medição (${m.unidade ?? ''})',
+              border: const OutlineInputBorder(),
+              helperText: st == StatusMedida.ok
+                  ? 'Dentro da tolerância'
+                  : st == StatusMedida.pendente
+                  ? 'Preencha o valor para classificar'
+                  : (st == StatusMedida.reprovadaAbaixo
+                  ? 'Abaixo do mínimo'
+                  : 'Acima do máximo'),
+              helperStyle: TextStyle(color: _statusColor(st)),
+            ),
+            onChanged: (txt) {
+              final v = _toDouble(txt);
+              final novoStatus = _classifica(v, m.minimo, m.maximo);
+              widget.onChanged(novoStatus, txt);
+              setState(() {});
+            },
+          ),
+        ]),
+      ),
+    );
+  }
+}

--- a/lib/features/main_menu/main_menu_page.dart
+++ b/lib/features/main_menu/main_menu_page.dart
@@ -4,6 +4,7 @@ import 'package:admin/screens/main/main_screen.dart';
 import 'package:admin/screens/main/components/side_menu.dart';
 import '../preparacao/presentation/preparacao_page.dart';
 import '../operador/presentation/operador_page.dart';
+import '../finalizar_os/presentation/finalizar_os_page.dart';
 
 class MainMenuPage extends StatelessWidget {
   const MainMenuPage({super.key});
@@ -37,6 +38,17 @@ class MainMenuPage extends StatelessWidget {
                 );
               },
               child: const Text('Operador'),
+            ),
+            const SizedBox(height: 16),
+            FilledButton(
+              onPressed: () {
+                Navigator.of(context).push(
+                  MaterialPageRoute(
+                    builder: (_) => const FinalizarOsPage(),
+                  ),
+                );
+              },
+              child: const Text('Finalizar OS'),
             ),
             const SizedBox(height: 16),
             FilledButton(

--- a/lib/features/operador/presentation/operador_page.dart
+++ b/lib/features/operador/presentation/operador_page.dart
@@ -259,7 +259,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
     }
   }
 
-  Future<void> _encerrarOs() async {
+  Future<void> _encerrarProducao() async {
     if (_osCtrl.text.trim().isEmpty) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
@@ -269,7 +269,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
     }
 
     final body = jsonEncode({'os': _osCtrl.text.trim()});
-    final uri = Uri.parse('$kBaseUrl/operador/encerrar_os');
+    final uri = Uri.parse('$kBaseUrl/operador/encerrar_producao');
     try {
       final resp = await http
           .post(uri, headers: {'Content-Type': 'application/json'}, body: body)
@@ -277,7 +277,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
       if (!mounted) return;
       if (resp.statusCode == 200) {
         ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('OS encerrada.')),
+          const SnackBar(content: Text('Produção encerrada.')),
         );
       } else {
         ScaffoldMessenger.of(context).showSnackBar(
@@ -291,12 +291,12 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
     }
   }
 
-  Future<void> _confirmEncerrarOs() async {
+  Future<void> _confirmEncerrarProducao() async {
     final confirma = await showDialog<bool>(
       context: context,
       builder: (context) => AlertDialog(
-        title: const Text('Encerrar OS'),
-        content: const Text('Tem certeza que deseja encerrar a OS?'),
+        title: const Text('Encerrar produção'),
+        content: const Text('Tem certeza que deseja encerrar a produção?'),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(context).pop(false),
@@ -310,7 +310,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
       ),
     );
     if (confirma == true) {
-      await _encerrarOs();
+      await _encerrarProducao();
     }
   }
 
@@ -493,7 +493,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                 child: PopupMenuButton<String>(
                   onSelected: (value) {
                     if (value == 'fim') _fimJornada();
-                    if (value == 'encerrar') _confirmEncerrarOs();
+                    if (value == 'encerrar') _confirmEncerrarProducao();
                   },
                   itemBuilder: (context) => const [
                     PopupMenuItem(
@@ -502,7 +502,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                     ),
                     PopupMenuItem(
                       value: 'encerrar',
-                      child: Text('Encerrar OS'),
+                      child: Text('Encerrar produção'),
                     ),
                   ],
                 ),

--- a/lib/features/preparacao/data/repository_provider.dart
+++ b/lib/features/preparacao/data/repository_provider.dart
@@ -20,3 +20,12 @@ final preparadorRepositoryProvider = Provider<MedidasRepository>((ref) {
     resultadoPath: '/preparador/resultado', // já existe no backend (retorna ok)
   );
 });
+
+/// Provider para a Finalização da OS pelo preparador
+final finalizadorRepositoryProvider = Provider<MedidasRepository>((ref) {
+  return MedidasRepositoryFactory.create(
+    useApi: true,
+    medidasPath: '/preparador/medidas',
+    resultadoPath: '/preparador/finalizar_os',
+  );
+});

--- a/lib/screens/main/components/side_menu.dart
+++ b/lib/screens/main/components/side_menu.dart
@@ -4,12 +4,13 @@ import 'package:flutter_svg/flutter_svg.dart';
 
 import 'package:admin/features/preparacao/presentation/preparacao_page.dart';
 import 'package:admin/features/operador/presentation/operador_page.dart';
+import 'package:admin/features/finalizar_os/presentation/finalizar_os_page.dart';
 import 'package:admin/features/cadastro_itens/presentation/cadastro_itens_page.dart';
 import 'package:admin/features/cadastro_preparadores/presentation/cadastro_preparadores_page.dart';
 import 'package:admin/features/export_relatorios/presentation/export_relatorios_page.dart';
 import 'package:admin/screens/main/main_screen.dart';
 
-enum SideMenuSection { mainMenu, dashboard, preparador, operador }
+enum SideMenuSection { mainMenu, dashboard, preparador, operador, finalizar }
 
 class SideMenu extends StatelessWidget {
   const SideMenu({super.key, required this.current});
@@ -68,22 +69,46 @@ class SideMenu extends StatelessWidget {
         ]);
         break;
       case SideMenuSection.preparador:
-        items.add(
+        items.addAll([
           DrawerListTile(
             title: 'Operador',
             svgSrc: 'assets/icons/menu_profile.svg',
             press: () => _navigate(context, const OperadorPage()),
           ),
-        );
+          DrawerListTile(
+            title: 'Finalizar OS',
+            svgSrc: 'assets/icons/menu_doc.svg',
+            press: () => _navigate(context, const FinalizarOsPage()),
+          ),
+        ]);
         break;
       case SideMenuSection.operador:
-        items.add(
+        items.addAll([
           DrawerListTile(
             title: 'Preparador',
             svgSrc: 'assets/icons/menu_setting.svg',
             press: () => _navigate(context, const PreparacaoPage()),
           ),
-        );
+          DrawerListTile(
+            title: 'Finalizar OS',
+            svgSrc: 'assets/icons/menu_doc.svg',
+            press: () => _navigate(context, const FinalizarOsPage()),
+          ),
+        ]);
+        break;
+      case SideMenuSection.finalizar:
+        items.addAll([
+          DrawerListTile(
+            title: 'Preparador',
+            svgSrc: 'assets/icons/menu_setting.svg',
+            press: () => _navigate(context, const PreparacaoPage()),
+          ),
+          DrawerListTile(
+            title: 'Operador',
+            svgSrc: 'assets/icons/menu_profile.svg',
+            press: () => _navigate(context, const OperadorPage()),
+          ),
+        ]);
         break;
       case SideMenuSection.mainMenu:
       default:
@@ -97,6 +122,11 @@ class SideMenu extends StatelessWidget {
             title: 'Operador',
             svgSrc: 'assets/icons/menu_profile.svg',
             press: () => _navigate(context, const OperadorPage()),
+          ),
+          DrawerListTile(
+            title: 'Finalizar OS',
+            svgSrc: 'assets/icons/menu_doc.svg',
+            press: () => _navigate(context, const FinalizarOsPage()),
           ),
           DrawerListTile(
             title: 'Supervisão',


### PR DESCRIPTION
## Summary
- duplicate preparador page into new Finalizar OS screen
- allow operator to end production before preparador finalizes OS
- wire side menu and main menu to new finalization flow and backend routes

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ebeefc68833180ee24070e63c825