### PR TITLE
fix: remove obsolete alerta status

### DIFF
--- a/lib/features/finalizar_os/presentation/finalizar_os_page.dart
+++ b/lib/features/finalizar_os/presentation/finalizar_os_page.dart
@@ -145,7 +145,6 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
   String statusToString(StatusMedida st) {
     switch (st) {
       case StatusMedida.ok:
-      case StatusMedida.alerta:
         return 'aprovado';
       case StatusMedida.reprovadaAbaixo:
       case StatusMedida.reprovadaAcima:

--- a/lib/features/preparacao/presentation/preparacao_page.dart
+++ b/lib/features/preparacao/presentation/preparacao_page.dart
@@ -145,7 +145,6 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
   String statusToString(StatusMedida st) {
     switch (st) {
       case StatusMedida.ok:
-      case StatusMedida.alerta:
         return 'aprovado';
       case StatusMedida.reprovadaAbaixo:
       case StatusMedida.reprovadaAcima:


### PR DESCRIPTION
## Summary
- remove outdated StatusMedida.alerta cases from prep and finalization pages

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1edfd9acc833187b395788b157259