### PR TITLE
fix: correct preparador rejected status mapping

### DIFF
--- a/lib/features/finalizar_os/presentation/finalizar_os_page.dart
+++ b/lib/features/finalizar_os/presentation/finalizar_os_page.dart
@@ -147,8 +147,8 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
       case StatusMedida.ok:
         return 'aprovado';
       case StatusMedida.reprovadaAbaixo:
+        return 'reprovada_abaixo';
       case StatusMedida.reprovadaAcima:
-
         return 'reprovada_acima';
       case StatusMedida.alertaAbaixo:
         return 'alerta_abaixo';

--- a/lib/features/preparacao/presentation/preparacao_page.dart
+++ b/lib/features/preparacao/presentation/preparacao_page.dart
@@ -147,8 +147,8 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
       case StatusMedida.ok:
         return 'aprovado';
       case StatusMedida.reprovadaAbaixo:
+        return 'reprovada_abaixo';
       case StatusMedida.reprovadaAcima:
-
         return 'reprovada_acima';
       case StatusMedida.alertaAbaixo:
         return 'alerta_abaixo';


### PR DESCRIPTION
## Summary
- ensure reprovada below measurements use `reprovada_abaixo` in preparador and finalization pages

## Testing
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f1deb57083318f471d1ff421d32a