### PR TITLE
fix: record preparador non-liberated status

### DIFF
--- a/app_db.py
+++ b/app_db.py
@@ -926,7 +926,7 @@ def resultado_preparador():
                 status_geral = (
                     "liberada"
                     if all_ok
-                    else ("reprovada" if has_reprov else "pendente")
+                    else ("nao_liberada" if has_reprov else "pendente")
                 )
 
 
@@ -1078,7 +1078,7 @@ def preparador_finalizar_os():
                 status_geral = (
                     "finalizada"
                     if all_ok
-                    else ("reprovada" if has_reprov else "pendente")
+                    else ("nao_liberada" if has_reprov else "pendente")
                 )
 
                 cur.execute(

--- a/lib/features/finalizar_os/presentation/finalizar_os_page.dart
+++ b/lib/features/finalizar_os/presentation/finalizar_os_page.dart
@@ -147,8 +147,8 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
       case StatusMedida.ok:
         return 'aprovado';
       case StatusMedida.reprovadaAbaixo:
+        return 'reprovada_abaixo';
       case StatusMedida.reprovadaAcima:
-
         return 'reprovada_acima';
       case StatusMedida.alertaAbaixo:
         return 'alerta_abaixo';

--- a/lib/features/preparacao/presentation/preparacao_page.dart
+++ b/lib/features/preparacao/presentation/preparacao_page.dart
@@ -147,8 +147,8 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
       case StatusMedida.ok:
         return 'aprovado';
       case StatusMedida.reprovadaAbaixo:
+        return 'reprovada_abaixo';
       case StatusMedida.reprovadaAcima:
-
         return 'reprovada_acima';
       case StatusMedida.alertaAbaixo:
         return 'alerta_abaixo';


### PR DESCRIPTION
## Summary
- store non-liberated status when preparer measurements fail
- propagate same non-liberated status during OS finalization

## Testing
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f1deb57083318f471d1ff421d32a