### PR TITLE
feat: redesign main menu with cards

### DIFF
--- a/lib/features/main_menu/main_menu_page.dart
+++ b/lib/features/main_menu/main_menu_page.dart
@@ -11,57 +11,70 @@ class MainMenuPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    void open(BuildContext context, Widget page) {
+      Navigator.of(context).push(
+        MaterialPageRoute(builder: (_) => page),
+      );
+    }
+
     return Scaffold(
       appBar: AppBar(title: const Text('Menu Principal')),
       drawer: const SideMenu(current: SideMenuSection.mainMenu),
-      body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            FilledButton(
-              onPressed: () {
-                Navigator.of(context).push(
-                  MaterialPageRoute(
-                    builder: (_) => const PreparacaoPage(),
-                  ),
-                );
-              },
-              child: const Text('Preparador'),
+      body: Column(
+        children: [
+          const SizedBox(height: 32),
+          Image.asset('assets/images/logo.png', height: 120),
+          const SizedBox(height: 32),
+          Expanded(
+            child: GridView.count(
+              crossAxisCount: 2,
+              crossAxisSpacing: 16,
+              mainAxisSpacing: 16,
+              padding: const EdgeInsets.all(16),
+              children: [
+                _MenuCard(
+                  title: 'Preparador',
+                  onTap: () => open(context, const PreparacaoPage()),
+                ),
+                _MenuCard(
+                  title: 'Operador',
+                  onTap: () => open(context, const OperadorPage()),
+                ),
+                _MenuCard(
+                  title: 'Finalizar OS',
+                  onTap: () => open(context, const FinalizarOsPage()),
+                ),
+                _MenuCard(
+                  title: 'Supervisão',
+                  onTap: () => open(context, MainScreen()),
+                ),
+              ],
             ),
-            const SizedBox(height: 16),
-            FilledButton(
-              onPressed: () {
-                Navigator.of(context).push(
-                  MaterialPageRoute(
-                    builder: (_) => const OperadorPage(),
-                  ),
-                );
-              },
-              child: const Text('Operador'),
-            ),
-            const SizedBox(height: 16),
-            FilledButton(
-              onPressed: () {
-                Navigator.of(context).push(
-                  MaterialPageRoute(
-                    builder: (_) => const FinalizarOsPage(),
-                  ),
-                );
-              },
-              child: const Text('Finalizar OS'),
-            ),
-            const SizedBox(height: 16),
-            FilledButton(
-              onPressed: () {
-                Navigator.of(context).push(
-                  MaterialPageRoute(
-                    builder: (_) => MainScreen(),
-                  ),
-                );
-              },
-              child: const Text('Supervisão'),
-            ),
-          ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MenuCard extends StatelessWidget {
+  const _MenuCard({required this.title, required this.onTap});
+
+  final String title;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      elevation: 4,
+      child: InkWell(
+        onTap: onTap,
+        child: Center(
+          child: Text(
+            title,
+            style: Theme.of(context).textTheme.titleMedium,
+            textAlign: TextAlign.center,
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- redesign main menu with card-based options
- display application logo on main menu screen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b573d7494c8331adc1e76b368ed1c7