### PR TITLE
Evita liberação duplicada de OS

### DIFF
--- a/app_db.py
+++ b/app_db.py
@@ -861,6 +861,30 @@ def resultado_preparador():
                 )
 
             with c.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT partnumber, operacao, status_geral
+                    FROM preparador_liberacao
+                    WHERE os=%s
+                      AND status_geral IN ('liberada','liberado','ok','aprovada','aprovado')
+                    ORDER BY id DESC LIMIT 1
+                    """,
+                    (os_num,),
+                )
+                row_os = cur.fetchone()
+                if row_os:
+                    return (
+                        jsonify(
+                            {
+                                "code": "ja_liberada",
+                                "error": "OS já liberada pelo preparador. Novos registros não são permitidos.",
+                                "fonte": "preparador_liberacao",
+                                "detalhe": f"status_geral={row_os.get('status_geral')}",
+                            }
+                        ),
+                        409,
+                    )
+
                 # garante OS na mestre (por causa de FKs futuras)
                 cur.execute(
                     "INSERT IGNORE INTO ordem_servico (os) VALUES (%s)", (os_num,)


### PR DESCRIPTION
## Summary
- impede nova liberação do preparador quando a OS já foi liberada

## Testing
- `python -m py_compile app_db.py`

------
https://chatgpt.com/codex/tasks/task_e_68b5781dee088331bdad9e3f6bec915f