### PR TITLE
Add machine selection and registration

### DIFF
--- a/lib/controllers/machine_controller.dart
+++ b/lib/controllers/machine_controller.dart
@@ -1,0 +1,19 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Controller that stores the list of available machine codes.
+class MachineListController extends StateNotifier<List<String>> {
+  MachineListController() : super(const []);
+
+  /// Adds a new machine code if it is not empty and not already present.
+  void add(String code) {
+    final trimmed = code.trim();
+    if (trimmed.isEmpty) return;
+    if (state.contains(trimmed)) return;
+    state = [...state, trimmed];
+  }
+}
+
+/// Provider exposing the list of machine codes to the application.
+final machineListProvider =
+    StateNotifierProvider<MachineListController, List<String>>(
+        (ref) => MachineListController());

--- a/lib/features/cadastro_maquinas/presentation/cadastro_maquinas_page.dart
+++ b/lib/features/cadastro_maquinas/presentation/cadastro_maquinas_page.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:admin/controllers/machine_controller.dart';
+import 'package:admin/screens/main/components/side_menu.dart';
+
+class CadastroMaquinasPage extends ConsumerWidget {
+  CadastroMaquinasPage({super.key});
+
+  final _codeCtrl = TextEditingController();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final maquinas = ref.watch(machineListProvider);
+    return Scaffold(
+      appBar: AppBar(title: const Text('Cadastro de Máquinas')),
+      drawer: const SideMenu(current: SideMenuSection.dashboard),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: _codeCtrl,
+                    decoration: const InputDecoration(
+                      labelText: 'Código da máquina',
+                      border: OutlineInputBorder(),
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                FilledButton(
+                  onPressed: () {
+                    ref
+                        .read(machineListProvider.notifier)
+                        .add(_codeCtrl.text);
+                    _codeCtrl.clear();
+                  },
+                  child: const Text('Adicionar'),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            Expanded(
+              child: ListView.builder(
+                itemCount: maquinas.length,
+                itemBuilder: (context, index) {
+                  final code = maquinas[index];
+                  return ListTile(title: Text(code));
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/finalizar_os/presentation/finalizar_os_page.dart
+++ b/lib/features/finalizar_os/presentation/finalizar_os_page.dart
@@ -9,6 +9,7 @@ import 'package:http/http.dart' as http;
 
 import 'package:admin/features/preparacao/data/models.dart';
 import 'package:admin/features/preparacao/data/repository_provider.dart';
+import 'package:admin/controllers/machine_controller.dart';
 import 'package:admin/screens/main/components/side_menu.dart';
 import 'package:admin/utils/string_utils.dart';
 
@@ -114,6 +115,7 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
   final _osCtrl = TextEditingController();   // <<< OS
   final _partCtrl = TextEditingController();
   final _opCtrl = TextEditingController();
+  String? _maquina;
 
   bool _registrando = false;
   bool _osFinalizada = false;
@@ -212,6 +214,7 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
       'os': _osCtrl.text.trim(),
       'partnumber': normalizeCode(_partCtrl.text),
       'operacao': normalizeCode(_opCtrl.text),
+      'maquina': _maquina,
       'itens': itens,
     });
 
@@ -266,6 +269,7 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
   @override
   Widget build(BuildContext context) {
     final medidasAsync = ref.watch(medidasFinalizadorControllerProvider);
+    final maquinas = ref.watch(machineListProvider);
     final medidas = medidasAsync.value ?? [];
 
     // Pode registrar quando: RE e OS preenchidos + todas as medições preenchidas
@@ -344,6 +348,25 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
                           ),
                         ),
                       ],
+                    ),
+
+                    const SizedBox(height: 12),
+
+                    DropdownButtonFormField<String>(
+                      value: _maquina,
+                      decoration: const InputDecoration(
+                        labelText: 'Máquina',
+                        border: OutlineInputBorder(),
+                      ),
+                      items: [
+                        for (final m in maquinas)
+                          DropdownMenuItem(value: m, child: Text(m))
+                      ],
+                      onChanged: (v) {
+                        setState(() => _maquina = v);
+                      },
+                      validator: (v) =>
+                          (v == null || v.isEmpty) ? 'Obrigatório' : null,
                     ),
 
                     const SizedBox(height: 12),

--- a/lib/features/operador/presentation/operador_page.dart
+++ b/lib/features/operador/presentation/operador_page.dart
@@ -10,6 +10,7 @@ import 'package:http/http.dart' as http;
 
 import '../../preparacao/data/models.dart';
 import '../data/repository_provider.dart';
+import 'package:admin/controllers/machine_controller.dart';
 import 'package:admin/screens/main/components/side_menu.dart';
 import 'package:admin/utils/string_utils.dart';
 
@@ -98,6 +99,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
   final _osCtrl = TextEditingController(); // <<<< O.S.
   final _partCtrl = TextEditingController();
   final _opCtrl = TextEditingController();
+  String? _maquina;
 
   bool _registrando = false;
 
@@ -184,6 +186,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
       'os': _osCtrl.text.trim(),
       'partnumber': normalizeCode(_partCtrl.text),
       'operacao': normalizeCode(_opCtrl.text),
+      'maquina': _maquina,
       // >>> chave correta no backend:
       'itens': itens,
     });
@@ -235,6 +238,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
       'os': _osCtrl.text.trim(),
       'partnumber': normalizeCode(_partCtrl.text),
       'operacao': normalizeCode(_opCtrl.text),
+      'maquina': _maquina,
     });
 
     final uri = Uri.parse('$kBaseUrl/operador/fim_jornada');
@@ -317,6 +321,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
   @override
   Widget build(BuildContext context) {
     final medidasAsync = ref.watch(medidasOperadorControllerProvider);
+    final maquinas = ref.watch(machineListProvider);
     final medidas = medidasAsync.value ?? [];
     final reOk = _reCtrl.text.trim().isNotEmpty;
     final osOk = _osCtrl.text.trim().isNotEmpty;
@@ -394,6 +399,25 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                           ),
                         ),
                       ],
+                    ),
+
+                    const SizedBox(height: 12),
+
+                    DropdownButtonFormField<String>(
+                      value: _maquina,
+                      decoration: const InputDecoration(
+                        labelText: 'Máquina',
+                        border: OutlineInputBorder(),
+                      ),
+                      items: [
+                        for (final m in maquinas)
+                          DropdownMenuItem(value: m, child: Text(m))
+                      ],
+                      onChanged: (v) {
+                        setState(() => _maquina = v);
+                      },
+                      validator: (v) =>
+                          (v == null || v.isEmpty) ? 'Obrigatório' : null,
                     ),
 
                     const SizedBox(height: 12),

--- a/lib/features/preparacao/presentation/preparacao_page.dart
+++ b/lib/features/preparacao/presentation/preparacao_page.dart
@@ -9,6 +9,7 @@ import 'package:http/http.dart' as http;
 
 import 'package:admin/features/preparacao/data/models.dart';
 import 'package:admin/features/operador/data/repository_provider.dart';
+import 'package:admin/controllers/machine_controller.dart';
 import 'package:admin/screens/main/components/side_menu.dart';
 import 'package:admin/utils/string_utils.dart';
 
@@ -114,6 +115,7 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
   final _osCtrl = TextEditingController();   // <<< OS
   final _partCtrl = TextEditingController();
   final _opCtrl = TextEditingController();
+  String? _maquina;
 
   bool _registrando = false;
   bool _osLiberada = false;
@@ -212,6 +214,7 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
       'os': _osCtrl.text.trim(),
       'partnumber': normalizeCode(_partCtrl.text),
       'operacao': normalizeCode(_opCtrl.text),
+      'maquina': _maquina,
       'itens': itens,
     });
 
@@ -273,6 +276,7 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
   @override
   Widget build(BuildContext context) {
     final medidasAsync = ref.watch(medidasPreparadorControllerProvider);
+    final maquinas = ref.watch(machineListProvider);
     final medidas = medidasAsync.value ?? [];
 
     // Pode registrar quando: RE e OS preenchidos + todas as medições preenchidas
@@ -349,8 +353,27 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
                               return null;
                             },
                           ),
-                        ),
+                    ),
+                  ],
+                ),
+
+                    const SizedBox(height: 12),
+
+                    DropdownButtonFormField<String>(
+                      value: _maquina,
+                      decoration: const InputDecoration(
+                        labelText: 'Máquina',
+                        border: OutlineInputBorder(),
+                      ),
+                      items: [
+                        for (final m in maquinas)
+                          DropdownMenuItem(value: m, child: Text(m))
                       ],
+                      onChanged: (v) {
+                        setState(() => _maquina = v);
+                      },
+                      validator: (v) =>
+                          (v == null || v.isEmpty) ? 'Obrigatório' : null,
                     ),
 
                     const SizedBox(height: 12),

--- a/lib/screens/main/components/side_menu.dart
+++ b/lib/screens/main/components/side_menu.dart
@@ -7,6 +7,7 @@ import 'package:admin/features/operador/presentation/operador_page.dart';
 import 'package:admin/features/finalizar_os/presentation/finalizar_os_page.dart';
 import 'package:admin/features/cadastro_itens/presentation/cadastro_itens_page.dart';
 import 'package:admin/features/cadastro_preparadores/presentation/cadastro_preparadores_page.dart';
+import 'package:admin/features/cadastro_maquinas/presentation/cadastro_maquinas_page.dart';
 import 'package:admin/features/export_relatorios/presentation/export_relatorios_page.dart';
 import 'package:admin/screens/main/main_screen.dart';
 
@@ -65,6 +66,11 @@ class SideMenu extends StatelessWidget {
             title: 'Cadastro de Preparadores',
             svgSrc: 'assets/icons/menu_profile.svg',
             press: () => _navigate(context, const CadastroPreparadoresPage()),
+          ),
+          DrawerListTile(
+            title: 'Cadastro de Máquinas',
+            svgSrc: 'assets/icons/menu_setting.svg',
+            press: () => _navigate(context, CadastroMaquinasPage()),
           ),
         ]);
         break;


### PR DESCRIPTION
## Summary
- enable machine code registration screen
- allow preparador, finalization and operator pages to select a machine
- expose machine management in supervision menu

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b57a21ca48833193daaa54f54f14e6