### PR TITLE
Add machine service and backend for async machine management

### DIFF
--- a/app_db.py
+++ b/app_db.py
@@ -248,6 +248,14 @@ def _ensure_schema():
             )
             cur.execute(
                 """
+                  CREATE TABLE IF NOT EXISTS maquinas (
+                    codigo VARCHAR(64) NOT NULL PRIMARY KEY,
+                    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+                  ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+                """
+            )
+            cur.execute(
+                """
                   CREATE TABLE IF NOT EXISTS supervisao_log (
                     id BIGINT AUTO_INCREMENT PRIMARY KEY,
                     tabela VARCHAR(64) NOT NULL,
@@ -1556,6 +1564,36 @@ def exportar_relatorio_excel():
         )
     except Exception as e:
         return jsonify({"error": f"Falha ao exportar relatório: {e}"}), 500
+
+
+@app.route("/machines", methods=["GET", "POST"])
+def machines():
+    if request.method == "GET":
+        with _conn_db(DB_NAME) as c:
+            with c.cursor() as cur:
+                cur.execute("SELECT codigo FROM maquinas ORDER BY codigo")
+                rows = [r["codigo"] for r in cur.fetchall()]
+        return jsonify(rows)
+
+    data = request.get_json(silent=True) or {}
+    codigo = (data.get("codigo") or "").strip()
+    if not codigo:
+        return jsonify({"error": "campo 'codigo' obrigatório"}), 400
+
+    with _conn_db(DB_NAME) as c:
+        with c.cursor() as cur:
+            cur.execute(
+                "SELECT 1 FROM for07_norm WHERE tipo_maquina=%s LIMIT 1",
+                (codigo,),
+            )
+            if not cur.fetchone():
+                return jsonify({"error": "máquina não encontrada"}), 400
+            cur.execute(
+                "INSERT INTO maquinas (codigo) VALUES (%s) ON DUPLICATE KEY UPDATE codigo=codigo",
+                (codigo,),
+            )
+        c.commit()
+    return jsonify({"status": "ok", "codigo": codigo})
 
 
 @app.route("/relatorios/sql")

--- a/lib/controllers/machine_controller.dart
+++ b/lib/controllers/machine_controller.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/foundation.dart';
+
+import '../services/machine_service.dart';
+
+class MachineController extends ChangeNotifier {
+  MachineController({MachineService? service})
+      : _service = service ?? MachineService();
+
+  final MachineService _service;
+
+  final List<String> maquinas = [];
+  bool isLoading = false;
+  bool isSaving = false;
+  String? error;
+
+  Future<void> fetchMaquinas() async {
+    try {
+      isLoading = true;
+      notifyListeners();
+      final data = await _service.fetchMaquinas();
+      maquinas
+        ..clear()
+        ..addAll(data);
+      error = null;
+    } catch (e) {
+      error = e.toString();
+    } finally {
+      isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> addMaquina(String codigo) async {
+    try {
+      isSaving = true;
+      notifyListeners();
+      final ok = await _service.addMaquina(codigo);
+      if (ok) {
+        maquinas.add(codigo);
+        error = null;
+      } else {
+        error = 'Falha ao adicionar';
+      }
+    } catch (e) {
+      error = e.toString();
+    } finally {
+      isSaving = false;
+      notifyListeners();
+    }
+  }
+}

--- a/lib/features/cadastro_maquinas/presentation/cadastro_maquinas_page.dart
+++ b/lib/features/cadastro_maquinas/presentation/cadastro_maquinas_page.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+
+import '../../../controllers/machine_controller.dart';
+
+class CadastroMaquinasPage extends StatefulWidget {
+  const CadastroMaquinasPage({super.key, MachineController? controller})
+      : controller = controller ?? MachineController();
+
+  final MachineController controller;
+
+  @override
+  State<CadastroMaquinasPage> createState() => _CadastroMaquinasPageState();
+}
+
+class _CadastroMaquinasPageState extends State<CadastroMaquinasPage> {
+  final _codigoCtrl = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    widget.controller.addListener(_onChanged);
+    widget.controller.fetchMaquinas();
+  }
+
+  void _onChanged() {
+    if (!mounted) return;
+    final err = widget.controller.error;
+    if (err != null) {
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text(err)));
+    }
+    setState(() {});
+  }
+
+  @override
+  void dispose() {
+    widget.controller.removeListener(_onChanged);
+    _codigoCtrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ctrl = widget.controller;
+    return Scaffold(
+      appBar: AppBar(title: const Text('Cadastro de máquinas')),
+      body: ctrl.isLoading
+          ? const Center(child: CircularProgressIndicator())
+          : Column(
+              children: [
+                Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: TextField(
+                          controller: _codigoCtrl,
+                          decoration:
+                              const InputDecoration(labelText: 'Código da máquina'),
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      ctrl.isSaving
+                          ? const SizedBox(
+                              height: 24,
+                              width: 24,
+                              child: CircularProgressIndicator(),
+                            )
+                          : FilledButton(
+                              onPressed: () async {
+                                final codigo = _codigoCtrl.text.trim();
+                                if (codigo.isEmpty) return;
+                                await ctrl.addMaquina(codigo);
+                                if (ctrl.error == null) _codigoCtrl.clear();
+                              },
+                              child: const Text('Adicionar'),
+                            ),
+                    ],
+                  ),
+                ),
+                Expanded(
+                  child: ListView.builder(
+                    itemCount: ctrl.maquinas.length,
+                    itemBuilder: (context, index) {
+                      final m = ctrl.maquinas[index];
+                      return ListTile(title: Text(m));
+                    },
+                  ),
+                ),
+              ],
+            ),
+    );
+  }
+}

--- a/lib/services/machine_service.dart
+++ b/lib/services/machine_service.dart
@@ -1,0 +1,31 @@
+import 'dart:convert';
+
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:http/http.dart' as http;
+
+class MachineService {
+  MachineService({http.Client? client, String? baseUrl})
+      : _client = client ?? http.Client(),
+        _baseUrl = baseUrl ?? dotenv.env['API_BASE_URL'] ?? 'http://localhost:5000';
+
+  final http.Client _client;
+  final String _baseUrl;
+
+  Future<List<String>> fetchMaquinas() async {
+    final uri = Uri.parse('$_baseUrl/machines');
+    final resp = await _client.get(uri);
+    if (resp.statusCode == 200) {
+      final data = jsonDecode(resp.body) as List;
+      return data.map((e) => e.toString()).toList();
+    }
+    throw Exception('Falha ao carregar máquinas');
+  }
+
+  Future<bool> addMaquina(String codigo) async {
+    final uri = Uri.parse('$_baseUrl/machines');
+    final resp = await _client.post(uri,
+        headers: {'Content-Type': 'application/json'},
+        body: jsonEncode({'codigo': codigo}));
+    return resp.statusCode == 200;
+  }
+}

--- a/test/machine_integration_test.dart
+++ b/test/machine_integration_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:admin/controllers/machine_controller.dart';
+import 'package:admin/features/cadastro_maquinas/presentation/cadastro_maquinas_page.dart';
+import 'package:admin/services/machine_service.dart';
+
+class _FakeMachineService implements MachineService {
+  _FakeMachineService(this._items);
+
+  final List<String> _items;
+  final List<String> added = [];
+
+  @override
+  Future<List<String>> fetchMaquinas() async {
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+    return List<String>.from(_items);
+  }
+
+  @override
+  Future<bool> addMaquina(String codigo) async {
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+    added.add(codigo);
+    _items.add(codigo);
+    return true;
+  }
+}
+
+void main() {
+  testWidgets('loads initial list and adds new machine', (tester) async {
+    final service = _FakeMachineService(['MX1']);
+    final controller = MachineController(service: service);
+
+    await tester.pumpWidget(MaterialApp(
+      home: CadastroMaquinasPage(controller: controller),
+    ));
+    await tester.pump(const Duration(milliseconds: 20));
+
+    expect(find.text('MX1'), findsOneWidget);
+
+    await tester.enterText(find.byType(TextField), 'MX2');
+    await tester.tap(find.byType(FilledButton));
+    await tester.pump(const Duration(milliseconds: 20));
+
+    expect(find.text('MX2'), findsOneWidget);
+    expect(service.added, ['MX2']);
+  });
+}


### PR DESCRIPTION
## Summary
- create MachineService with fetchMaquinas and addMaquina API calls
- add MachineController to load and insert machines using the service
- build CadastroMaquinasPage to display list with async progress and errors
- add integration test to ensure list loading and updates via service
- support machine registration in Python backend with new table and `/machines` endpoint

## Testing
- `python -m py_compile app_db.py`
- `flutter test` *(fails: bash: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68b57d63dc6083319b3797b6cbffe6cc