### PR TITLE
Add machine selection across OS workflows

### DIFF
--- a/app_db.py
+++ b/app_db.py
@@ -108,6 +108,7 @@ def _ensure_schema():
                     partnumber VARCHAR(128) NOT NULL,
                     operacao VARCHAR(64) NOT NULL,
                     re_operador VARCHAR(64) NOT NULL,
+                    maquina VARCHAR(128) DEFAULT NULL,
                     observacao TEXT NULL,
                     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                     KEY idx_oa_os (os),
@@ -173,6 +174,7 @@ def _ensure_schema():
                   partnumber VARCHAR(128) NOT NULL,
                   operacao VARCHAR(64) NOT NULL,
                   re_preparador VARCHAR(64) NOT NULL,
+                  maquina VARCHAR(128) DEFAULT NULL,
                   created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
                   KEY idx_os (os),
                   KEY idx_part_op (partnumber, operacao)
@@ -212,6 +214,7 @@ def _ensure_schema():
                   partnumber VARCHAR(128) NOT NULL,
                   operacao VARCHAR(64) NOT NULL,
                   re_preparador VARCHAR(64) NOT NULL,
+                  maquina VARCHAR(128) DEFAULT NULL,
                   status_geral VARCHAR(32) DEFAULT NULL,
                   observacao TEXT DEFAULT NULL,
                   created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -265,6 +268,15 @@ def _ensure_schema():
                     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
                   ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
                   """
+            )
+            cur.execute(
+                "ALTER TABLE preparador_liberacao ADD COLUMN IF NOT EXISTS maquina VARCHAR(128) DEFAULT NULL"
+            )
+            cur.execute(
+                "ALTER TABLE operador_amostragem ADD COLUMN IF NOT EXISTS maquina VARCHAR(128) DEFAULT NULL"
+            )
+            cur.execute(
+                "ALTER TABLE preparador_registro ADD COLUMN IF NOT EXISTS maquina VARCHAR(128) DEFAULT NULL"
             )
         c.commit()
 
@@ -534,7 +546,9 @@ def _medidas_operador_db(part: str, op: str):
 
 
 # ========= HELPERS DE NEGÓCIO =========
-def _maquina_liberada(conn, os_num: str, part: str, op: str) -> Tuple[bool, str, str]:
+def _maquina_liberada(
+    conn, os_num: str, part: str, op: str, maquina: str
+) -> Tuple[bool, str, str]:
     """
     Retorna (liberada, fonte, detalhe).
     fonte: 'preparador_liberacao' | 'preparador_registro' | ''
@@ -542,7 +556,8 @@ def _maquina_liberada(conn, os_num: str, part: str, op: str) -> Tuple[bool, str,
     os_num = _norm(os_num)
     part = _norm_part(part)
     op = _norm_op(op)
-    if not (os_num and part and op):
+    maquina = _norm(maquina)
+    if not (os_num and part and op and maquina):
         return (False, "", "Parâmetros insuficientes para validação.")
 
     with conn.cursor() as cur:
@@ -560,10 +575,11 @@ def _maquina_liberada(conn, os_num: str, part: str, op: str) -> Tuple[bool, str,
 
               AND TRIM(LEADING '0' FROM TRIM(partnumber))=%s
               AND TRIM(LEADING '0' FROM TRIM(operacao))=%s
+              AND maquina=%s
 
             ORDER BY id DESC LIMIT 1
             """,
-            (os_num, part, op),
+            (os_num, part, op, maquina),
         )
         row = cur.fetchone()
         if row:
@@ -581,10 +597,11 @@ def _maquina_liberada(conn, os_num: str, part: str, op: str) -> Tuple[bool, str,
             WHERE os=%s
               AND TRIM(LEADING '0' FROM TRIM(partnumber))=%s
               AND TRIM(LEADING '0' FROM TRIM(operacao))=%s
+              AND maquina=%s
 
             ORDER BY created_at DESC, id DESC LIMIT 1
             """,
-            (os_num, part, op),
+            (os_num, part, op, maquina),
         )
         reg = cur.fetchone()
         if not reg:
@@ -835,13 +852,14 @@ def resultado_preparador():
     re_prep = _norm(payload.get("re"))
     part = _norm_part(payload.get("partnumber"))
     op = _norm_op(payload.get("operacao"))
+    maquina = _norm(payload.get("maquina"))
     itens = payload.get("itens", [])
 
-    if not os_num or not re_prep or not part or not op:
+    if not os_num or not re_prep or not part or not op or not maquina:
         return (
             jsonify(
                 {
-                    "error": "Campos 'os', 're', 'partnumber' e 'operacao' são obrigatórios"
+                    "error": "Campos 'os', 're', 'partnumber', 'operacao' e 'maquina' são obrigatórios"
                 }
             ),
             400,
@@ -854,7 +872,12 @@ def resultado_preparador():
 
     try:
         with _conn_db(DB_NAME) as c:
-            ok, fonte, detalhe = _maquina_liberada(c, os_num, part, op)
+            with c.cursor() as cur:
+                cur.execute("SELECT 1 FROM maquinas WHERE codigo=%s", (maquina,))
+                if not cur.fetchone():
+                    return jsonify({"error": "máquina não cadastrada"}), 400
+
+            ok, fonte, detalhe = _maquina_liberada(c, os_num, part, op, maquina)
             if ok:
                 return (
                     jsonify(
@@ -874,10 +897,13 @@ def resultado_preparador():
                     SELECT partnumber, operacao, status_geral
                     FROM preparador_liberacao
                     WHERE os=%s
+                      AND TRIM(LEADING '0' FROM TRIM(partnumber))=%s
+                      AND TRIM(LEADING '0' FROM TRIM(operacao))=%s
+                      AND maquina=%s
                       AND status_geral IN ('liberada','liberado','ok','aprovada','aprovado')
                     ORDER BY id DESC LIMIT 1
                     """,
-                    (os_num,),
+                    (os_num, part, op, maquina),
                 )
                 row_os = cur.fetchone()
                 if row_os:
@@ -901,10 +927,10 @@ def resultado_preparador():
                 # cabeçalho
                 cur.execute(
                     """
-                    INSERT INTO preparador_registro (os, partnumber, operacao, re_preparador)
-                    VALUES (%s, %s, %s, %s)
+                    INSERT INTO preparador_registro (os, partnumber, operacao, re_preparador, maquina)
+                    VALUES (%s, %s, %s, %s, %s)
                     """,
-                    (os_num, part, op, re_prep),
+                    (os_num, part, op, re_prep, maquina),
                 )
                 registro_id = cur.lastrowid
 
@@ -971,28 +997,38 @@ def resultado_preparador():
 
                       AND TRIM(LEADING '0' FROM TRIM(partnumber))=%s
                       AND TRIM(LEADING '0' FROM TRIM(operacao))=%s
-
+                      AND maquina=%s
                     ORDER BY id DESC LIMIT 1
                     """,
-                    (os_num, part, op),
+                    (os_num, part, op, maquina),
                 )
                 row = cur.fetchone()
                 if row:
                     cur.execute(
-                        "UPDATE preparador_liberacao SET re_preparador=%s, status_geral=%s WHERE id=%s",
-                        (re_prep, status_geral, row["id"]),
+                        "UPDATE preparador_liberacao SET re_preparador=%s, status_geral=%s, maquina=%s WHERE id=%s",
+                        (re_prep, status_geral, maquina, row["id"]),
                     )
                 else:
                     cur.execute(
                         """
                         INSERT INTO preparador_liberacao
-                          (os, partnumber, operacao, re_preparador, status_geral)
-                        VALUES (%s, %s, %s, %s, %s)
+                          (os, partnumber, operacao, re_preparador, status_geral, maquina)
+                        VALUES (%s, %s, %s, %s, %s, %s)
                         """,
-                        (os_num, part, op, re_prep, status_geral),
+                        (os_num, part, op, re_prep, status_geral, maquina),
                     )
 
-            c.commit()
+            cur.execute(
+                "ALTER TABLE preparador_liberacao ADD COLUMN IF NOT EXISTS maquina VARCHAR(128) DEFAULT NULL"
+            )
+            cur.execute(
+                "ALTER TABLE operador_amostragem ADD COLUMN IF NOT EXISTS maquina VARCHAR(128) DEFAULT NULL"
+            )
+            cur.execute(
+                "ALTER TABLE preparador_registro ADD COLUMN IF NOT EXISTS maquina VARCHAR(128) DEFAULT NULL"
+            )
+
+        c.commit()
 
         return jsonify(
             {"status": "ok", "registro_id": registro_id, "status_geral": status_geral}
@@ -1012,12 +1048,15 @@ def preparador_finalizar_os():
     re_prep = _norm(payload.get("re"))
     part = _norm_part(payload.get("partnumber"))
     op = _norm_op(payload.get("operacao"))
+    maquina = _norm(payload.get("maquina"))
     itens = payload.get("itens", [])
 
-    if not os_num or not re_prep or not part or not op:
+    if not os_num or not re_prep or not part or not op or not maquina:
         return (
             jsonify(
-                {"error": "Campos 'os', 're', 'partnumber' e 'operacao' são obrigatórios"}
+                {
+                    "error": "Campos 'os', 're', 'partnumber', 'operacao' e 'maquina' são obrigatórios"
+                }
             ),
             400,
         )
@@ -1030,6 +1069,10 @@ def preparador_finalizar_os():
     try:
         with _conn_db(DB_NAME) as c:
             with c.cursor() as cur:
+                cur.execute("SELECT 1 FROM maquinas WHERE codigo=%s", (maquina,))
+                if not cur.fetchone():
+                    return jsonify({"error": "máquina não cadastrada"}), 400
+
                 cur.execute(
                     "SELECT status FROM ordem_servico WHERE os=%s", (os_num,)
                 )
@@ -1056,10 +1099,10 @@ def preparador_finalizar_os():
 
                 cur.execute(
                     """
-                    INSERT INTO preparador_registro (os, partnumber, operacao, re_preparador)
-                    VALUES (%s, %s, %s, %s)
+                    INSERT INTO preparador_registro (os, partnumber, operacao, re_preparador, maquina)
+                    VALUES (%s, %s, %s, %s, %s)
                     """,
-                    (os_num, part, op, re_prep),
+                    (os_num, part, op, re_prep, maquina),
                 )
                 registro_id = cur.lastrowid
 
@@ -1116,22 +1159,23 @@ def preparador_finalizar_os():
                 cur.execute(
                     """
                     UPDATE preparador_liberacao
-                    SET re_preparador=%s, status_geral=%s
+                    SET re_preparador=%s, status_geral=%s, maquina=%s
                     WHERE os=%s
                       AND TRIM(LEADING '0' FROM TRIM(partnumber))=%s
                       AND TRIM(LEADING '0' FROM TRIM(operacao))=%s
+                      AND maquina=%s
                     ORDER BY id DESC LIMIT 1
                     """,
-                    (re_prep, status_geral, os_num, part, op),
+                    (re_prep, status_geral, maquina, os_num, part, op, maquina),
                 )
                 if cur.rowcount == 0:
                     cur.execute(
                         """
                         INSERT INTO preparador_liberacao
-                          (os, partnumber, operacao, re_preparador, status_geral)
-                        VALUES (%s, %s, %s, %s, %s)
+                          (os, partnumber, operacao, re_preparador, status_geral, maquina)
+                        VALUES (%s, %s, %s, %s, %s, %s)
                         """,
-                        (os_num, part, op, re_prep, status_geral),
+                        (os_num, part, op, re_prep, status_geral, maquina),
                     )
 
                 cur.execute(
@@ -1156,22 +1200,31 @@ def operador_pode():
     os_num = _norm(request.args.get("os"))
     part = _norm_part(request.args.get("partnumber"))
     op = _norm_op(request.args.get("operacao"))
-    if not os_num or not part or not op:
+    maquina = _norm(request.args.get("maquina"))
+    if not os_num or not part or not op or not maquina:
         return (
             jsonify(
-                {"error": "Parâmetros 'os', 'partnumber' e 'operacao' são obrigatórios"}
+                {
+                    "error": "Parâmetros 'os', 'partnumber', 'operacao' e 'maquina' são obrigatórios"
+                }
             ),
             400,
         )
 
     try:
         with _conn_db(DB_NAME) as c:
-            ok, fonte, detalhe = _maquina_liberada(c, os_num, part, op)
+            with c.cursor() as cur:
+                cur.execute("SELECT 1 FROM maquinas WHERE codigo=%s", (maquina,))
+                if not cur.fetchone():
+                    return jsonify({"error": "máquina não cadastrada"}), 400
+
+            ok, fonte, detalhe = _maquina_liberada(c, os_num, part, op, maquina)
         return jsonify(
             {
                 "os": os_num,
                 "partnumber": part,
                 "operacao": op,
+                "maquina": maquina,
                 "liberada": ok,
                 "fonte": fonte,
                 "detalhe": detalhe,
@@ -1211,14 +1264,15 @@ def operador_registrar():
     re_op = _norm(payload.get("re"))
     part = _norm_part(payload.get("partnumber"))
     op = _norm_op(payload.get("operacao"))
+    maquina = _norm(payload.get("maquina"))
     itens = payload.get("itens", [])
 
     # validações mínimas
-    if not os_num or not re_op or not part or not op:
+    if not os_num or not re_op or not part or not op or not maquina:
         return (
             jsonify(
                 {
-                    "error": "Campos 'os', 're', 'partnumber' e 'operacao' são obrigatórios"
+                    "error": "Campos 'os', 're', 'partnumber', 'operacao' e 'maquina' são obrigatórios"
                 }
             ),
             400,
@@ -1231,10 +1285,15 @@ def operador_registrar():
 
     try:
         with _conn_db(DB_NAME) as c:
+            with c.cursor() as cur:
+                cur.execute("SELECT 1 FROM maquinas WHERE codigo=%s", (maquina,))
+                if not cur.fetchone():
+                    return jsonify({"error": "máquina não cadastrada"}), 400
+
             # BLOQUEIO: exige liberação
-            ok, fonte, detalhe = _maquina_liberada(c, os_num, part, op)
+            ok, fonte, detalhe = _maquina_liberada(c, os_num, part, op, maquina)
             if not ok:
-                msg = _mensagem_bloqueio(os_num, part, op, fonte, detalhe)
+                msg = _mensagem_bloqueio(os_num, part, op, maquina, fonte, detalhe)
                 return (
                     jsonify(
                         {
@@ -1256,10 +1315,10 @@ def operador_registrar():
                 # cabeçalho
                 cur.execute(
                     """
-                    INSERT INTO operador_amostragem (os, partnumber, operacao, re_operador)
-                    VALUES (%s, %s, %s, %s)
+                    INSERT INTO operador_amostragem (os, partnumber, operacao, re_operador, maquina)
+                    VALUES (%s, %s, %s, %s, %s)
                     """,
-                    (os_num, part, op, re_op),
+                    (os_num, part, op, re_op, maquina),
                 )
                 amostragem_id = cur.lastrowid
 
@@ -1615,14 +1674,14 @@ def health():
 
 
 def _mensagem_bloqueio(
-    os_num: str, part: str, op: str, fonte: str, detalhe: str
+    os_num: str, part: str, op: str, maquina: str, fonte: str, detalhe: str
 ) -> str:
     """
     Gera um texto legível explicando por que o operador não pode registrar.
     fonte: "", "preparador_registro" ou "preparador_liberacao"
     detalhe: texto livre com dicas (ex.: "3/4 OK", "status_geral=pendente")
     """
-    base = f"OS: {os_num}  •  Peça: {part}  •  Operação: {op}."
+    base = f"OS: {os_num}  •  Peça: {part}  •  Operação: {op}  •  Máquina: {maquina}."
 
     fonte = (fonte or "").strip().lower()
     det = str(detalhe or "")

--- a/lib/features/finalizar_os/presentation/finalizar_os_page.dart
+++ b/lib/features/finalizar_os/presentation/finalizar_os_page.dart
@@ -11,6 +11,7 @@ import 'package:admin/features/preparacao/data/models.dart';
 import 'package:admin/features/preparacao/data/repository_provider.dart';
 import 'package:admin/screens/main/components/side_menu.dart';
 import 'package:admin/utils/string_utils.dart';
+import 'package:admin/services/machine_service.dart';
 
 /// Mesmo base URL usado no Operador
 const String kBaseUrl = 'http://192.168.0.241:5005';
@@ -115,6 +116,9 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
   final _partCtrl = TextEditingController();
   final _opCtrl = TextEditingController();
 
+  final List<String> _maquinas = [];
+  String? _maquinaSel;
+
   bool _registrando = false;
   bool _osFinalizada = false;
 
@@ -128,6 +132,19 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
     _osCtrl.addListener(_resetFinalizada);
     _partCtrl.addListener(_resetFinalizada);
     _opCtrl.addListener(_resetFinalizada);
+    _carregarMaquinas();
+  }
+
+  Future<void> _carregarMaquinas() async {
+    try {
+      final list = await MachineService().fetchMaquinas();
+      if (mounted) setState(() => _maquinas.addAll(list));
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(SnackBar(content: Text('Erro ao carregar máquinas: $e')));
+      }
+    }
   }
 
   @override
@@ -162,11 +179,13 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
   Future<void> _registrarFinalizacao() async {
     final medidas = ref.read(medidasFinalizadorControllerProvider).value ?? [];
 
-    // Valida RE / OS
-    if (_reCtrl.text.trim().isEmpty || _osCtrl.text.trim().isEmpty) {
+    // Valida RE / OS / Máquina
+    if (_reCtrl.text.trim().isEmpty ||
+        _osCtrl.text.trim().isEmpty ||
+        (_maquinaSel ?? '').isEmpty) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Preencha RE e O.S. para registrar.')),
+        const SnackBar(content: Text('Preencha RE, O.S. e máquina para registrar.')),
       );
       return;
     }
@@ -212,6 +231,7 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
       'os': _osCtrl.text.trim(),
       'partnumber': normalizeCode(_partCtrl.text),
       'operacao': normalizeCode(_opCtrl.text),
+      'maquina': _maquinaSel,
       'itens': itens,
     });
 
@@ -271,12 +291,13 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
     // Pode registrar quando: RE e OS preenchidos + todas as medições preenchidas
     final reOk = _reCtrl.text.trim().isNotEmpty;
     final osOk = _osCtrl.text.trim().isNotEmpty;
+    final maquinaOk = (_maquinaSel ?? '').isNotEmpty;
     final todasOk = medidas.isNotEmpty &&
         medidas.every((m) =>
             (m.medicao ?? '').isNotEmpty &&
                 m.status != StatusMedida.pendente);
     final podeRegistrar =
-        reOk && osOk && todasOk && !_registrando && !_osFinalizada;
+        reOk && osOk && maquinaOk && todasOk && !_registrando && !_osFinalizada;
 
     return Scaffold(
       appBar: AppBar(
@@ -344,6 +365,23 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
                           ),
                         ),
                       ],
+                    ),
+
+                    const SizedBox(height: 12),
+
+                    DropdownButtonFormField<String>(
+                      value: _maquinaSel,
+                      decoration: const InputDecoration(
+                        labelText: 'Código da máquina',
+                        border: OutlineInputBorder(),
+                      ),
+                      items: _maquinas
+                          .map((m) =>
+                              DropdownMenuItem(value: m, child: Text(m)))
+                          .toList(),
+                      onChanged: (v) => setState(() => _maquinaSel = v),
+                      validator: (v) =>
+                          (v == null || v.isEmpty) ? 'Obrigatório' : null,
                     ),
 
                     const SizedBox(height: 12),

--- a/lib/features/operador/presentation/operador_page.dart
+++ b/lib/features/operador/presentation/operador_page.dart
@@ -12,6 +12,7 @@ import '../../preparacao/data/models.dart';
 import '../data/repository_provider.dart';
 import 'package:admin/screens/main/components/side_menu.dart';
 import 'package:admin/utils/string_utils.dart';
+import 'package:admin/services/machine_service.dart';
 
 /// >>>>> Ajuste para o endereço/porta do seu Flask <<<<<
 const String kBaseUrl = 'http://192.168.0.241:5005';
@@ -99,7 +100,28 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
   final _partCtrl = TextEditingController();
   final _opCtrl = TextEditingController();
 
+  final List<String> _maquinas = [];
+  String? _maquinaSel;
+
   bool _registrando = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _carregarMaquinas();
+  }
+
+  Future<void> _carregarMaquinas() async {
+    try {
+      final list = await MachineService().fetchMaquinas();
+      if (mounted) setState(() => _maquinas.addAll(list));
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(SnackBar(content: Text('Erro ao carregar máquinas: $e')));
+      }
+    }
+  }
 
   @override
   void dispose() {
@@ -113,11 +135,13 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
   Future<void> _registrarAmostragem() async {
     final medidas = ref.read(medidasOperadorControllerProvider).value ?? [];
 
-    // Valida RE/OS
-    if (_reCtrl.text.trim().isEmpty || _osCtrl.text.trim().isEmpty) {
+    // Valida RE/OS/Máquina
+    if (_reCtrl.text.trim().isEmpty ||
+        _osCtrl.text.trim().isEmpty ||
+        (_maquinaSel ?? '').isEmpty) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Preencha RE e O.S. para registrar.')),
+        const SnackBar(content: Text('Preencha RE, O.S. e máquina para registrar.')),
       );
       return;
     }
@@ -184,6 +208,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
       'os': _osCtrl.text.trim(),
       'partnumber': normalizeCode(_partCtrl.text),
       'operacao': normalizeCode(_opCtrl.text),
+      'maquina': _maquinaSel,
       // >>> chave correta no backend:
       'itens': itens,
     });
@@ -320,13 +345,15 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
     final medidas = medidasAsync.value ?? [];
     final reOk = _reCtrl.text.trim().isNotEmpty;
     final osOk = _osCtrl.text.trim().isNotEmpty;
+    final maquinaOk = (_maquinaSel ?? '').isNotEmpty;
 
     // todas respondidas?
     final todasRespondidas = medidas.isNotEmpty &&
         medidas.every((m) =>
         m.status != StatusMedida.pendente && (m.medicao ?? '').isNotEmpty);
 
-    final podeRegistrar = reOk && osOk && todasRespondidas && !_registrando;
+    final podeRegistrar =
+        reOk && osOk && maquinaOk && todasRespondidas && !_registrando;
 
     return Scaffold(
       appBar: AppBar(
@@ -394,6 +421,23 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                           ),
                         ),
                       ],
+                    ),
+
+                    const SizedBox(height: 12),
+
+                    DropdownButtonFormField<String>(
+                      value: _maquinaSel,
+                      decoration: const InputDecoration(
+                        labelText: 'Código da máquina',
+                        border: OutlineInputBorder(),
+                      ),
+                      items: _maquinas
+                          .map((m) =>
+                              DropdownMenuItem(value: m, child: Text(m)))
+                          .toList(),
+                      onChanged: (v) => setState(() => _maquinaSel = v),
+                      validator: (v) =>
+                          (v == null || v.isEmpty) ? 'Obrigatório' : null,
                     ),
 
                     const SizedBox(height: 12),

--- a/lib/features/preparacao/presentation/preparacao_page.dart
+++ b/lib/features/preparacao/presentation/preparacao_page.dart
@@ -11,6 +11,7 @@ import 'package:admin/features/preparacao/data/models.dart';
 import 'package:admin/features/operador/data/repository_provider.dart';
 import 'package:admin/screens/main/components/side_menu.dart';
 import 'package:admin/utils/string_utils.dart';
+import 'package:admin/services/machine_service.dart';
 
 /// Mesmo base URL usado no Operador
 const String kBaseUrl = 'http://192.168.0.241:5005';
@@ -115,6 +116,9 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
   final _partCtrl = TextEditingController();
   final _opCtrl = TextEditingController();
 
+  final List<String> _maquinas = [];
+  String? _maquinaSel;
+
   bool _registrando = false;
   bool _osLiberada = false;
 
@@ -128,6 +132,19 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
     _osCtrl.addListener(_resetLiberada);
     _partCtrl.addListener(_resetLiberada);
     _opCtrl.addListener(_resetLiberada);
+    _carregarMaquinas();
+  }
+
+  Future<void> _carregarMaquinas() async {
+    try {
+      final list = await MachineService().fetchMaquinas();
+      if (mounted) setState(() => _maquinas.addAll(list));
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(SnackBar(content: Text('Erro ao carregar máquinas: $e')));
+      }
+    }
   }
 
   @override
@@ -163,10 +180,12 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
     final medidas = ref.read(medidasPreparadorControllerProvider).value ?? [];
 
     // Valida RE / OS
-    if (_reCtrl.text.trim().isEmpty || _osCtrl.text.trim().isEmpty) {
+    if (_reCtrl.text.trim().isEmpty ||
+        _osCtrl.text.trim().isEmpty ||
+        (_maquinaSel ?? '').isEmpty) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Preencha RE e O.S. para registrar.')),
+        const SnackBar(content: Text('Preencha RE, O.S. e máquina para registrar.')),
       );
       return;
     }
@@ -212,6 +231,7 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
       'os': _osCtrl.text.trim(),
       'partnumber': normalizeCode(_partCtrl.text),
       'operacao': normalizeCode(_opCtrl.text),
+      'maquina': _maquinaSel,
       'itens': itens,
     });
 
@@ -278,12 +298,13 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
     // Pode registrar quando: RE e OS preenchidos + todas as medições preenchidas
     final reOk = _reCtrl.text.trim().isNotEmpty;
     final osOk = _osCtrl.text.trim().isNotEmpty;
+    final maquinaOk = (_maquinaSel ?? '').isNotEmpty;
     final todasOk = medidas.isNotEmpty &&
         medidas.every((m) =>
         (m.medicao ?? '').isNotEmpty &&
             m.status != StatusMedida.pendente);
     final podeRegistrar =
-        reOk && osOk && todasOk && !_registrando && !_osLiberada;
+        reOk && osOk && maquinaOk && todasOk && !_registrando && !_osLiberada;
 
     return Scaffold(
       appBar: AppBar(
@@ -351,6 +372,23 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
                           ),
                         ),
                       ],
+                    ),
+
+                    const SizedBox(height: 12),
+
+                    DropdownButtonFormField<String>(
+                      value: _maquinaSel,
+                      decoration: const InputDecoration(
+                        labelText: 'Código da máquina',
+                        border: OutlineInputBorder(),
+                      ),
+                      items: _maquinas
+                          .map((m) =>
+                              DropdownMenuItem(value: m, child: Text(m)))
+                          .toList(),
+                      onChanged: (v) => setState(() => _maquinaSel = v),
+                      validator: (v) =>
+                          (v == null || v.isEmpty) ? 'Obrigatório' : null,
                     ),
 
                     const SizedBox(height: 12),

--- a/lib/screens/main/components/side_menu.dart
+++ b/lib/screens/main/components/side_menu.dart
@@ -8,6 +8,7 @@ import 'package:admin/features/finalizar_os/presentation/finalizar_os_page.dart'
 import 'package:admin/features/cadastro_itens/presentation/cadastro_itens_page.dart';
 import 'package:admin/features/cadastro_preparadores/presentation/cadastro_preparadores_page.dart';
 import 'package:admin/features/export_relatorios/presentation/export_relatorios_page.dart';
+import 'package:admin/features/cadastro_maquinas/presentation/cadastro_maquinas_page.dart';
 import 'package:admin/screens/main/main_screen.dart';
 
 enum SideMenuSection { mainMenu, dashboard, preparador, operador, finalizar }
@@ -65,6 +66,11 @@ class SideMenu extends StatelessWidget {
             title: 'Cadastro de Preparadores',
             svgSrc: 'assets/icons/menu_profile.svg',
             press: () => _navigate(context, const CadastroPreparadoresPage()),
+          ),
+          DrawerListTile(
+            title: 'Cadastro de Máquinas',
+            svgSrc: 'assets/icons/menu_setting.svg',
+            press: () => _navigate(context, const CadastroMaquinasPage()),
           ),
         ]);
         break;


### PR DESCRIPTION
## Summary
- expose machine registration in admin menu
- require machine selection in preparation, sampling, and OS finalization forms
- persist machine codes in backend tables and endpoints

## Testing
- `python -m py_compile app_db.py`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5805ba4d0833188eab710af46ef8e