### PR TITLE
fix: remove const constructor for machine registration page

### DIFF
--- a/lib/features/cadastro_maquinas/presentation/cadastro_maquinas_page.dart
+++ b/lib/features/cadastro_maquinas/presentation/cadastro_maquinas_page.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import '../../../controllers/machine_controller.dart';
 
 class CadastroMaquinasPage extends StatefulWidget {
-  const CadastroMaquinasPage({super.key, MachineController? controller})
+  CadastroMaquinasPage({super.key, MachineController? controller})
       : controller = controller ?? MachineController();
 
   final MachineController controller;


### PR DESCRIPTION
## Summary
- fix non-const MachineController being used in const constructor

## Testing
- `flutter test` *(fails: command not found: flutter)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68b58316c088833196f5cd3105b9481d