### PR TITLE
fix machine registration endpoint

### DIFF
--- a/app_db.py
+++ b/app_db.py
@@ -1642,12 +1642,6 @@ def machines():
     with _conn_db(DB_NAME) as c:
         with c.cursor() as cur:
             cur.execute(
-                "SELECT 1 FROM for07_norm WHERE tipo_maquina=%s LIMIT 1",
-                (codigo,),
-            )
-            if not cur.fetchone():
-                return jsonify({"error": "máquina não encontrada"}), 400
-            cur.execute(
                 "INSERT INTO maquinas (codigo) VALUES (%s) ON DUPLICATE KEY UPDATE codigo=codigo",
                 (codigo,),
             )


### PR DESCRIPTION
## Summary
- allow adding machines without verifying existence in for07_norm

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_68b584ed10c083319d0f283a2b64d4ac