### PR TITLE
feat: categorize machines and filter by category

### DIFF
--- a/app_db.py
+++ b/app_db.py
@@ -253,9 +253,14 @@ def _ensure_schema():
                 """
                   CREATE TABLE IF NOT EXISTS maquinas (
                     codigo VARCHAR(64) NOT NULL PRIMARY KEY,
+                    categoria VARCHAR(128) DEFAULT NULL,
                     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
                   ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
                 """
+            )
+            cur.execute(
+                """ALTER TABLE maquinas
+                      ADD COLUMN IF NOT EXISTS categoria VARCHAR(128) DEFAULT NULL"""
             )
             cur.execute(
                 """
@@ -636,8 +641,6 @@ def _maquina_liberada(
             )
 
 
-
-
 # ========= Rotas de Leitura =========
 # ========= Supervisão =========
 
@@ -669,9 +672,7 @@ def supervisor_registros():
         with _conn_db(DB_NAME) as c:
             with c.cursor() as cur:
                 cur.execute(
-
                     f"SELECT * FROM {tabela} WHERE TRIM(LEADING '0' FROM TRIM(partnumber))=%s AND TRIM(LEADING '0' FROM TRIM(operacao))=%s ORDER BY idx_medida",
-
                     (part, op),
                 )
                 rows = cur.fetchall()
@@ -702,9 +703,7 @@ def supervisor_inserir():
                             400,
                         )
                     cur.execute(
-
                         f"SELECT COALESCE(MAX(idx_medida),0)+1 FROM {tabela} WHERE TRIM(LEADING '0' FROM TRIM(partnumber))=%s AND TRIM(LEADING '0' FROM TRIM(operacao))=%s",
-
                         (part, op),
                     )
                     dados["idx_medida"] = cur.fetchone()[0]
@@ -743,17 +742,13 @@ def supervisor_atualizar():
         with _conn_db(DB_NAME) as c:
             with c.cursor() as cur:
                 cur.execute(
-
                     f"SELECT * FROM {tabela} WHERE TRIM(LEADING '0' FROM TRIM(partnumber))=%s AND TRIM(LEADING '0' FROM TRIM(operacao))=%s AND idx_medida=%s",
-
                     (part, op, idx),
                 )
                 antes = cur.fetchone()
                 set_sql = ", ".join([f"{k}=%s" for k in updates.keys()])
                 cur.execute(
-
                     f"UPDATE {tabela} SET {set_sql} WHERE TRIM(LEADING '0' FROM TRIM(partnumber))=%s AND TRIM(LEADING '0' FROM TRIM(operacao))=%s AND idx_medida=%s",
-
                     list(updates.values()) + [part, op, idx],
                 )
                 _log_supervisao(
@@ -971,7 +966,6 @@ def resultado_preparador():
                     )
                     all_status.append(status)
 
-
                 # Consolida liberação
                 has_reprov = any(
                     any(parte.strip().startswith("reprov") for parte in s.split("|"))
@@ -986,8 +980,6 @@ def resultado_preparador():
                     if all_ok
                     else ("nao_liberada" if has_reprov else "pendente")
                 )
-
-
 
                 # upsert simples em preparador_liberacao (não cria itens aqui)
                 cur.execute(
@@ -1073,13 +1065,13 @@ def preparador_finalizar_os():
                 if not cur.fetchone():
                     return jsonify({"error": "máquina não cadastrada"}), 400
 
-                cur.execute(
-                    "SELECT status FROM ordem_servico WHERE os=%s", (os_num,)
-                )
+                cur.execute("SELECT status FROM ordem_servico WHERE os=%s", (os_num,))
                 st = (cur.fetchone() or {}).get("status", "").lower()
                 if st == "encerrada":
                     return (
-                        jsonify({"code": "ja_finalizada", "error": "OS já finalizada."}),
+                        jsonify(
+                            {"code": "ja_finalizada", "error": "OS já finalizada."}
+                        ),
                         409,
                     )
                 if st != "fim_prod":
@@ -1193,6 +1185,8 @@ def preparador_finalizar_os():
         )
     except Exception as e:
         return jsonify({"error": f"Falha ao finalizar OS: {e}"}), 500
+
+
 # ========= CHECAGEM (para UI) =========
 @app.route("/operador/pode")
 def operador_pode():
@@ -1473,7 +1467,6 @@ def operador_encerrar_producao():
         return jsonify({"error": f"Falha ao encerrar produção: {e}"}), 500
 
 
-
 @app.route("/reports")
 def listar_relatorios():
     try:
@@ -1509,7 +1502,10 @@ def listar_relatorios_preparador():
                 rows = cur.fetchall()
         return jsonify(rows)
     except Exception as e:
-        return jsonify({"error": f"Falha ao consultar relatórios do preparador: {e}"}), 500
+        return (
+            jsonify({"error": f"Falha ao consultar relatórios do preparador: {e}"}),
+            500,
+        )
 
 
 @app.route("/reports/operador")
@@ -1546,7 +1542,10 @@ def listar_relatorios_operador():
                 rows = cur.fetchall()
         return jsonify(rows)
     except Exception as e:
-        return jsonify({"error": f"Falha ao consultar relatórios do operador: {e}"}), 500
+        return (
+            jsonify({"error": f"Falha ao consultar relatórios do operador: {e}"}),
+            500,
+        )
 
 
 @app.route("/reports/export")
@@ -1569,7 +1568,14 @@ def exportar_relatorio_excel():
                         (os_num,),
                     )
                     rows = cur.fetchall()
-                    headers = ["os", "partnumber", "operacao", "re_preparador", "status_geral", "created_at"]
+                    headers = [
+                        "os",
+                        "partnumber",
+                        "operacao",
+                        "re_preparador",
+                        "status_geral",
+                        "created_at",
+                    ]
                 else:
                     cur.execute(
                         """
@@ -1630,23 +1636,26 @@ def machines():
     if request.method == "GET":
         with _conn_db(DB_NAME) as c:
             with c.cursor() as cur:
-                cur.execute("SELECT codigo FROM maquinas ORDER BY codigo")
-                rows = [r["codigo"] for r in cur.fetchall()]
+                cur.execute(
+                    "SELECT codigo, categoria FROM maquinas ORDER BY categoria, codigo"
+                )
+                rows = cur.fetchall()
         return jsonify(rows)
 
     data = request.get_json(silent=True) or {}
     codigo = (data.get("codigo") or "").strip()
-    if not codigo:
-        return jsonify({"error": "campo 'codigo' obrigatório"}), 400
+    categoria = (data.get("categoria") or "").strip()
+    if not codigo or not categoria:
+        return jsonify({"error": "campos 'codigo' e 'categoria' obrigatórios"}), 400
 
     with _conn_db(DB_NAME) as c:
         with c.cursor() as cur:
             cur.execute(
-                "INSERT INTO maquinas (codigo) VALUES (%s) ON DUPLICATE KEY UPDATE codigo=codigo",
-                (codigo,),
+                "INSERT INTO maquinas (codigo, categoria) VALUES (%s, %s) ON DUPLICATE KEY UPDATE categoria=VALUES(categoria)",
+                (codigo, categoria),
             )
         c.commit()
-    return jsonify({"status": "ok", "codigo": codigo})
+    return jsonify({"status": "ok", "codigo": codigo, "categoria": categoria})
 
 
 @app.route("/relatorios/sql")
@@ -1709,7 +1718,6 @@ def _mensagem_bloqueio(
                 + f"\nProgresso do registro do Preparador: {aprov_cnt}/{total} medidas aprovadas. Aguarde até todas estarem aprovadas."
             )
         return base + "\nO registro do Preparador ainda não está 100% aprovado."
-
 
     return base
 

--- a/lib/controllers/machine_controller.dart
+++ b/lib/controllers/machine_controller.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 
 import '../services/machine_service.dart';
+import '../models/machine.dart';
 
 class MachineController extends ChangeNotifier {
   MachineController({MachineService? service})
@@ -8,7 +9,7 @@ class MachineController extends ChangeNotifier {
 
   final MachineService _service;
 
-  final List<String> maquinas = [];
+  final List<Machine> maquinas = [];
   bool isLoading = false;
   bool isSaving = false;
   String? error;
@@ -30,13 +31,13 @@ class MachineController extends ChangeNotifier {
     }
   }
 
-  Future<void> addMaquina(String codigo) async {
+  Future<void> addMaquina(String codigo, String categoria) async {
     try {
       isSaving = true;
       notifyListeners();
-      final ok = await _service.addMaquina(codigo);
+      final ok = await _service.addMaquina(codigo, categoria);
       if (ok) {
-        maquinas.add(codigo);
+        maquinas.add(Machine(codigo: codigo, categoria: categoria));
         error = null;
       } else {
         error = 'Falha ao adicionar';

--- a/lib/features/cadastro_maquinas/presentation/cadastro_maquinas_page.dart
+++ b/lib/features/cadastro_maquinas/presentation/cadastro_maquinas_page.dart
@@ -14,6 +14,7 @@ class CadastroMaquinasPage extends StatefulWidget {
 
 class _CadastroMaquinasPageState extends State<CadastroMaquinasPage> {
   final _codigoCtrl = TextEditingController();
+  final _categoriaCtrl = TextEditingController();
 
   @override
   void initState() {
@@ -36,6 +37,7 @@ class _CadastroMaquinasPageState extends State<CadastroMaquinasPage> {
   void dispose() {
     widget.controller.removeListener(_onChanged);
     _codigoCtrl.dispose();
+    _categoriaCtrl.dispose();
     super.dispose();
   }
 
@@ -54,6 +56,14 @@ class _CadastroMaquinasPageState extends State<CadastroMaquinasPage> {
                     children: [
                       Expanded(
                         child: TextField(
+                          controller: _categoriaCtrl,
+                          decoration:
+                              const InputDecoration(labelText: 'Categoria'),
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: TextField(
                           controller: _codigoCtrl,
                           decoration:
                               const InputDecoration(labelText: 'Código da máquina'),
@@ -69,9 +79,13 @@ class _CadastroMaquinasPageState extends State<CadastroMaquinasPage> {
                           : FilledButton(
                               onPressed: () async {
                                 final codigo = _codigoCtrl.text.trim();
-                                if (codigo.isEmpty) return;
-                                await ctrl.addMaquina(codigo);
-                                if (ctrl.error == null) _codigoCtrl.clear();
+                                final categoria = _categoriaCtrl.text.trim();
+                                if (codigo.isEmpty || categoria.isEmpty) return;
+                                await ctrl.addMaquina(codigo, categoria);
+                                if (ctrl.error == null) {
+                                  _codigoCtrl.clear();
+                                  _categoriaCtrl.clear();
+                                }
                               },
                               child: const Text('Adicionar'),
                             ),
@@ -83,7 +97,8 @@ class _CadastroMaquinasPageState extends State<CadastroMaquinasPage> {
                     itemCount: ctrl.maquinas.length,
                     itemBuilder: (context, index) {
                       final m = ctrl.maquinas[index];
-                      return ListTile(title: Text(m));
+                      return ListTile(
+                          title: Text('${m.codigo} (${m.categoria})'));
                     },
                   ),
                 ),

--- a/lib/features/finalizar_os/presentation/finalizar_os_page.dart
+++ b/lib/features/finalizar_os/presentation/finalizar_os_page.dart
@@ -12,6 +12,7 @@ import 'package:admin/features/preparacao/data/repository_provider.dart';
 import 'package:admin/screens/main/components/side_menu.dart';
 import 'package:admin/utils/string_utils.dart';
 import 'package:admin/services/machine_service.dart';
+import 'package:admin/models/machine.dart';
 
 /// Mesmo base URL usado no Operador
 const String kBaseUrl = 'http://192.168.0.241:5005';
@@ -116,7 +117,9 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
   final _partCtrl = TextEditingController();
   final _opCtrl = TextEditingController();
 
-  final List<String> _maquinas = [];
+  final List<Machine> _maquinas = [];
+  final List<String> _categorias = [];
+  String? _categoriaSel;
   String? _maquinaSel;
 
   bool _registrando = false;
@@ -138,7 +141,13 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
   Future<void> _carregarMaquinas() async {
     try {
       final list = await MachineService().fetchMaquinas();
-      if (mounted) setState(() => _maquinas.addAll(list));
+      if (mounted) {
+        setState(() {
+          _maquinas.addAll(list);
+          _categorias.addAll(
+              _maquinas.map((e) => e.categoria).toSet().toList()..sort());
+        });
+      }
     } catch (e) {
       if (mounted) {
         ScaffoldMessenger.of(context)
@@ -370,14 +379,35 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
                     const SizedBox(height: 12),
 
                     DropdownButtonFormField<String>(
+                      value: _categoriaSel,
+                      decoration: const InputDecoration(
+                        labelText: 'Categoria',
+                        border: OutlineInputBorder(),
+                      ),
+                      items: _categorias
+                          .map((c) =>
+                              DropdownMenuItem(value: c, child: Text(c)))
+                          .toList(),
+                      onChanged: (v) => setState(() {
+                        _categoriaSel = v;
+                        _maquinaSel = null;
+                      }),
+                      validator: (v) =>
+                          (v == null || v.isEmpty) ? 'Obrigatório' : null,
+                    ),
+
+                    const SizedBox(height: 12),
+
+                    DropdownButtonFormField<String>(
                       value: _maquinaSel,
                       decoration: const InputDecoration(
                         labelText: 'Código da máquina',
                         border: OutlineInputBorder(),
                       ),
                       items: _maquinas
+                          .where((m) => m.categoria == _categoriaSel)
                           .map((m) =>
-                              DropdownMenuItem(value: m, child: Text(m)))
+                              DropdownMenuItem(value: m.codigo, child: Text(m.codigo)))
                           .toList(),
                       onChanged: (v) => setState(() => _maquinaSel = v),
                       validator: (v) =>

--- a/lib/features/operador/presentation/operador_page.dart
+++ b/lib/features/operador/presentation/operador_page.dart
@@ -13,6 +13,7 @@ import '../data/repository_provider.dart';
 import 'package:admin/screens/main/components/side_menu.dart';
 import 'package:admin/utils/string_utils.dart';
 import 'package:admin/services/machine_service.dart';
+import 'package:admin/models/machine.dart';
 
 /// >>>>> Ajuste para o endereço/porta do seu Flask <<<<<
 const String kBaseUrl = 'http://192.168.0.241:5005';
@@ -100,7 +101,9 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
   final _partCtrl = TextEditingController();
   final _opCtrl = TextEditingController();
 
-  final List<String> _maquinas = [];
+  final List<Machine> _maquinas = [];
+  final List<String> _categorias = [];
+  String? _categoriaSel;
   String? _maquinaSel;
 
   bool _registrando = false;
@@ -114,7 +117,13 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
   Future<void> _carregarMaquinas() async {
     try {
       final list = await MachineService().fetchMaquinas();
-      if (mounted) setState(() => _maquinas.addAll(list));
+      if (mounted) {
+        setState(() {
+          _maquinas.addAll(list);
+          _categorias.addAll(
+              _maquinas.map((e) => e.categoria).toSet().toList()..sort());
+        });
+      }
     } catch (e) {
       if (mounted) {
         ScaffoldMessenger.of(context)
@@ -426,14 +435,35 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                     const SizedBox(height: 12),
 
                     DropdownButtonFormField<String>(
+                      value: _categoriaSel,
+                      decoration: const InputDecoration(
+                        labelText: 'Categoria',
+                        border: OutlineInputBorder(),
+                      ),
+                      items: _categorias
+                          .map((c) =>
+                              DropdownMenuItem(value: c, child: Text(c)))
+                          .toList(),
+                      onChanged: (v) => setState(() {
+                        _categoriaSel = v;
+                        _maquinaSel = null;
+                      }),
+                      validator: (v) =>
+                          (v == null || v.isEmpty) ? 'Obrigatório' : null,
+                    ),
+
+                    const SizedBox(height: 12),
+
+                    DropdownButtonFormField<String>(
                       value: _maquinaSel,
                       decoration: const InputDecoration(
                         labelText: 'Código da máquina',
                         border: OutlineInputBorder(),
                       ),
                       items: _maquinas
-                          .map((m) =>
-                              DropdownMenuItem(value: m, child: Text(m)))
+                          .where((m) => m.categoria == _categoriaSel)
+                          .map((m) => DropdownMenuItem(
+                              value: m.codigo, child: Text(m.codigo)))
                           .toList(),
                       onChanged: (v) => setState(() => _maquinaSel = v),
                       validator: (v) =>

--- a/lib/features/preparacao/presentation/preparacao_page.dart
+++ b/lib/features/preparacao/presentation/preparacao_page.dart
@@ -12,6 +12,7 @@ import 'package:admin/features/operador/data/repository_provider.dart';
 import 'package:admin/screens/main/components/side_menu.dart';
 import 'package:admin/utils/string_utils.dart';
 import 'package:admin/services/machine_service.dart';
+import 'package:admin/models/machine.dart';
 
 /// Mesmo base URL usado no Operador
 const String kBaseUrl = 'http://192.168.0.241:5005';
@@ -116,7 +117,9 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
   final _partCtrl = TextEditingController();
   final _opCtrl = TextEditingController();
 
-  final List<String> _maquinas = [];
+  final List<Machine> _maquinas = [];
+  final List<String> _categorias = [];
+  String? _categoriaSel;
   String? _maquinaSel;
 
   bool _registrando = false;
@@ -138,7 +141,13 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
   Future<void> _carregarMaquinas() async {
     try {
       final list = await MachineService().fetchMaquinas();
-      if (mounted) setState(() => _maquinas.addAll(list));
+      if (mounted) {
+        setState(() {
+          _maquinas.addAll(list);
+          _categorias.addAll(
+              _maquinas.map((e) => e.categoria).toSet().toList()..sort());
+        });
+      }
     } catch (e) {
       if (mounted) {
         ScaffoldMessenger.of(context)
@@ -377,14 +386,35 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
                     const SizedBox(height: 12),
 
                     DropdownButtonFormField<String>(
+                      value: _categoriaSel,
+                      decoration: const InputDecoration(
+                        labelText: 'Categoria',
+                        border: OutlineInputBorder(),
+                      ),
+                      items: _categorias
+                          .map((c) =>
+                              DropdownMenuItem(value: c, child: Text(c)))
+                          .toList(),
+                      onChanged: (v) => setState(() {
+                        _categoriaSel = v;
+                        _maquinaSel = null;
+                      }),
+                      validator: (v) =>
+                          (v == null || v.isEmpty) ? 'Obrigatório' : null,
+                    ),
+
+                    const SizedBox(height: 12),
+
+                    DropdownButtonFormField<String>(
                       value: _maquinaSel,
                       decoration: const InputDecoration(
                         labelText: 'Código da máquina',
                         border: OutlineInputBorder(),
                       ),
                       items: _maquinas
+                          .where((m) => m.categoria == _categoriaSel)
                           .map((m) =>
-                              DropdownMenuItem(value: m, child: Text(m)))
+                              DropdownMenuItem(value: m.codigo, child: Text(m.codigo)))
                           .toList(),
                       onChanged: (v) => setState(() => _maquinaSel = v),
                       validator: (v) =>

--- a/lib/models/machine.dart
+++ b/lib/models/machine.dart
@@ -1,0 +1,20 @@
+class Machine {
+  final String codigo;
+  final String categoria;
+
+  Machine({required this.codigo, required this.categoria});
+
+  factory Machine.fromJson(Map<String, dynamic> json) {
+    return Machine(
+      codigo: json['codigo'] as String,
+      categoria: json['categoria'] as String? ?? '',
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'codigo': codigo,
+      'categoria': categoria,
+    };
+  }
+}

--- a/lib/services/machine_service.dart
+++ b/lib/services/machine_service.dart
@@ -3,6 +3,8 @@ import 'dart:convert';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:http/http.dart' as http;
 
+import '../models/machine.dart';
+
 class MachineService {
   MachineService({http.Client? client, String? baseUrl})
       : _client = client ?? http.Client(),
@@ -11,21 +13,23 @@ class MachineService {
   final http.Client _client;
   final String _baseUrl;
 
-  Future<List<String>> fetchMaquinas() async {
+  Future<List<Machine>> fetchMaquinas() async {
     final uri = Uri.parse('$_baseUrl/machines');
     final resp = await _client.get(uri);
     if (resp.statusCode == 200) {
       final data = jsonDecode(resp.body) as List;
-      return data.map((e) => e.toString()).toList();
+      return data
+          .map((e) => Machine.fromJson(e as Map<String, dynamic>))
+          .toList();
     }
     throw Exception('Falha ao carregar máquinas');
   }
 
-  Future<bool> addMaquina(String codigo) async {
+  Future<bool> addMaquina(String codigo, String categoria) async {
     final uri = Uri.parse('$_baseUrl/machines');
     final resp = await _client.post(uri,
         headers: {'Content-Type': 'application/json'},
-        body: jsonEncode({'codigo': codigo}));
+        body: jsonEncode({'codigo': codigo, 'categoria': categoria}));
     return resp.statusCode == 200;
   }
 }

--- a/test/machine_integration_test.dart
+++ b/test/machine_integration_test.dart
@@ -4,31 +4,35 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:admin/controllers/machine_controller.dart';
 import 'package:admin/features/cadastro_maquinas/presentation/cadastro_maquinas_page.dart';
 import 'package:admin/services/machine_service.dart';
+import 'package:admin/models/machine.dart';
 
 class _FakeMachineService implements MachineService {
   _FakeMachineService(this._items);
 
-  final List<String> _items;
-  final List<String> added = [];
+  final List<Machine> _items;
+  final List<Machine> added = [];
 
   @override
-  Future<List<String>> fetchMaquinas() async {
+  Future<List<Machine>> fetchMaquinas() async {
     await Future<void>.delayed(const Duration(milliseconds: 10));
-    return List<String>.from(_items);
+    return List<Machine>.from(_items);
   }
 
   @override
-  Future<bool> addMaquina(String codigo) async {
+  Future<bool> addMaquina(String codigo, String categoria) async {
     await Future<void>.delayed(const Duration(milliseconds: 10));
-    added.add(codigo);
-    _items.add(codigo);
+    final m = Machine(codigo: codigo, categoria: categoria);
+    added.add(m);
+    _items.add(m);
     return true;
   }
 }
 
 void main() {
   testWidgets('loads initial list and adds new machine', (tester) async {
-    final service = _FakeMachineService(['MX1']);
+    final service = _FakeMachineService([
+      Machine(codigo: 'MX1', categoria: 'CAT1'),
+    ]);
     final controller = MachineController(service: service);
 
     await tester.pumpWidget(MaterialApp(
@@ -36,13 +40,15 @@ void main() {
     ));
     await tester.pump(const Duration(milliseconds: 20));
 
-    expect(find.text('MX1'), findsOneWidget);
+    expect(find.text('MX1 (CAT1)'), findsOneWidget);
 
-    await tester.enterText(find.byType(TextField), 'MX2');
+    await tester.enterText(find.byType(TextField).at(0), 'CAT2');
+    await tester.enterText(find.byType(TextField).at(1), 'MX2');
     await tester.tap(find.byType(FilledButton));
     await tester.pump(const Duration(milliseconds: 20));
 
-    expect(find.text('MX2'), findsOneWidget);
-    expect(service.added, ['MX2']);
+    expect(find.text('MX2 (CAT2)'), findsOneWidget);
+    expect(service.added.single.codigo, 'MX2');
+    expect(service.added.single.categoria, 'CAT2');
   });
 }


### PR DESCRIPTION
## Summary
- add machine model with category support
- allow selecting category before machine selection in preparador, operador, and machine registration pages
- update backend and service to store and fetch machine categories

## Testing
- `python -m black app_db.py`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5875a39308331ac879ee9d9346a23