### PR TITLE
Add machine editing support

### DIFF
--- a/app_db.py
+++ b/app_db.py
@@ -1658,6 +1658,23 @@ def machines():
     return jsonify({"status": "ok", "codigo": codigo, "categoria": categoria})
 
 
+@app.route("/machines/<codigo>", methods=["PUT"])
+def update_machine(codigo: str):
+    data = request.get_json(silent=True) or {}
+    new_codigo = (data.get("codigo") or "").strip()
+    categoria = (data.get("categoria") or "").strip()
+    if not new_codigo or not categoria:
+        return jsonify({"error": "campos 'codigo' e 'categoria' obrigatórios"}), 400
+    with _conn_db(DB_NAME) as c:
+        with c.cursor() as cur:
+            cur.execute(
+                "UPDATE maquinas SET codigo=%s, categoria=%s WHERE codigo=%s",
+                (new_codigo, categoria, codigo),
+            )
+        c.commit()
+    return jsonify({"status": "ok", "codigo": new_codigo, "categoria": categoria})
+
+
 @app.route("/relatorios/sql")
 def relatorio_sql():
     path = request.args.get("path")

--- a/lib/controllers/machine_controller.dart
+++ b/lib/controllers/machine_controller.dart
@@ -49,4 +49,27 @@ class MachineController extends ChangeNotifier {
       notifyListeners();
     }
   }
+
+  Future<void> updateMaquina(
+      String oldCodigo, String codigo, String categoria) async {
+    try {
+      isSaving = true;
+      notifyListeners();
+      final ok = await _service.updateMaquina(oldCodigo, codigo, categoria);
+      if (ok) {
+        final idx = maquinas.indexWhere((m) => m.codigo == oldCodigo);
+        if (idx != -1) {
+          maquinas[idx] = Machine(codigo: codigo, categoria: categoria);
+        }
+        error = null;
+      } else {
+        error = 'Falha ao atualizar';
+      }
+    } catch (e) {
+      error = e.toString();
+    } finally {
+      isSaving = false;
+      notifyListeners();
+    }
+  }
 }

--- a/lib/features/cadastro_maquinas/presentation/cadastro_maquinas_page.dart
+++ b/lib/features/cadastro_maquinas/presentation/cadastro_maquinas_page.dart
@@ -98,7 +98,60 @@ class _CadastroMaquinasPageState extends State<CadastroMaquinasPage> {
                     itemBuilder: (context, index) {
                       final m = ctrl.maquinas[index];
                       return ListTile(
-                          title: Text('${m.codigo} (${m.categoria})'));
+                        title: Text('${m.codigo} (${m.categoria})'),
+                        trailing: IconButton(
+                          icon: const Icon(Icons.edit),
+                          onPressed: () async {
+                            final catCtrl =
+                                TextEditingController(text: m.categoria);
+                            final codCtrl =
+                                TextEditingController(text: m.codigo);
+                            final result = await showDialog<bool>(
+                              context: context,
+                              builder: (context) {
+                                return AlertDialog(
+                                  title: const Text('Editar máquina'),
+                                  content: Column(
+                                    mainAxisSize: MainAxisSize.min,
+                                    children: [
+                                      TextField(
+                                        controller: catCtrl,
+                                        decoration: const InputDecoration(
+                                            labelText: 'Categoria'),
+                                      ),
+                                      TextField(
+                                        controller: codCtrl,
+                                        decoration: const InputDecoration(
+                                            labelText: 'Código da máquina'),
+                                      ),
+                                    ],
+                                  ),
+                                  actions: [
+                                    TextButton(
+                                      onPressed: () =>
+                                          Navigator.pop(context, false),
+                                      child: const Text('Cancelar'),
+                                    ),
+                                    FilledButton(
+                                      onPressed: () =>
+                                          Navigator.pop(context, true),
+                                      child: const Text('Salvar'),
+                                    ),
+                                  ],
+                                );
+                              },
+                            );
+                            if (result == true) {
+                              await ctrl.updateMaquina(
+                                  m.codigo,
+                                  codCtrl.text.trim(),
+                                  catCtrl.text.trim());
+                            }
+                            catCtrl.dispose();
+                            codCtrl.dispose();
+                          },
+                        ),
+                      );
                     },
                   ),
                 ),

--- a/lib/services/machine_service.dart
+++ b/lib/services/machine_service.dart
@@ -17,10 +17,22 @@ class MachineService {
     final uri = Uri.parse('$_baseUrl/machines');
     final resp = await _client.get(uri);
     if (resp.statusCode == 200) {
-      final data = jsonDecode(resp.body) as List;
-      return data
-          .map((e) => Machine.fromJson(e as Map<String, dynamic>))
-          .toList();
+      final body = jsonDecode(resp.body);
+      if (body is List) {
+        return body.map<Machine>((e) {
+          if (e is Map<String, dynamic>) {
+            return Machine.fromJson(e);
+          }
+          if (e is List && e.length >= 2) {
+            return Machine(
+              codigo: e[0].toString(),
+              categoria: e[1].toString(),
+            );
+          }
+          throw Exception('Formato de máquina inválido');
+        }).toList();
+      }
+      throw Exception('Formato de resposta inválido');
     }
     throw Exception('Falha ao carregar máquinas');
   }
@@ -28,6 +40,15 @@ class MachineService {
   Future<bool> addMaquina(String codigo, String categoria) async {
     final uri = Uri.parse('$_baseUrl/machines');
     final resp = await _client.post(uri,
+        headers: {'Content-Type': 'application/json'},
+        body: jsonEncode({'codigo': codigo, 'categoria': categoria}));
+    return resp.statusCode == 200;
+  }
+
+  Future<bool> updateMaquina(
+      String oldCodigo, String codigo, String categoria) async {
+    final uri = Uri.parse('$_baseUrl/machines/$oldCodigo');
+    final resp = await _client.put(uri,
         headers: {'Content-Type': 'application/json'},
         body: jsonEncode({'codigo': codigo, 'categoria': categoria}));
     return resp.statusCode == 200;

--- a/test/machine_integration_test.dart
+++ b/test/machine_integration_test.dart
@@ -11,6 +11,7 @@ class _FakeMachineService implements MachineService {
 
   final List<Machine> _items;
   final List<Machine> added = [];
+  final List<Map<String, String>> updated = [];
 
   @override
   Future<List<Machine>> fetchMaquinas() async {
@@ -24,6 +25,17 @@ class _FakeMachineService implements MachineService {
     final m = Machine(codigo: codigo, categoria: categoria);
     added.add(m);
     _items.add(m);
+    return true;
+  }
+
+  @override
+  Future<bool> updateMaquina(
+      String oldCodigo, String codigo, String categoria) async {
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+    final idx = _items.indexWhere((m) => m.codigo == oldCodigo);
+    if (idx < 0) return false;
+    _items[idx] = Machine(codigo: codigo, categoria: categoria);
+    updated.add({'old': oldCodigo, 'codigo': codigo, 'categoria': categoria});
     return true;
   }
 }
@@ -50,5 +62,34 @@ void main() {
     expect(find.text('MX2 (CAT2)'), findsOneWidget);
     expect(service.added.single.codigo, 'MX2');
     expect(service.added.single.categoria, 'CAT2');
+  });
+
+  testWidgets('edits existing machine', (tester) async {
+    final service = _FakeMachineService([
+      Machine(codigo: 'MX1', categoria: 'CAT1'),
+    ]);
+    final controller = MachineController(service: service);
+
+    await tester.pumpWidget(MaterialApp(
+      home: CadastroMaquinasPage(controller: controller),
+    ));
+    await tester.pump(const Duration(milliseconds: 20));
+
+    await tester.tap(find.byIcon(Icons.edit));
+    await tester.pumpAndSettle();
+
+    final dialog = find.byType(AlertDialog);
+    await tester.enterText(
+        find.descendant(of: dialog, matching: find.byType(TextField)).at(0),
+        'CAT2');
+    await tester.enterText(
+        find.descendant(of: dialog, matching: find.byType(TextField)).at(1),
+        'MX1');
+    await tester.tap(find.descendant(of: dialog, matching: find.text('Salvar')));
+    await tester.pump(const Duration(milliseconds: 20));
+
+    expect(find.text('MX1 (CAT2)'), findsOneWidget);
+    expect(service.updated.single['codigo'], 'MX1');
+    expect(service.updated.single['categoria'], 'CAT2');
   });
 }


### PR DESCRIPTION
## Summary
- improve machine fetch parsing to handle varied backend responses
- support editing machines via new service/controller methods and UI
- add backend endpoint for updating machines and corresponding tests

## Testing
- `python -m black app_db.py`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b58937f2bc8331be00d385c19e8c76