### PR TITLE
Ensure categoria column exists for older MySQL

### DIFF
--- a/app_db.py
+++ b/app_db.py
@@ -258,10 +258,21 @@ def _ensure_schema():
                   ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
                 """
             )
+            # Garante a coluna 'categoria' mesmo em bancos MySQL mais antigos
             cur.execute(
-                """ALTER TABLE maquinas
-                      ADD COLUMN IF NOT EXISTS categoria VARCHAR(128) DEFAULT NULL"""
+                """
+                SELECT COUNT(*) AS cnt
+                  FROM information_schema.COLUMNS
+                 WHERE TABLE_SCHEMA=%s
+                   AND TABLE_NAME='maquinas'
+                   AND COLUMN_NAME='categoria'
+                """,
+                (DB_NAME,),
             )
+            if not cur.fetchone()["cnt"]:
+                cur.execute(
+                    "ALTER TABLE maquinas ADD COLUMN categoria VARCHAR(128) DEFAULT NULL"
+                )
             cur.execute(
                 """
                   CREATE TABLE IF NOT EXISTS supervisao_log (


### PR DESCRIPTION
## Summary
- ensure maquinas table adds categoria column if missing

## Testing
- `python -m py_compile app_db.py`
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b58e3f231c833196173212ad7c87fe