### PR TITLE
Fix machine category parsing for operator and preparer screens

### DIFF
--- a/lib/services/machine_service.dart
+++ b/lib/services/machine_service.dart
@@ -54,8 +54,8 @@ class MachineService {
       }
       if (e is List || e is Iterable) {
         final list = e is List ? e : e.toList();
-        final codigo = list.isNotEmpty ? list[0].toString() : '';
-        final categoria = list.length > 1 ? list[1].toString() : '';
+        final categoria = list.isNotEmpty ? list[0].toString() : '';
+        final codigo = list.length > 1 ? list[1].toString() : '';
         return Machine(codigo: codigo, categoria: categoria);
       }
       return Machine(codigo: e.toString(), categoria: '');

--- a/test/machine_service_test.dart
+++ b/test/machine_service_test.dart
@@ -6,7 +6,8 @@ import 'package:admin/services/machine_service.dart';
 
 void main() {
   test('parses list responses', () async {
-    final client = MockClient((req) async => http.Response('[["M1","C1"]]', 200));
+    final client =
+        MockClient((req) async => http.Response('[["C1","M1"]]', 200));
     final service = MachineService(client: client, baseUrl: 'http://dummy');
     final machines = await service.fetchMaquinas();
     expect(machines.single.codigo, 'M1');


### PR DESCRIPTION
## Summary
- Parse machine list responses with category before code
- Update machine service tests for new order

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b58f423c388331b23337c6694abbfe