### PR TITLE
Align category and machine code fields

### DIFF
--- a/lib/features/finalizar_os/presentation/finalizar_os_page.dart
+++ b/lib/features/finalizar_os/presentation/finalizar_os_page.dart
@@ -378,40 +378,47 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
 
                     const SizedBox(height: 12),
 
-                    DropdownButtonFormField<String>(
-                      value: _categoriaSel,
-                      decoration: const InputDecoration(
-                        labelText: 'Categoria',
-                        border: OutlineInputBorder(),
-                      ),
-                      items: _categorias
-                          .map((c) =>
-                              DropdownMenuItem(value: c, child: Text(c)))
-                          .toList(),
-                      onChanged: (v) => setState(() {
-                        _categoriaSel = v;
-                        _maquinaSel = null;
-                      }),
-                      validator: (v) =>
-                          (v == null || v.isEmpty) ? 'Obrigatório' : null,
-                    ),
-
-                    const SizedBox(height: 12),
-
-                    DropdownButtonFormField<String>(
-                      value: _maquinaSel,
-                      decoration: const InputDecoration(
-                        labelText: 'Código da máquina',
-                        border: OutlineInputBorder(),
-                      ),
-                      items: _maquinas
-                          .where((m) => m.categoria == _categoriaSel)
-                          .map((m) =>
-                              DropdownMenuItem(value: m.codigo, child: Text(m.codigo)))
-                          .toList(),
-                      onChanged: (v) => setState(() => _maquinaSel = v),
-                      validator: (v) =>
-                          (v == null || v.isEmpty) ? 'Obrigatório' : null,
+                    Row(
+                      children: [
+                        Expanded(
+                          child: DropdownButtonFormField<String>(
+                            value: _categoriaSel,
+                            decoration: const InputDecoration(
+                              labelText: 'Categoria',
+                              border: OutlineInputBorder(),
+                            ),
+                            items: _categorias
+                                .map((c) =>
+                                    DropdownMenuItem(value: c, child: Text(c)))
+                                .toList(),
+                            onChanged: (v) => setState(() {
+                              _categoriaSel = v;
+                              _maquinaSel = null;
+                            }),
+                            validator: (v) =>
+                                (v == null || v.isEmpty) ? 'Obrigatório' : null,
+                          ),
+                        ),
+                        const SizedBox(width: 12),
+                        Expanded(
+                          child: DropdownButtonFormField<String>(
+                            value: _maquinaSel,
+                            decoration: const InputDecoration(
+                              labelText: 'Código da máquina',
+                              border: OutlineInputBorder(),
+                            ),
+                            items: _maquinas
+                                .where((m) => m.categoria == _categoriaSel)
+                                .map((m) => DropdownMenuItem(
+                                    value: m.codigo, child: Text(m.codigo)))
+                                .toList(),
+                            onChanged: (v) =>
+                                setState(() => _maquinaSel = v),
+                            validator: (v) =>
+                                (v == null || v.isEmpty) ? 'Obrigatório' : null,
+                          ),
+                        ),
+                      ],
                     ),
 
                     const SizedBox(height: 12),

--- a/lib/features/operador/presentation/operador_page.dart
+++ b/lib/features/operador/presentation/operador_page.dart
@@ -434,40 +434,47 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
 
                     const SizedBox(height: 12),
 
-                    DropdownButtonFormField<String>(
-                      value: _categoriaSel,
-                      decoration: const InputDecoration(
-                        labelText: 'Categoria',
-                        border: OutlineInputBorder(),
-                      ),
-                      items: _categorias
-                          .map((c) =>
-                              DropdownMenuItem(value: c, child: Text(c)))
-                          .toList(),
-                      onChanged: (v) => setState(() {
-                        _categoriaSel = v;
-                        _maquinaSel = null;
-                      }),
-                      validator: (v) =>
-                          (v == null || v.isEmpty) ? 'Obrigatório' : null,
-                    ),
-
-                    const SizedBox(height: 12),
-
-                    DropdownButtonFormField<String>(
-                      value: _maquinaSel,
-                      decoration: const InputDecoration(
-                        labelText: 'Código da máquina',
-                        border: OutlineInputBorder(),
-                      ),
-                      items: _maquinas
-                          .where((m) => m.categoria == _categoriaSel)
-                          .map((m) => DropdownMenuItem(
-                              value: m.codigo, child: Text(m.codigo)))
-                          .toList(),
-                      onChanged: (v) => setState(() => _maquinaSel = v),
-                      validator: (v) =>
-                          (v == null || v.isEmpty) ? 'Obrigatório' : null,
+                    Row(
+                      children: [
+                        Expanded(
+                          child: DropdownButtonFormField<String>(
+                            value: _categoriaSel,
+                            decoration: const InputDecoration(
+                              labelText: 'Categoria',
+                              border: OutlineInputBorder(),
+                            ),
+                            items: _categorias
+                                .map((c) =>
+                                    DropdownMenuItem(value: c, child: Text(c)))
+                                .toList(),
+                            onChanged: (v) => setState(() {
+                              _categoriaSel = v;
+                              _maquinaSel = null;
+                            }),
+                            validator: (v) =>
+                                (v == null || v.isEmpty) ? 'Obrigatório' : null,
+                          ),
+                        ),
+                        const SizedBox(width: 12),
+                        Expanded(
+                          child: DropdownButtonFormField<String>(
+                            value: _maquinaSel,
+                            decoration: const InputDecoration(
+                              labelText: 'Código da máquina',
+                              border: OutlineInputBorder(),
+                            ),
+                            items: _maquinas
+                                .where((m) => m.categoria == _categoriaSel)
+                                .map((m) => DropdownMenuItem(
+                                    value: m.codigo, child: Text(m.codigo)))
+                                .toList(),
+                            onChanged: (v) =>
+                                setState(() => _maquinaSel = v),
+                            validator: (v) =>
+                                (v == null || v.isEmpty) ? 'Obrigatório' : null,
+                          ),
+                        ),
+                      ],
                     ),
 
                     const SizedBox(height: 12),

--- a/lib/features/preparacao/presentation/preparacao_page.dart
+++ b/lib/features/preparacao/presentation/preparacao_page.dart
@@ -385,40 +385,47 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
 
                     const SizedBox(height: 12),
 
-                    DropdownButtonFormField<String>(
-                      value: _categoriaSel,
-                      decoration: const InputDecoration(
-                        labelText: 'Categoria',
-                        border: OutlineInputBorder(),
-                      ),
-                      items: _categorias
-                          .map((c) =>
-                              DropdownMenuItem(value: c, child: Text(c)))
-                          .toList(),
-                      onChanged: (v) => setState(() {
-                        _categoriaSel = v;
-                        _maquinaSel = null;
-                      }),
-                      validator: (v) =>
-                          (v == null || v.isEmpty) ? 'Obrigatório' : null,
-                    ),
-
-                    const SizedBox(height: 12),
-
-                    DropdownButtonFormField<String>(
-                      value: _maquinaSel,
-                      decoration: const InputDecoration(
-                        labelText: 'Código da máquina',
-                        border: OutlineInputBorder(),
-                      ),
-                      items: _maquinas
-                          .where((m) => m.categoria == _categoriaSel)
-                          .map((m) =>
-                              DropdownMenuItem(value: m.codigo, child: Text(m.codigo)))
-                          .toList(),
-                      onChanged: (v) => setState(() => _maquinaSel = v),
-                      validator: (v) =>
-                          (v == null || v.isEmpty) ? 'Obrigatório' : null,
+                    Row(
+                      children: [
+                        Expanded(
+                          child: DropdownButtonFormField<String>(
+                            value: _categoriaSel,
+                            decoration: const InputDecoration(
+                              labelText: 'Categoria',
+                              border: OutlineInputBorder(),
+                            ),
+                            items: _categorias
+                                .map((c) =>
+                                    DropdownMenuItem(value: c, child: Text(c)))
+                                .toList(),
+                            onChanged: (v) => setState(() {
+                              _categoriaSel = v;
+                              _maquinaSel = null;
+                            }),
+                            validator: (v) =>
+                                (v == null || v.isEmpty) ? 'Obrigatório' : null,
+                          ),
+                        ),
+                        const SizedBox(width: 12),
+                        Expanded(
+                          child: DropdownButtonFormField<String>(
+                            value: _maquinaSel,
+                            decoration: const InputDecoration(
+                              labelText: 'Código da máquina',
+                              border: OutlineInputBorder(),
+                            ),
+                            items: _maquinas
+                                .where((m) => m.categoria == _categoriaSel)
+                                .map((m) => DropdownMenuItem(
+                                    value: m.codigo, child: Text(m.codigo)))
+                                .toList(),
+                            onChanged: (v) =>
+                                setState(() => _maquinaSel = v),
+                            validator: (v) =>
+                                (v == null || v.isEmpty) ? 'Obrigatório' : null,
+                          ),
+                        ),
+                      ],
                     ),
 
                     const SizedBox(height: 12),


### PR DESCRIPTION
## Summary
- Display category and machine code dropdowns on the same row in preparer, operator, and OS finalization screens

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b591ff3dc48331bea5a75a18ca33c7