### PR TITLE
Fix cursor closed error in preparador endpoint

### DIFF
--- a/app_db.py
+++ b/app_db.py
@@ -1021,15 +1021,17 @@ def resultado_preparador():
                         (os_num, part, op, re_prep, status_geral, maquina),
                     )
 
-            cur.execute(
-                "ALTER TABLE preparador_liberacao ADD COLUMN IF NOT EXISTS maquina VARCHAR(128) DEFAULT NULL"
-            )
-            cur.execute(
-                "ALTER TABLE operador_amostragem ADD COLUMN IF NOT EXISTS maquina VARCHAR(128) DEFAULT NULL"
-            )
-            cur.execute(
-                "ALTER TABLE preparador_registro ADD COLUMN IF NOT EXISTS maquina VARCHAR(128) DEFAULT NULL"
-            )
+        # DDL statements can implicitly close the current cursor on some MySQL
+        # servers. Execute each `ALTER TABLE` using a fresh cursor to avoid
+        # "cursor closed" errors on subsequent statements.
+        ddl_statements = (
+            "ALTER TABLE preparador_liberacao ADD COLUMN IF NOT EXISTS maquina VARCHAR(128) DEFAULT NULL",
+            "ALTER TABLE operador_amostragem ADD COLUMN IF NOT EXISTS maquina VARCHAR(128) DEFAULT NULL",
+            "ALTER TABLE preparador_registro ADD COLUMN IF NOT EXISTS maquina VARCHAR(128) DEFAULT NULL",
+        )
+        for ddl in ddl_statements:
+            with c.cursor() as cur:
+                cur.execute(ddl)
 
         c.commit()
 


### PR DESCRIPTION
## Summary
- prevent `cursor closed` errors by running DDL statements with fresh cursors

## Testing
- `python -m py_compile app_db.py`
- `pytest`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5952058948331a4bb013d6ef7fbd8