### PR TITLE
fix: define Android namespace

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -24,6 +24,7 @@ if (flutterVersionName == null) {
 
 android {
     compileSdkVersion 34
+    namespace "com.example.admin"
 
 
     sourceSets {


### PR DESCRIPTION
## Summary
- specify app namespace to satisfy Android Gradle Plugin requirements

## Testing
- `flutter test` *(fails: command not found)*
- `gradle -p android tasks` *(fails: `/workspace/relic/android/local.properties (No such file or directory)`)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a71531d483319493ff0656d486b4