### PR TITLE
fix: prevent storage card overflow

### DIFF
--- a/lib/screens/dashboard/components/storage_info_card.dart
+++ b/lib/screens/dashboard/components/storage_info_card.dart
@@ -55,7 +55,14 @@ class StorageInfoCard extends StatelessWidget {
               ),
             ),
           ),
-          Text(amountOfFiles)
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              amountOfFiles,
+              textAlign: TextAlign.right,
+              overflow: TextOverflow.ellipsis,
+            ),
+          )
         ],
       ),
     );


### PR DESCRIPTION
## Summary
- avoid horizontal overflow by making file count text flexible

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b769b4d083319e53462daf86a7f7