### PR TITLE
Restrict admin area and add access management UI

### DIFF
--- a/app_db.py
+++ b/app_db.py
@@ -302,11 +302,22 @@ def _ensure_schema():
             _ensure_column(
                 c, "preparador_liberacao", "maquina", "VARCHAR(128) DEFAULT NULL"
             )
-            _ensure_column(
-                c, "operador_amostragem", "maquina", "VARCHAR(128) DEFAULT NULL"
-            )
-            _ensure_column(
-                c, "preparador_registro", "maquina", "VARCHAR(128) DEFAULT NULL"
+        _ensure_column(
+            c, "operador_amostragem", "maquina", "VARCHAR(128) DEFAULT NULL"
+        )
+        _ensure_column(
+            c, "preparador_registro", "maquina", "VARCHAR(128) DEFAULT NULL"
+        )
+        with c.cursor() as cur:
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS usuarios (
+                  id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                  username VARCHAR(64) NOT NULL UNIQUE,
+                  password VARCHAR(255) NOT NULL,
+                  is_admin TINYINT(1) DEFAULT 0
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+                """
             )
         c.commit()
 
@@ -1651,6 +1662,66 @@ def exportar_relatorio_excel():
         )
     except Exception as e:
         return jsonify({"error": f"Falha ao exportar relatório: {e}"}), 500
+
+
+def _is_admin_request() -> bool:
+    """Check HTTP Basic credentials and confirm admin user."""
+    auth = request.authorization
+    if not auth:
+        return False
+    with _conn_db(DB_NAME) as c:
+        with c.cursor() as cur:
+            cur.execute(
+                "SELECT is_admin FROM usuarios WHERE username=%s AND password=%s",
+                (auth.username, auth.password),
+            )
+            row = cur.fetchone()
+    return bool(row and row.get("is_admin"))
+
+
+@app.route("/login", methods=["POST"])
+def login():
+    data = request.get_json(silent=True) or {}
+    username = (data.get("username") or "").strip()
+    password = (data.get("password") or "").strip()
+    with _conn_db(DB_NAME) as c:
+        with c.cursor() as cur:
+            cur.execute(
+                "SELECT id, username, is_admin FROM usuarios WHERE username=%s AND password=%s",
+                (username, password),
+            )
+            user = cur.fetchone()
+    if user:
+        return jsonify({"user": user})
+    return jsonify({"error": "credenciais inválidas"}), 401
+
+
+@app.route("/usuarios", methods=["GET", "POST"])
+def usuarios():
+    if not _is_admin_request():
+        return jsonify({"error": "unauthorized"}), 401
+
+    if request.method == "GET":
+        with _conn_db(DB_NAME) as c:
+            with c.cursor() as cur:
+                cur.execute("SELECT id, username, is_admin FROM usuarios")
+                rows = cur.fetchall()
+        return jsonify(rows)
+
+    data = request.get_json(silent=True) or {}
+    username = (data.get("username") or "").strip()
+    password = (data.get("password") or "").strip()
+    is_admin = int(bool(data.get("is_admin")))
+    if not username or not password:
+        return jsonify({"error": "campos obrigatórios"}), 400
+    with _conn_db(DB_NAME) as c:
+        with c.cursor() as cur:
+            cur.execute(
+                "INSERT INTO usuarios (username, password, is_admin) VALUES (%s, %s, %s)",
+                (username, password, is_admin),
+            )
+        c.commit()
+    return jsonify({"status": "ok"})
 
 
 @app.route("/machines", methods=["GET", "POST"])

--- a/lib/features/login/login_page.dart
+++ b/lib/features/login/login_page.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../services/auth_service.dart';
+
+class LoginPage extends ConsumerStatefulWidget {
+  const LoginPage({super.key});
+
+  @override
+  ConsumerState<LoginPage> createState() => _LoginPageState();
+}
+
+class _LoginPageState extends ConsumerState<LoginPage> {
+  final _userCtrl = TextEditingController();
+  final _passCtrl = TextEditingController();
+  String? _error;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Login')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            TextField(
+              controller: _userCtrl,
+              decoration: const InputDecoration(labelText: 'Usuário'),
+            ),
+            TextField(
+              controller: _passCtrl,
+              decoration: const InputDecoration(labelText: 'Senha'),
+              obscureText: true,
+            ),
+            if (_error != null)
+              Padding(
+                padding: const EdgeInsets.only(top: 8),
+                child: Text(_error!, style: const TextStyle(color: Colors.red)),
+              ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () async {
+                final ok = await ref
+                    .read(authServiceProvider.notifier)
+                    .login(_userCtrl.text, _passCtrl.text);
+                if (ok) {
+                  Navigator.of(context).pop(true);
+                } else {
+                  setState(() => _error = 'Credenciais inválidas');
+                }
+              },
+              child: const Text('Entrar'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/main_menu/main_menu_page.dart
+++ b/lib/features/main_menu/main_menu_page.dart
@@ -1,16 +1,19 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:admin/screens/main/main_screen.dart';
 import 'package:admin/screens/main/components/side_menu.dart';
 import '../preparacao/presentation/preparacao_page.dart';
 import '../operador/presentation/operador_page.dart';
 import '../finalizar_os/presentation/finalizar_os_page.dart';
+import '../login/login_page.dart';
+import '../../services/auth_service.dart';
 
-class MainMenuPage extends StatelessWidget {
+class MainMenuPage extends ConsumerWidget {
   const MainMenuPage({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     void open(BuildContext context, Widget page) {
       Navigator.of(context).push(
         MaterialPageRoute(builder: (_) => page),
@@ -46,7 +49,25 @@ class MainMenuPage extends StatelessWidget {
                 ),
                 _MenuCard(
                   title: 'Administração',
-                  onTap: () => open(context, MainScreen()),
+                  onTap: () async {
+                    var auth = ref.read(authServiceProvider);
+                    if (auth == null) {
+                      final ok = await Navigator.of(context).push<bool>(
+                        MaterialPageRoute(
+                            builder: (_) => const LoginPage()),
+                      );
+                      if (ok != true) return;
+                      auth = ref.read(authServiceProvider);
+                    }
+                    if (auth == null || !auth.isAdmin) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(
+                            content: Text('Acesso restrito a administradores')),
+                      );
+                      return;
+                    }
+                    open(context, MainScreen());
+                  },
                 ),
               ],
             ),

--- a/lib/features/users/users_page.dart
+++ b/lib/features/users/users_page.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../models/user.dart';
+import '../../services/auth_service.dart';
+import '../../services/user_service.dart';
+
+class UsersPage extends ConsumerStatefulWidget {
+  const UsersPage({super.key});
+
+  @override
+  ConsumerState<UsersPage> createState() => _UsersPageState();
+}
+
+class _UsersPageState extends ConsumerState<UsersPage> {
+  late Future<List<AppUser>> _future;
+  final _userCtrl = TextEditingController();
+  final _passCtrl = TextEditingController();
+  bool _isAdmin = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = _load();
+  }
+
+  Future<List<AppUser>> _load() {
+    final auth = ref.read(authServiceProvider)!;
+    return UserService().fetchUsers(auth.username, auth.password);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final auth = ref.watch(authServiceProvider);
+    if (auth == null || !auth.isAdmin) {
+      return const Scaffold(body: Center(child: Text('Acesso negado')));
+    }
+    return Scaffold(
+      appBar: AppBar(title: const Text('Gerenciar Acessos')),
+      body: FutureBuilder<List<AppUser>>(
+        future: _future,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState != ConnectionState.done) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          final users = snapshot.data ?? [];
+          return Column(
+            children: [
+              Expanded(
+                child: ListView(
+                  children: users
+                      .map((u) => ListTile(
+                            title: Text(u.username),
+                            subtitle: Text(
+                                u.isAdmin ? 'Administrador' : 'Usuário'),
+                          ))
+                      .toList(),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  children: [
+                    TextField(
+                      controller: _userCtrl,
+                      decoration:
+                          const InputDecoration(labelText: 'Novo usuário'),
+                    ),
+                    TextField(
+                      controller: _passCtrl,
+                      decoration:
+                          const InputDecoration(labelText: 'Senha'),
+                      obscureText: true,
+                    ),
+                    SwitchListTile(
+                      title: const Text('Administrador'),
+                      value: _isAdmin,
+                      onChanged: (v) => setState(() => _isAdmin = v),
+                    ),
+                    ElevatedButton(
+                      onPressed: () async {
+                        final ok = await UserService().createUser(
+                            _userCtrl.text,
+                            _passCtrl.text,
+                            _isAdmin,
+                            auth.username,
+                            auth.password);
+                        if (ok) {
+                          setState(() {
+                            _future = _load();
+                            _userCtrl.clear();
+                            _passCtrl.clear();
+                            _isAdmin = false;
+                          });
+                        }
+                      },
+                      child: const Text('Adicionar'),
+                    )
+                  ],
+                ),
+              )
+            ],
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -1,0 +1,15 @@
+class AppUser {
+  final int id;
+  final String username;
+  final bool isAdmin;
+
+  AppUser({required this.id, required this.username, required this.isAdmin});
+
+  factory AppUser.fromJson(Map<String, dynamic> json) {
+    return AppUser(
+      id: json['id'] as int,
+      username: json['username'] as String,
+      isAdmin: (json['is_admin'] as int) == 1,
+    );
+  }
+}

--- a/lib/screens/dashboard/components/header.dart
+++ b/lib/screens/dashboard/components/header.dart
@@ -2,9 +2,12 @@ import 'package:admin/controllers/menu_app_controller.dart';
 import 'package:admin/responsive.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:provider/provider.dart';
 
 import '../../../constants.dart';
+import '../../../services/auth_service.dart';
+import '../../../features/users/users_page.dart';
 
 class Header extends StatelessWidget {
   const Header({
@@ -34,38 +37,55 @@ class Header extends StatelessWidget {
   }
 }
 
-class ProfileCard extends StatelessWidget {
-  const ProfileCard({
-    Key? key,
-  }) : super(key: key);
+class ProfileCard extends ConsumerWidget {
+  const ProfileCard({Key? key}) : super(key: key);
 
   @override
-  Widget build(BuildContext context) {
-    return Container(
-      margin: EdgeInsets.only(left: defaultPadding),
-      padding: EdgeInsets.symmetric(
-        horizontal: defaultPadding,
-        vertical: defaultPadding / 2,
-      ),
-      decoration: BoxDecoration(
-        color: secondaryColor,
-        borderRadius: const BorderRadius.all(Radius.circular(10)),
-        border: Border.all(color: Colors.white10),
-      ),
-      child: Row(
-        children: [
-          Image.asset(
-            "assets/images/profile_pic.png",
-            height: 38,
-          ),
-          if (!Responsive.isMobile(context))
-            Padding(
-              padding:
-                  const EdgeInsets.symmetric(horizontal: defaultPadding / 2),
-              child: Text("Angelina Jolie"),
+  Widget build(BuildContext context, WidgetRef ref) {
+    final auth = ref.watch(authServiceProvider);
+    if (auth == null) return const SizedBox.shrink();
+    return PopupMenuButton<String>(
+      onSelected: (value) {
+        if (value == 'logout') {
+          ref.read(authServiceProvider.notifier).logout();
+          Navigator.of(context).pop();
+        } else if (value == 'manage') {
+          Navigator.of(context)
+              .push(MaterialPageRoute(builder: (_) => const UsersPage()));
+        }
+      },
+      itemBuilder: (context) => [
+        if (auth.isAdmin)
+          const PopupMenuItem(
+              value: 'manage', child: Text('Gerenciar Acessos')),
+        const PopupMenuItem(value: 'logout', child: Text('Logout')),
+      ],
+      child: Container(
+        margin: EdgeInsets.only(left: defaultPadding),
+        padding: EdgeInsets.symmetric(
+          horizontal: defaultPadding,
+          vertical: defaultPadding / 2,
+        ),
+        decoration: BoxDecoration(
+          color: secondaryColor,
+          borderRadius: const BorderRadius.all(Radius.circular(10)),
+          border: Border.all(color: Colors.white10),
+        ),
+        child: Row(
+          children: [
+            Image.asset(
+              "assets/images/profile_pic.png",
+              height: 38,
             ),
-          Icon(Icons.keyboard_arrow_down),
-        ],
+            if (!Responsive.isMobile(context))
+              Padding(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: defaultPadding / 2),
+                child: Text(auth.username),
+              ),
+            const Icon(Icons.keyboard_arrow_down),
+          ],
+        ),
       ),
     );
   }

--- a/lib/screens/main/components/side_menu.dart
+++ b/lib/screens/main/components/side_menu.dart
@@ -1,6 +1,7 @@
 // Side menu for navigation across application sections
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:admin/features/preparacao/presentation/preparacao_page.dart';
 import 'package:admin/features/operador/presentation/operador_page.dart';
@@ -9,11 +10,14 @@ import 'package:admin/features/cadastro_itens/presentation/cadastro_itens_page.d
 import 'package:admin/features/cadastro_preparadores/presentation/cadastro_preparadores_page.dart';
 import 'package:admin/features/export_relatorios/presentation/export_relatorios_page.dart';
 import 'package:admin/features/cadastro_maquinas/presentation/cadastro_maquinas_page.dart';
+import 'package:admin/features/login/login_page.dart';
+import 'package:admin/features/users/users_page.dart';
+import 'package:admin/services/auth_service.dart';
 import 'package:admin/screens/main/main_screen.dart';
 
 enum SideMenuSection { mainMenu, dashboard, preparador, operador, finalizar }
 
-class SideMenu extends StatelessWidget {
+class SideMenu extends ConsumerWidget {
   const SideMenu({super.key, required this.current});
 
   final SideMenuSection current;
@@ -35,7 +39,7 @@ class SideMenu extends StatelessWidget {
   }
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final items = <Widget>[
       DrawerListTile(
         title: 'Menu Principal',
@@ -71,6 +75,11 @@ class SideMenu extends StatelessWidget {
             title: 'Cadastro de Máquinas',
             svgSrc: 'assets/icons/menu_setting.svg',
             press: () => _navigate(context, const CadastroMaquinasPage()),
+          ),
+          DrawerListTile(
+            title: 'Gerenciar Acessos',
+            svgSrc: 'assets/icons/menu_profile.svg',
+            press: () => _navigate(context, const UsersPage()),
           ),
         ]);
         break;
@@ -137,7 +146,22 @@ class SideMenu extends StatelessWidget {
           DrawerListTile(
             title: 'Supervisão',
             svgSrc: 'assets/icons/menu_task.svg',
-            press: () => _navigate(context, MainScreen()),
+            press: () async {
+              var auth = ref.read(authServiceProvider);
+              if (auth == null) {
+                final ok = await Navigator.of(context).push<bool>(
+                  MaterialPageRoute(builder: (_) => const LoginPage()),
+                );
+                if (ok != true) return;
+                auth = ref.read(authServiceProvider);
+              }
+              if (auth == null || !auth.isAdmin) {
+                ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
+                    content: Text('Acesso restrito a administradores')));
+                return;
+              }
+              _navigate(context, MainScreen());
+            },
           ),
         ]);
     }

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -1,0 +1,48 @@
+import 'dart:convert';
+
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:http/http.dart' as http;
+
+class AuthState {
+  const AuthState(
+      {required this.username, required this.password, required this.isAdmin});
+
+  final String username;
+  final String password;
+  final bool isAdmin;
+}
+
+class AuthService extends StateNotifier<AuthState?> {
+  AuthService(this._client, this._baseUrl) : super(null);
+
+  final http.Client _client;
+  final String _baseUrl;
+
+  Future<bool> login(String username, String password) async {
+    final uri = Uri.parse('$_baseUrl/login');
+    final resp = await _client.post(uri,
+        headers: {'Content-Type': 'application/json'},
+        body: jsonEncode({'username': username, 'password': password}));
+    if (resp.statusCode == 200) {
+      final data = jsonDecode(resp.body) as Map<String, dynamic>;
+      final user = data['user'] as Map<String, dynamic>;
+      state = AuthState(
+          username: user['username'] as String,
+          password: password,
+          isAdmin: (user['is_admin'] as int) == 1);
+      return true;
+    }
+    return false;
+  }
+
+  void logout() {
+    state = null;
+  }
+}
+
+final authServiceProvider =
+    StateNotifierProvider<AuthService, AuthState?>((ref) {
+  final baseUrl = dotenv.env['API_BASE_URL'] ?? 'http://localhost:5000';
+  return AuthService(http.Client(), baseUrl);
+});

--- a/lib/services/user_service.dart
+++ b/lib/services/user_service.dart
@@ -1,0 +1,49 @@
+import 'dart:convert';
+
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:http/http.dart' as http;
+
+import '../models/user.dart';
+
+class UserService {
+  UserService({http.Client? client, String? baseUrl})
+      : _client = client ?? http.Client(),
+        _baseUrl =
+            baseUrl ?? dotenv.env['API_BASE_URL'] ?? 'http://localhost:5000';
+
+  final http.Client _client;
+  final String _baseUrl;
+
+  Map<String, String> _authHeader(String username, String password) {
+    final token = base64Encode(utf8.encode('$username:$password'));
+    return {
+      'Authorization': 'Basic $token',
+      'Content-Type': 'application/json'
+    };
+  }
+
+  Future<List<AppUser>> fetchUsers(String username, String password) async {
+    final uri = Uri.parse('$_baseUrl/usuarios');
+    final resp = await _client.get(uri, headers: _authHeader(username, password));
+    if (resp.statusCode != 200) {
+      throw Exception('Falha ao carregar usuários');
+    }
+    final data = jsonDecode(resp.body) as List;
+    return data
+        .map((e) => AppUser.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  Future<bool> createUser(String username, String password, bool isAdmin,
+      String adminUser, String adminPass) async {
+    final uri = Uri.parse('$_baseUrl/usuarios');
+    final resp = await _client.post(uri,
+        headers: _authHeader(adminUser, adminPass),
+        body: jsonEncode({
+          'username': username,
+          'password': password,
+          'is_admin': isAdmin ? 1 : 0
+        }));
+    return resp.statusCode == 200;
+  }
+}


### PR DESCRIPTION
## Summary
- secure `/usuarios` endpoint with basic admin auth
- allow Flutter admins to manage user access via new page and menu options
- gate supervision features behind administrator logins

## Testing
- `dart format lib/services/auth_service.dart lib/models/user.dart lib/services/user_service.dart lib/features/users/users_page.dart lib/screens/dashboard/components/header.dart lib/features/main_menu/main_menu_page.dart lib/screens/main/components/side_menu.dart` *(command not found)*
- `flutter test` *(command not found)*
- `python -m py_compile app_db.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5b94d76b48331996f8f6e13979365