### PR TITLE
Normaliza OS ao buscar relatórios de operador

### DIFF
--- a/lib/services/report_service.dart
+++ b/lib/services/report_service.dart
@@ -5,6 +5,7 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:http/http.dart' as http;
 
 import '../models/report.dart';
+import '../utils/string_utils.dart';
 
 /// Service responsible for fetching reports from the backend API.
 class ReportService {
@@ -56,7 +57,10 @@ class ReportService {
   /// Fetch releases performed by operators for a specific OS.
   Future<List<Report>> fetchOperatorReleasesByOs(String os) async {
     try {
-      final uri = Uri.parse('$_baseUrl/reports/operador?os=$os');
+      final normalized = normalizeCode(os);
+      final uri = Uri.parse(_baseUrl)
+          .resolve('reports/operador')
+          .replace(queryParameters: {'os': normalized});
       final response = await _client.get(uri);
       if (response.statusCode == 200) {
         return Report.listFromResponse(response.body);

--- a/test/report_service_test.dart
+++ b/test/report_service_test.dart
@@ -1,0 +1,19 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/testing.dart';
+import 'package:http/http.dart' as http;
+
+import 'package:admin/services/report_service.dart';
+
+void main() {
+  test('normalizes OS parameter before request', () async {
+    late Uri requestedUri;
+    final client = MockClient((req) async {
+      requestedUri = req.url;
+      return http.Response('[]', 200);
+    });
+    final service = ReportService(client: client, baseUrl: 'http://dummy');
+    await service.fetchOperatorReleasesByOs('000123');
+    expect(requestedUri.path, '/reports/operador');
+    expect(requestedUri.queryParameters['os'], '123');
+  });
+}


### PR DESCRIPTION
## Summary
- sanitize OS code in report service to avoid missing data
- add tests covering normalization logic for operator report fetch

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_68b5cb8b64ac8331af0358fa7e926e25