### PR TITLE
Fix operator chart status parsing

### DIFF
--- a/lib/features/operador/data/models.dart
+++ b/lib/features/operador/data/models.dart
@@ -23,7 +23,8 @@ StatusMedida statusFromString(String? s) {
     case 'alerta_abaixo':
     case 'alerta abaixo':
       return StatusMedida.alertaAbaixo;
-      // dados antigos sem direção
+    case 'alerta':
+      // Dados antigos sem direção definida
       return StatusMedida.alertaAcima;
 
     case 'reprovada_acima':

--- a/lib/screens/dashboard/components/operator_report_chart.dart
+++ b/lib/screens/dashboard/components/operator_report_chart.dart
@@ -36,12 +36,19 @@ class _OperatorReportChartState extends State<OperatorReportChart> {
   }
 
   double _statusToValue(String status) {
-    final st = status.toLowerCase();
-    if (st.contains('reprov') && st.contains('abaixo')) return -2;
-    if (st.contains('alerta') && st.contains('abaixo')) return -1;
-    if (st.contains('alerta') && st.contains('acima')) return 1;
-    if (st.contains('reprov') && st.contains('acima')) return 2;
-    return 0; // ok/aprovado/pendente
+    switch (statusFromString(status)) {
+      case StatusMedida.reprovadaAbaixo:
+        return -2;
+      case StatusMedida.alertaAbaixo:
+        return -1;
+      case StatusMedida.ok:
+      case StatusMedida.pendente:
+        return 0;
+      case StatusMedida.alertaAcima:
+        return 1;
+      case StatusMedida.reprovadaAcima:
+        return 2;
+    }
   }
 
   Color _statusColor(StatusMedida st) {


### PR DESCRIPTION
## Summary
- handle legacy 'alerta' status by mapping to a valid enum
- use shared status parser for operator chart values

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ccc7bdf08331a320fb3f044e9e56