### PR TITLE
Ensure machine code is sent with preparation results

### DIFF
--- a/lib/features/operador/data/models.dart
+++ b/lib/features/operador/data/models.dart
@@ -293,12 +293,14 @@ class PreparacaoResultado {
   final String re;
   final String partnumber;
   final String operacao;
+  final String maquina;
   final List<MedidaItem> medidas;
 
   PreparacaoResultado({
     required this.re,
     required this.partnumber,
     required this.operacao,
+    required this.maquina,
     required this.medidas,
   });
 
@@ -306,6 +308,7 @@ class PreparacaoResultado {
     're': re,
     'partnumber': normalizeCode(partnumber),
     'operacao': normalizeCode(operacao),
+    'maquina': maquina,
     'medidas': medidas.map((e) => e.toMap()).toList(),
   };
 

--- a/lib/features/preparacao/data/models.dart
+++ b/lib/features/preparacao/data/models.dart
@@ -291,12 +291,14 @@ class PreparacaoResultado {
   final String re;
   final String partnumber;
   final String operacao;
+  final String maquina;
   final List<MedidaItem> medidas;
 
   PreparacaoResultado({
     required this.re,
     required this.partnumber,
     required this.operacao,
+    required this.maquina,
     required this.medidas,
   });
 
@@ -304,6 +306,7 @@ class PreparacaoResultado {
     're': re,
     'partnumber': normalizeCode(partnumber),
     'operacao': normalizeCode(operacao),
+    'maquina': maquina,
     'medidas': medidas.map((e) => e.toMap()).toList(),
   };
 


### PR DESCRIPTION
## Summary
- include `maquina` field in `PreparacaoResultado` models so machine selection is persisted

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d701a3008331a63a3da7febeeaa9