### PR TITLE
Include preparer measures in FOR07 reports

### DIFF
--- a/app_db.py
+++ b/app_db.py
@@ -1545,10 +1545,12 @@ def listar_relatorios_preparador():
             with c.cursor() as cur:
                 cur.execute(
                     """
-                    SELECT os, partnumber, operacao, re_preparador, status_geral, created_at
-                    FROM preparador_liberacao
-                    ORDER BY created_at DESC
-                    LIMIT 200
+                    SELECT r.os, r.partnumber, r.operacao, r.re_preparador,
+                           i.idx_medida, i.titulo, i.status, i.created_at
+                      FROM preparador_registro r
+                      JOIN preparador_registro_item i ON i.registro_id = r.id
+                     ORDER BY i.created_at
+                     LIMIT 200
                     """
                 )
                 rows = cur.fetchall()
@@ -1670,10 +1672,12 @@ def exportar_relatorio_excel():
                 if tipo == "FOR07":
                     cur.execute(
                         """
-                        SELECT os, partnumber, operacao, re_preparador, status_geral, maquina, created_at
-                        FROM preparador_liberacao
-                        WHERE os=%s
-                        ORDER BY created_at DESC
+                        SELECT r.os, r.partnumber, r.operacao, r.re_preparador,
+                               i.idx_medida, i.titulo, i.medicao, i.status, i.observacao, i.created_at
+                          FROM preparador_registro r
+                          JOIN preparador_registro_item i ON i.registro_id = r.id
+                         WHERE r.os=%s
+                         ORDER BY i.created_at
                         """,
                         (os_num,),
                     )
@@ -1683,8 +1687,11 @@ def exportar_relatorio_excel():
                         "partnumber",
                         "operacao",
                         "re_preparador",
-                        "status_geral",
-                        "maquina",
+                        "idx_medida",
+                        "titulo",
+                        "medicao",
+                        "status",
+                        "observacao",
                         "created_at",
                     ]
                 else:


### PR DESCRIPTION
## Summary
- fetch all preparer measurements for FOR07 reports instead of only machine releases
- export FOR07 Excel files with detailed preparer measurement data
- query preparer measurements chronologically

## Testing
- `flutter test` *(fails: command not found)*
- `python -m py_compile app_db.py`

------
https://chatgpt.com/codex/tasks/task_e_68b5de15ef648331b3a7a3153ed9c25c