### PR TITLE
Normalize OS in report service

### DIFF
--- a/lib/services/report_service.dart
+++ b/lib/services/report_service.dart
@@ -74,8 +74,10 @@ class ReportService {
   Future<Map<String, dynamic>?> fetchOsReport(String os,
       {String section = 'full'}) async {
     try {
-      final uri =
-          Uri.parse('$_baseUrl/reports/os?os=$os&section=$section');
+      final normalized = normalizeCode(os);
+      final uri = Uri.parse(_baseUrl)
+          .resolve('reports/os')
+          .replace(queryParameters: {'os': normalized, 'section': section});
       final response = await _client.get(uri);
       if (response.statusCode == 200) {
         return jsonDecode(response.body) as Map<String, dynamic>;
@@ -88,10 +90,13 @@ class ReportService {
   /// Returns `true` if the file was saved successfully.
   Future<bool> exportToExcel({required String os, required String tipo}) async {
     try {
-      final uri = Uri.parse('$_baseUrl/reports/export?os=$os&type=$tipo');
+      final normalized = normalizeCode(os);
+      final uri = Uri.parse(_baseUrl)
+          .resolve('reports/export')
+          .replace(queryParameters: {'os': normalized, 'type': tipo});
       final response = await _client.get(uri);
       if (response.statusCode == 200) {
-        final file = File('relatorio_${os}_$tipo.xlsx');
+        final file = File('relatorio_${normalized}_$tipo.xlsx');
         await file.writeAsBytes(response.bodyBytes);
         return true;
       }

--- a/test/report_service_test.dart
+++ b/test/report_service_test.dart
@@ -17,14 +17,14 @@ void main() {
     expect(requestedUri.queryParameters['os'], '123');
   });
 
-  test('fetchOsReport forwards section parameter', () async {
+  test('fetchOsReport normalizes OS and forwards section parameter', () async {
     late Uri requestedUri;
     final client = MockClient((req) async {
       requestedUri = req.url;
       return http.Response('{"liberacao": []}', 200);
     });
     final service = ReportService(client: client, baseUrl: 'http://dummy');
-    await service.fetchOsReport('456', section: 'liberacao');
+    await service.fetchOsReport('000456', section: 'liberacao');
     expect(requestedUri.path, '/reports/os');
     expect(requestedUri.queryParameters['section'], 'liberacao');
     expect(requestedUri.queryParameters['os'], '456');


### PR DESCRIPTION
## Summary
- normalize OS and use Uri builders for report requests
- ensure Excel export uses normalized OS values
- test fetchOsReport query parameter handling

## Testing
- `dart format lib/services/report_service.dart test/report_service_test.dart` *(fails: command not found)*
- `flutter format lib/services/report_service.dart test/report_service_test.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6d52124748331b5cb0b9bc30e8198