### PR TITLE
Fix preparador reports endpoint

### DIFF
--- a/app_db.py
+++ b/app_db.py
@@ -1681,6 +1681,7 @@ def operador_encerrar_producao():
         return jsonify({"error": f"Falha ao encerrar produção: {e}"}), 500
 
 @app.route("/reports")
+@app.route("/reports/preparador")
 def listar_relatorios():
     try:
         with _conn_db(DB_NAME) as c:

--- a/test/report_service_test.dart
+++ b/test/report_service_test.dart
@@ -5,6 +5,17 @@ import 'package:http/http.dart' as http;
 import 'package:admin/services/report_service.dart';
 
 void main() {
+  test('fetchPreparerReleases hits preparador endpoint', () async {
+    late Uri requestedUri;
+    final client = MockClient((req) async {
+      requestedUri = req.url;
+      return http.Response('[]', 200);
+    });
+    final service = ReportService(client: client, baseUrl: 'http://dummy');
+    await service.fetchPreparerReleases();
+    expect(requestedUri.path, '/reports/preparador');
+  });
+
   test('normalizes OS parameter before request', () async {
     late Uri requestedUri;
     final client = MockClient((req) async {


### PR DESCRIPTION
## Summary
- add Flask route for `/reports/preparador`
- add unit test to ensure preparador reports use correct endpoint

## Testing
- `python -m py_compile app_db.py`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f37c23a48331b3a478c4f512f911