### PR TITLE
Atualiza nomenclatura dos status de amostragem

### DIFF
--- a/app_db.py
+++ b/app_db.py
@@ -958,7 +958,7 @@ def resultado_preparador():
           "faixaTexto": "...",
           "min": 1.23, "max": 4.56, "unidade": "mm",
           "medicao": "1.30",
-          "status": "ok|reprovada_acima|reprovada_abaixo|alerta_acima|alerta_abaixo|pendente",
+          "status": "OK|Reprovada acima|Reprovada abaixo|Alerta acima|Alerta abaixo|pendente",
           "observacao": ""
         }, ...
       ]
@@ -1464,7 +1464,7 @@ def operador_registrar():
           "indice": 0, "titulo": "...", "instrumento": "...",
           "faixaTexto": "...", "min": 1.23, "max": 4.56, "unidade": "mm",
           "periodicidade": "5 peças", "tolerancias": [..],
-          "escolha": "OK", "status": "ok|reprovada_acima|reprovada_abaixo|alerta_acima|alerta_abaixo",
+          "escolha": "OK", "status": "OK|Reprovada acima|Reprovada abaixo|Alerta acima|Alerta abaixo",
           "observacao": "..."
         }, ...
       ]

--- a/lib/features/finalizar_os/presentation/finalizar_os_page.dart
+++ b/lib/features/finalizar_os/presentation/finalizar_os_page.dart
@@ -25,10 +25,12 @@ class FinalizarOsPage extends ConsumerStatefulWidget {
 }
 
 final medidasFinalizadorControllerProvider =
-    StateNotifierProvider.autoDispose<MedidasFinalizadorController,
-    AsyncValue<List<MedidaItem>>>((ref) {
-  return MedidasFinalizadorController(ref);
-});
+    StateNotifierProvider.autoDispose<
+      MedidasFinalizadorController,
+      AsyncValue<List<MedidaItem>>
+    >((ref) {
+      return MedidasFinalizadorController(ref);
+    });
 
 class MedidasFinalizadorController
     extends StateNotifier<AsyncValue<List<MedidaItem>>> {
@@ -42,24 +44,28 @@ class MedidasFinalizadorController
     state = const AsyncValue.loading();
     try {
       final repo = _ref.read(finalizadorRepositoryProvider);
-      final itens =
-      await repo.getMedidas(partnumber: partnumber, operacao: operacao);
+      final itens = await repo.getMedidas(
+        partnumber: partnumber,
+        operacao: operacao,
+      );
 
       // Zera status/medição – sem copyWith
       final normalizados = itens
-          .map((m) => MedidaItem(
-        titulo: m.titulo,
-        faixaTexto: m.faixaTexto,
-        minimo: m.minimo,
-        maximo: m.maximo,
-        unidade: m.unidade,
-        status: StatusMedida.pendente,
-        medicao: null,
-        observacao: m.observacao,
-        periodicidade: m.periodicidade,
-        instrumento: m.instrumento,
-        tolerancias: m.tolerancias,
-      ))
+          .map(
+            (m) => MedidaItem(
+              titulo: m.titulo,
+              faixaTexto: m.faixaTexto,
+              minimo: m.minimo,
+              maximo: m.maximo,
+              unidade: m.unidade,
+              status: StatusMedida.pendente,
+              medicao: null,
+              observacao: m.observacao,
+              periodicidade: m.periodicidade,
+              instrumento: m.instrumento,
+              tolerancias: m.tolerancias,
+            ),
+          )
           .toList();
 
       state = AsyncValue.data(normalizados);
@@ -112,8 +118,8 @@ class MedidasFinalizadorController
 
 class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
   final _formKey = GlobalKey<FormState>();
-  final _reCtrl = TextEditingController();   // <<< RE
-  final _osCtrl = TextEditingController();   // <<< OS
+  final _reCtrl = TextEditingController(); // <<< RE
+  final _osCtrl = TextEditingController(); // <<< OS
   final _partCtrl = TextEditingController();
   final _opCtrl = TextEditingController();
 
@@ -145,13 +151,15 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
         setState(() {
           _maquinas.addAll(list);
           _categorias.addAll(
-              _maquinas.map((e) => e.categoria).toSet().toList()..sort());
+            _maquinas.map((e) => e.categoria).toSet().toList()..sort(),
+          );
         });
       }
     } catch (e) {
       if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(SnackBar(content: Text('Erro ao carregar máquinas: $e')));
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Erro ao carregar máquinas: $e')),
+        );
       }
     }
   }
@@ -171,15 +179,15 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
   String statusToString(StatusMedida st) {
     switch (st) {
       case StatusMedida.ok:
-        return 'aprovado';
+        return 'OK';
       case StatusMedida.reprovadaAbaixo:
-        return 'reprovada_abaixo';
+        return 'Reprovada abaixo';
       case StatusMedida.reprovadaAcima:
-        return 'reprovada_acima';
+        return 'Reprovada acima';
       case StatusMedida.alertaAbaixo:
-        return 'alerta_abaixo';
+        return 'Alerta abaixo';
       case StatusMedida.alertaAcima:
-        return 'alerta_acima';
+        return 'Alerta acima';
       case StatusMedida.pendente:
         return 'pendente';
     }
@@ -194,7 +202,9 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
         (_maquinaSel ?? '').isEmpty) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Preencha RE, O.S. e máquina para registrar.')),
+        const SnackBar(
+          content: Text('Preencha RE, O.S. e máquina para registrar.'),
+        ),
       );
       return;
     }
@@ -256,37 +266,40 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
 
       if (resp.statusCode == 200) {
         final data = jsonDecode(resp.body);
-        final statusGeral =
-            (data['status_geral'] ?? '').toString().toLowerCase();
+        final statusGeral = (data['status_geral'] ?? '')
+            .toString()
+            .toLowerCase();
         if (statusGeral.isNotEmpty) {
           setState(() => _osFinalizada = true);
         }
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text('OS finalizada com sucesso!')),
         );
-        ref
-            .read(medidasFinalizadorControllerProvider.notifier)
-            .resetSelecoes();
+        ref.read(medidasFinalizadorControllerProvider.notifier).resetSelecoes();
       } else if (resp.statusCode == 409) {
         final data = jsonDecode(resp.body);
         if ((data['code'] ?? '') == 'ja_finalizada') {
           setState(() => _osFinalizada = true);
         }
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Falha ao registrar: ${data['error'] ?? resp.body}')),
+          SnackBar(
+            content: Text('Falha ao registrar: ${data['error'] ?? resp.body}'),
+          ),
         );
       } else {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: Text('Falha ao registrar: ${resp.statusCode} ${resp.body}'),
+            content: Text(
+              'Falha ao registrar: ${resp.statusCode} ${resp.body}',
+            ),
           ),
         );
       }
     } catch (e) {
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Erro ao registrar: $e')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('Erro ao registrar: $e')));
     } finally {
       if (mounted) setState(() => _registrando = false);
     }
@@ -301,10 +314,12 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
     final reOk = _reCtrl.text.trim().isNotEmpty;
     final osOk = _osCtrl.text.trim().isNotEmpty;
     final maquinaOk = (_maquinaSel ?? '').isNotEmpty;
-    final todasOk = medidas.isNotEmpty &&
-        medidas.every((m) =>
-            (m.medicao ?? '').isNotEmpty &&
-                m.status != StatusMedida.pendente);
+    final todasOk =
+        medidas.isNotEmpty &&
+        medidas.every(
+          (m) =>
+              (m.medicao ?? '').isNotEmpty && m.status != StatusMedida.pendente,
+        );
     final podeRegistrar =
         reOk && osOk && maquinaOk && todasOk && !_registrando && !_osFinalizada;
 
@@ -316,11 +331,13 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
             padding: const EdgeInsets.only(right: 12.0),
             child: Center(
               child: Text(
-                Platform.isWindows ? 'Windows: leitura direta/API' : 'Android: via API',
+                Platform.isWindows
+                    ? 'Windows: leitura direta/API'
+                    : 'Android: via API',
                 style: const TextStyle(fontSize: 12),
               ),
             ),
-          )
+          ),
         ],
       ),
       drawer: const SideMenu(current: SideMenuSection.finalizar),
@@ -340,15 +357,19 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
                             controller: _reCtrl,
                             textInputAction: TextInputAction.next,
                             keyboardType: TextInputType.number,
-                            inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                            inputFormatters: [
+                              FilteringTextInputFormatter.digitsOnly,
+                            ],
                             decoration: const InputDecoration(
-                              labelText: 'R.E. do Preparador', // ajuste o texto se for Operador
+                              labelText:
+                                  'R.E. do Preparador', // ajuste o texto se for Operador
                               border: OutlineInputBorder(),
                             ),
                             validator: (v) {
                               final s = (v ?? '').trim();
                               if (s.isEmpty) return 'Obrigatório';
-                              if (!RegExp(r'^\d+$').hasMatch(s)) return 'Apenas números';
+                              if (!RegExp(r'^\d+$').hasMatch(s))
+                                return 'Apenas números';
                               return null;
                             },
                           ),
@@ -360,7 +381,9 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
                             controller: _osCtrl,
                             textInputAction: TextInputAction.next,
                             keyboardType: TextInputType.number,
-                            inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                            inputFormatters: [
+                              FilteringTextInputFormatter.digitsOnly,
+                            ],
                             decoration: const InputDecoration(
                               labelText: 'O.S.',
                               border: OutlineInputBorder(),
@@ -368,7 +391,8 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
                             validator: (v) {
                               final s = (v ?? '').trim();
                               if (s.isEmpty) return 'Obrigatório';
-                              if (!RegExp(r'^\d+$').hasMatch(s)) return 'Apenas números';
+                              if (!RegExp(r'^\d+$').hasMatch(s))
+                                return 'Apenas números';
                               return null;
                             },
                           ),
@@ -388,8 +412,12 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
                               border: OutlineInputBorder(),
                             ),
                             items: _categorias
-                                .map((c) =>
-                                    DropdownMenuItem(value: c, child: Text(c)))
+                                .map(
+                                  (c) => DropdownMenuItem(
+                                    value: c,
+                                    child: Text(c),
+                                  ),
+                                )
                                 .toList(),
                             onChanged: (v) => setState(() {
                               _categoriaSel = v;
@@ -409,11 +437,14 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
                             ),
                             items: _maquinas
                                 .where((m) => m.categoria == _categoriaSel)
-                                .map((m) => DropdownMenuItem(
-                                    value: m.codigo, child: Text(m.codigo)))
+                                .map(
+                                  (m) => DropdownMenuItem(
+                                    value: m.codigo,
+                                    child: Text(m.codigo),
+                                  ),
+                                )
                                 .toList(),
-                            onChanged: (v) =>
-                                setState(() => _maquinaSel = v),
+                            onChanged: (v) => setState(() => _maquinaSel = v),
                             validator: (v) =>
                                 (v == null || v.isEmpty) ? 'Obrigatório' : null,
                           ),
@@ -434,8 +465,9 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
                               labelText: 'Código da peça (PartNumber)',
                               border: OutlineInputBorder(),
                             ),
-                            validator: (v) =>
-                            (v == null || v.trim().isEmpty) ? 'Obrigatório' : null,
+                            validator: (v) => (v == null || v.trim().isEmpty)
+                                ? 'Obrigatório'
+                                : null,
                           ),
                         ),
                         const SizedBox(width: 12),
@@ -444,7 +476,9 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
                           child: TextFormField(
                             controller: _opCtrl,
                             keyboardType: TextInputType.number,
-                            inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                            inputFormatters: [
+                              FilteringTextInputFormatter.digitsOnly,
+                            ],
                             decoration: const InputDecoration(
                               labelText: 'Operação',
                               border: OutlineInputBorder(),
@@ -452,7 +486,8 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
                             validator: (v) {
                               final s = (v ?? '').trim();
                               if (s.isEmpty) return 'Obrigatório';
-                              if (!RegExp(r'^\d+$').hasMatch(s)) return 'Apenas números';
+                              if (!RegExp(r'^\d+$').hasMatch(s))
+                                return 'Apenas números';
                               return null;
                             },
                           ),
@@ -468,11 +503,13 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
                           if (_formKey.currentState!.validate()) {
                             FocusScope.of(context).unfocus();
                             await ref
-                                .read(medidasFinalizadorControllerProvider.notifier)
+                                .read(
+                                  medidasFinalizadorControllerProvider.notifier,
+                                )
                                 .carregar(
-                              partnumber: normalizeCode(_partCtrl.text),
-                              operacao: normalizeCode(_opCtrl.text),
-                            );
+                                  partnumber: normalizeCode(_partCtrl.text),
+                                  operacao: normalizeCode(_opCtrl.text),
+                                );
                           }
                         },
                         icon: const Icon(Icons.search),
@@ -488,7 +525,9 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
                   data: (list) {
                     if (list.isEmpty) {
                       return const Center(
-                        child: Text('Nenhuma medida encontrada para a chave informada.'),
+                        child: Text(
+                          'Nenhuma medida encontrada para a chave informada.',
+                        ),
                       );
                     }
                     return ListView.separated(
@@ -500,16 +539,18 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
                           index: index,
                           item: item,
                           onChanged: (status, valor) => ref
-                              .read(medidasFinalizadorControllerProvider.notifier)
+                              .read(
+                                medidasFinalizadorControllerProvider.notifier,
+                              )
                               .setStatusAndMedicao(index, status, valor),
                         );
                       },
                     );
                   },
-                  loading: () => const Center(child: CircularProgressIndicator()),
-                  error: (e, _) => Center(
-                    child: Text('Erro ao carregar:\n${e.toString()}'),
-                  ),
+                  loading: () =>
+                      const Center(child: CircularProgressIndicator()),
+                  error: (e, _) =>
+                      Center(child: Text('Erro ao carregar:\n${e.toString()}')),
                 ),
               ),
               const SizedBox(height: 10),
@@ -521,7 +562,8 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
                       ? const SizedBox(
                           width: 18,
                           height: 18,
-                          child: CircularProgressIndicator(strokeWidth: 2))
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
                       : const Icon(Icons.save_outlined),
                   label: const Text('Finalizar OS'),
                 ),
@@ -569,7 +611,8 @@ class _MeasurementTilePrepState extends State<_MeasurementTilePrep> {
 
   void _setTextFromParent(String? txt) {
     final newText = (txt ?? '');
-    if (newText == _ctrl.text) return; // evita sobrescrever e mexer no cursor à toa
+    if (newText == _ctrl.text)
+      return; // evita sobrescrever e mexer no cursor à toa
     _ctrl.value = TextEditingValue(
       text: newText,
       // cursor no final do texto (sem selecionar tudo)
@@ -637,53 +680,60 @@ class _MeasurementTilePrepState extends State<_MeasurementTilePrep> {
       elevation: 0.5,
       child: Padding(
         padding: const EdgeInsets.all(12.0),
-        child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
-          Row(
-            children: [
-              Container(
-                width: 10,
-                height: 10,
-                decoration:
-                BoxDecoration(color: _statusColor(st), shape: BoxShape.circle),
-              ),
-              const SizedBox(width: 8),
-              Expanded(
-                child: Text(m.titulo.isEmpty ? '(sem título)' : m.titulo,
-                    style: Theme.of(context).textTheme.titleMedium),
-              ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Container(
+                  width: 10,
+                  height: 10,
+                  decoration: BoxDecoration(
+                    color: _statusColor(st),
+                    shape: BoxShape.circle,
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    m.titulo.isEmpty ? '(sem título)' : m.titulo,
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                ),
+              ],
+            ),
+            if (subtitulo.isNotEmpty) ...[
+              const SizedBox(height: 4),
+              Text(subtitulo, style: Theme.of(context).textTheme.bodyMedium),
             ],
-          ),
-          if (subtitulo.isNotEmpty) ...[
-            const SizedBox(height: 4),
-            Text(subtitulo, style: Theme.of(context).textTheme.bodyMedium),
+            const SizedBox(height: 10),
+            TextField(
+              controller: _ctrl,
+              keyboardType: const TextInputType.numberWithOptions(
+                decimal: true,
+                signed: false,
+              ),
+              decoration: InputDecoration(
+                labelText: 'Medição (${m.unidade ?? ''})',
+                border: const OutlineInputBorder(),
+                helperText: st == StatusMedida.ok
+                    ? 'Dentro da tolerância'
+                    : st == StatusMedida.pendente
+                    ? 'Preencha o valor para classificar'
+                    : (st == StatusMedida.reprovadaAbaixo
+                          ? 'Abaixo do mínimo'
+                          : 'Acima do máximo'),
+                helperStyle: TextStyle(color: _statusColor(st)),
+              ),
+              onChanged: (txt) {
+                final v = _toDouble(txt);
+                final novoStatus = _classifica(v, m.minimo, m.maximo);
+                widget.onChanged(novoStatus, txt);
+                setState(() {});
+              },
+            ),
           ],
-          const SizedBox(height: 10),
-          TextField(
-            controller: _ctrl,
-            keyboardType: const TextInputType.numberWithOptions(
-              decimal: true,
-              signed: false,
-            ),
-            decoration: InputDecoration(
-              labelText: 'Medição (${m.unidade ?? ''})',
-              border: const OutlineInputBorder(),
-              helperText: st == StatusMedida.ok
-                  ? 'Dentro da tolerância'
-                  : st == StatusMedida.pendente
-                  ? 'Preencha o valor para classificar'
-                  : (st == StatusMedida.reprovadaAbaixo
-                  ? 'Abaixo do mínimo'
-                  : 'Acima do máximo'),
-              helperStyle: TextStyle(color: _statusColor(st)),
-            ),
-            onChanged: (txt) {
-              final v = _toDouble(txt);
-              final novoStatus = _classifica(v, m.minimo, m.maximo);
-              widget.onChanged(novoStatus, txt);
-              setState(() {});
-            },
-          ),
-        ]),
+        ),
       ),
     );
   }

--- a/lib/features/operador/data/models.dart
+++ b/lib/features/operador/data/models.dart
@@ -9,7 +9,7 @@ enum StatusMedida {
   alertaAbaixo,
   reprovadaAcima,
   reprovadaAbaixo,
-  pendente
+  pendente,
 }
 
 StatusMedida statusFromString(String? s) {
@@ -28,11 +28,13 @@ StatusMedida statusFromString(String? s) {
       return StatusMedida.alertaAcima;
 
     case 'reprovada_acima':
+    case 'reprovada acima':
     case 'acima':
     case 'reprovada':
     case 'reprovado':
       return StatusMedida.reprovadaAcima;
     case 'reprovada_abaixo':
+    case 'reprovada abaixo':
     case 'abaixo':
       return StatusMedida.reprovadaAbaixo;
     default:
@@ -43,16 +45,16 @@ StatusMedida statusFromString(String? s) {
 String statusToString(StatusMedida s) {
   switch (s) {
     case StatusMedida.ok:
-
-      return 'ok';
+      return 'OK';
     case StatusMedida.alertaAcima:
-      return 'alerta_acima';
+      return 'Alerta acima';
     case StatusMedida.alertaAbaixo:
-      return 'alerta_abaixo';
+      return 'Alerta abaixo';
 
     case StatusMedida.reprovadaAcima:
+      return 'Reprovada acima';
     case StatusMedida.reprovadaAbaixo:
-      return 'reprovado';
+      return 'Reprovada abaixo';
     case StatusMedida.pendente:
       return 'pendente';
   }
@@ -61,17 +63,22 @@ String statusToString(StatusMedida s) {
 class MedidaItem {
   // Básicos
   final String titulo;
+
   /// Texto amigável da faixa (ex.: "10,00 ~ 12,00 mm", "≥ 15,30 mm", "≤ 3,2 µm")
   final String faixaTexto;
+
   /// Limite mínimo aceito (opcional).
   final double? minimo;
+
   /// Limite máximo aceito (opcional).
   final double? maximo;
+
   /// Unidade de medida (ex.: "mm", "°", "µm", etc.).
   final String? unidade;
 
   // Metadados
   final StatusMedida status;
+
   /// Mantido como String? para compatibilidade com o restante do app.
   final String? medicao;
   final String? observacao;
@@ -121,10 +128,16 @@ class MedidaItem {
 
   static String _normalizeLower(String s) {
     final rep = {
-      'á': 'a', 'à': 'a', 'â': 'a', 'ã': 'a',
-      'é': 'e', 'ê': 'e',
+      'á': 'a',
+      'à': 'a',
+      'â': 'a',
+      'ã': 'a',
+      'é': 'e',
+      'ê': 'e',
       'í': 'i',
-      'ó': 'o', 'ô': 'o', 'õ': 'o',
+      'ó': 'o',
+      'ô': 'o',
+      'õ': 'o',
       'ú': 'u',
       'ç': 'c',
     };
@@ -160,7 +173,9 @@ class MedidaItem {
   ///  - Único valor: retorna (v,v,uni)
   ///  - Com token “minimo” → (v,null,uni)
   ///  - Com token “maximo” → (null,v,uni)
-  static ({double? min, double? max, String? uni}) _parseRangeAny(String texto) {
+  static ({double? min, double? max, String? uni}) _parseRangeAny(
+    String texto,
+  ) {
     if (texto.trim().isEmpty) return (min: null, max: null, uni: null);
     final s = texto.trim();
 
@@ -172,9 +187,13 @@ class MedidaItem {
     if (m != null) {
       var v1 = _toDouble(m.group(1));
       var v2 = _toDouble(m.group(2));
-      final uni = (m.group(3) ?? '').trim().isEmpty ? null : (m.group(3) ?? '').trim();
+      final uni = (m.group(3) ?? '').trim().isEmpty
+          ? null
+          : (m.group(3) ?? '').trim();
       if (v1 != null && v2 != null && v1 > v2) {
-        final tmp = v1; v1 = v2; v2 = tmp;
+        final tmp = v1;
+        v1 = v2;
+        v2 = tmp;
       }
       return (min: v1, max: v2, uni: uni);
     }
@@ -182,7 +201,9 @@ class MedidaItem {
     // Único valor (com possíveis tokens de minimo/máximo)
     final v = _firstNumber(s);
     final uniMatch = RegExp(r'[a-zA-Zµ°]+[a-zA-Z0-9/%²³]*$').firstMatch(s);
-    final uni = (uniMatch?.group(0) ?? '').trim().isEmpty ? null : uniMatch!.group(0)!.trim();
+    final uni = (uniMatch?.group(0) ?? '').trim().isEmpty
+        ? null
+        : uniMatch!.group(0)!.trim();
 
     if (v == null) return (min: null, max: null, uni: null);
 
@@ -215,17 +236,21 @@ class MedidaItem {
 
     double? minimo = _toDouble(map['minimo'] ?? map['min']);
     double? maximo = _toDouble(map['maximo'] ?? map['max']);
-    String? uni    = (map['unidade']?.toString().trim().isEmpty ?? true)
+    String? uni = (map['unidade']?.toString().trim().isEmpty ?? true)
         ? null
         : map['unidade']!.toString().trim();
 
     // Se não veio min/max, tenta extrair da faixa; se ainda não, tenta do título.
     if (minimo == null && maximo == null) {
       final r1 = _parseRangeAny(faixa);
-      minimo = r1.min; maximo = r1.max; uni ??= r1.uni;
+      minimo = r1.min;
+      maximo = r1.max;
+      uni ??= r1.uni;
       if (minimo == null && maximo == null) {
         final r2 = _parseRangeAny(titulo);
-        minimo = r2.min; maximo = r2.max; uni ??= r2.uni;
+        minimo = r2.min;
+        maximo = r2.max;
+        uni ??= r2.uni;
       }
     }
 
@@ -243,16 +268,18 @@ class MedidaItem {
     // valores absolutos ordenados quando tratar-se de ângulo.
     final tituloNorm = _normalizeLower(titulo);
     final isAngulo =
-        (uni != null && RegExp(r'[°º]').hasMatch(uni)) || tituloNorm.contains('angulo');
+        (uni != null && RegExp(r'[°º]').hasMatch(uni)) ||
+        tituloNorm.contains('angulo');
     if (isAngulo && minimo != null && maximo != null) {
-      final vals = [minimo!.abs(), maximo!.abs()]
-        ..sort();
+      final vals = [minimo!.abs(), maximo!.abs()]..sort();
       minimo = vals.first;
       maximo = vals.last;
     }
 
     // Se faixaTexto veio vazio, monta automaticamente a partir de min/max/unidade
-    final faixaOut = (faixa.isNotEmpty) ? faixa : _makeFaixaTexto(minimo, maximo, uni);
+    final faixaOut = (faixa.isNotEmpty)
+        ? faixa
+        : _makeFaixaTexto(minimo, maximo, uni);
 
     // Tolerâncias para Operador (lista de rótulos), se existirem
     final tol = (map['tolerancias'] is List)

--- a/lib/features/preparacao/data/models.dart
+++ b/lib/features/preparacao/data/models.dart
@@ -9,7 +9,7 @@ enum StatusMedida {
   alertaAbaixo,
   reprovadaAcima,
   reprovadaAbaixo,
-  pendente
+  pendente,
 }
 
 StatusMedida statusFromString(String? s) {
@@ -27,11 +27,13 @@ StatusMedida statusFromString(String? s) {
       // suporte a registros antigos sem direção
       return StatusMedida.alertaAcima;
     case 'reprovada_acima':
+    case 'reprovada acima':
     case 'acima':
     case 'reprovada':
     case 'reprovado':
       return StatusMedida.reprovadaAcima;
     case 'reprovada_abaixo':
+    case 'reprovada abaixo':
     case 'abaixo':
       return StatusMedida.reprovadaAbaixo;
     default:
@@ -42,15 +44,15 @@ StatusMedida statusFromString(String? s) {
 String statusToString(StatusMedida s) {
   switch (s) {
     case StatusMedida.ok:
-
-      return 'ok';
+      return 'OK';
     case StatusMedida.alertaAcima:
-      return 'alerta_acima';
+      return 'Alerta acima';
     case StatusMedida.alertaAbaixo:
-      return 'alerta_abaixo';
+      return 'Alerta abaixo';
     case StatusMedida.reprovadaAcima:
+      return 'Reprovada acima';
     case StatusMedida.reprovadaAbaixo:
-      return 'reprovado';
+      return 'Reprovada abaixo';
     case StatusMedida.pendente:
       return 'pendente';
   }
@@ -59,17 +61,22 @@ String statusToString(StatusMedida s) {
 class MedidaItem {
   // Básicos
   final String titulo;
+
   /// Texto amigável da faixa (ex.: "10,00 ~ 12,00 mm", "≥ 15,30 mm", "≤ 3,2 µm")
   final String faixaTexto;
+
   /// Limite mínimo aceito (opcional).
   final double? minimo;
+
   /// Limite máximo aceito (opcional).
   final double? maximo;
+
   /// Unidade de medida (ex.: "mm", "°", "µm", etc.).
   final String? unidade;
 
   // Metadados
   final StatusMedida status;
+
   /// Mantido como String? para compatibilidade com o restante do app.
   final String? medicao;
   final String? observacao;
@@ -119,10 +126,16 @@ class MedidaItem {
 
   static String _normalizeLower(String s) {
     final rep = {
-      'á': 'a', 'à': 'a', 'â': 'a', 'ã': 'a',
-      'é': 'e', 'ê': 'e',
+      'á': 'a',
+      'à': 'a',
+      'â': 'a',
+      'ã': 'a',
+      'é': 'e',
+      'ê': 'e',
       'í': 'i',
-      'ó': 'o', 'ô': 'o', 'õ': 'o',
+      'ó': 'o',
+      'ô': 'o',
+      'õ': 'o',
       'ú': 'u',
       'ç': 'c',
     };
@@ -158,7 +171,9 @@ class MedidaItem {
   ///  - Único valor: retorna (v,v,uni)
   ///  - Com token “minimo” → (v,null,uni)
   ///  - Com token “maximo” → (null,v,uni)
-  static ({double? min, double? max, String? uni}) _parseRangeAny(String texto) {
+  static ({double? min, double? max, String? uni}) _parseRangeAny(
+    String texto,
+  ) {
     if (texto.trim().isEmpty) return (min: null, max: null, uni: null);
     final s = texto.trim();
 
@@ -170,9 +185,13 @@ class MedidaItem {
     if (m != null) {
       var v1 = _toDouble(m.group(1));
       var v2 = _toDouble(m.group(2));
-      final uni = (m.group(3) ?? '').trim().isEmpty ? null : (m.group(3) ?? '').trim();
+      final uni = (m.group(3) ?? '').trim().isEmpty
+          ? null
+          : (m.group(3) ?? '').trim();
       if (v1 != null && v2 != null && v1 > v2) {
-        final tmp = v1; v1 = v2; v2 = tmp;
+        final tmp = v1;
+        v1 = v2;
+        v2 = tmp;
       }
       return (min: v1, max: v2, uni: uni);
     }
@@ -180,7 +199,9 @@ class MedidaItem {
     // Único valor (com possíveis tokens de minimo/máximo)
     final v = _firstNumber(s);
     final uniMatch = RegExp(r'[a-zA-Zµ°]+[a-zA-Z0-9/%²³]*$').firstMatch(s);
-    final uni = (uniMatch?.group(0) ?? '').trim().isEmpty ? null : uniMatch!.group(0)!.trim();
+    final uni = (uniMatch?.group(0) ?? '').trim().isEmpty
+        ? null
+        : uniMatch!.group(0)!.trim();
 
     if (v == null) return (min: null, max: null, uni: null);
 
@@ -213,17 +234,21 @@ class MedidaItem {
 
     double? minimo = _toDouble(map['minimo'] ?? map['min']);
     double? maximo = _toDouble(map['maximo'] ?? map['max']);
-    String? uni    = (map['unidade']?.toString().trim().isEmpty ?? true)
+    String? uni = (map['unidade']?.toString().trim().isEmpty ?? true)
         ? null
         : map['unidade']!.toString().trim();
 
     // Se não veio min/max, tenta extrair da faixa; se ainda não, tenta do título.
     if (minimo == null && maximo == null) {
       final r1 = _parseRangeAny(faixa);
-      minimo = r1.min; maximo = r1.max; uni ??= r1.uni;
+      minimo = r1.min;
+      maximo = r1.max;
+      uni ??= r1.uni;
       if (minimo == null && maximo == null) {
         final r2 = _parseRangeAny(titulo);
-        minimo = r2.min; maximo = r2.max; uni ??= r2.uni;
+        minimo = r2.min;
+        maximo = r2.max;
+        uni ??= r2.uni;
       }
     }
 
@@ -241,16 +266,18 @@ class MedidaItem {
     // valores absolutos e ordenados quando o item é um ângulo.
     final tituloNorm = _normalizeLower(titulo);
     final isAngulo =
-        (uni != null && RegExp(r'[°º]').hasMatch(uni)) || tituloNorm.contains('angulo');
+        (uni != null && RegExp(r'[°º]').hasMatch(uni)) ||
+        tituloNorm.contains('angulo');
     if (isAngulo && minimo != null && maximo != null) {
-      final vals = [minimo!.abs(), maximo!.abs()]
-        ..sort();
+      final vals = [minimo!.abs(), maximo!.abs()]..sort();
       minimo = vals.first;
       maximo = vals.last;
     }
 
     // Se faixaTexto veio vazio, monta automaticamente a partir de min/max/unidade
-    final faixaOut = (faixa.isNotEmpty) ? faixa : _makeFaixaTexto(minimo, maximo, uni);
+    final faixaOut = (faixa.isNotEmpty)
+        ? faixa
+        : _makeFaixaTexto(minimo, maximo, uni);
 
     // Tolerâncias para Operador (lista de rótulos), se existirem
     final tol = (map['tolerancias'] is List)

--- a/lib/features/preparacao/presentation/preparacao_page.dart
+++ b/lib/features/preparacao/presentation/preparacao_page.dart
@@ -25,10 +25,12 @@ class PreparacaoPage extends ConsumerStatefulWidget {
 }
 
 final medidasPreparadorControllerProvider =
-StateNotifierProvider.autoDispose<MedidasPreparadorController,
-    AsyncValue<List<MedidaItem>>>((ref) {
-  return MedidasPreparadorController(ref);
-});
+    StateNotifierProvider.autoDispose<
+      MedidasPreparadorController,
+      AsyncValue<List<MedidaItem>>
+    >((ref) {
+      return MedidasPreparadorController(ref);
+    });
 
 class MedidasPreparadorController
     extends StateNotifier<AsyncValue<List<MedidaItem>>> {
@@ -42,24 +44,28 @@ class MedidasPreparadorController
     state = const AsyncValue.loading();
     try {
       final repo = _ref.read(preparadorRepositoryProvider);
-      final itens =
-      await repo.getMedidas(partnumber: partnumber, operacao: operacao);
+      final itens = await repo.getMedidas(
+        partnumber: partnumber,
+        operacao: operacao,
+      );
 
       // Zera status/medição – sem copyWith
       final normalizados = itens
-          .map((m) => MedidaItem(
-        titulo: m.titulo,
-        faixaTexto: m.faixaTexto,
-        minimo: m.minimo,
-        maximo: m.maximo,
-        unidade: m.unidade,
-        status: StatusMedida.pendente,
-        medicao: null,
-        observacao: m.observacao,
-        periodicidade: m.periodicidade,
-        instrumento: m.instrumento,
-        tolerancias: m.tolerancias,
-      ))
+          .map(
+            (m) => MedidaItem(
+              titulo: m.titulo,
+              faixaTexto: m.faixaTexto,
+              minimo: m.minimo,
+              maximo: m.maximo,
+              unidade: m.unidade,
+              status: StatusMedida.pendente,
+              medicao: null,
+              observacao: m.observacao,
+              periodicidade: m.periodicidade,
+              instrumento: m.instrumento,
+              tolerancias: m.tolerancias,
+            ),
+          )
           .toList();
 
       state = AsyncValue.data(normalizados);
@@ -112,8 +118,8 @@ class MedidasPreparadorController
 
 class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
   final _formKey = GlobalKey<FormState>();
-  final _reCtrl = TextEditingController();   // <<< RE
-  final _osCtrl = TextEditingController();   // <<< OS
+  final _reCtrl = TextEditingController(); // <<< RE
+  final _osCtrl = TextEditingController(); // <<< OS
   final _partCtrl = TextEditingController();
   final _opCtrl = TextEditingController();
 
@@ -145,13 +151,15 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
         setState(() {
           _maquinas.addAll(list);
           _categorias.addAll(
-              _maquinas.map((e) => e.categoria).toSet().toList()..sort());
+            _maquinas.map((e) => e.categoria).toSet().toList()..sort(),
+          );
         });
       }
     } catch (e) {
       if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(SnackBar(content: Text('Erro ao carregar máquinas: $e')));
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Erro ao carregar máquinas: $e')),
+        );
       }
     }
   }
@@ -171,15 +179,15 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
   String statusToString(StatusMedida st) {
     switch (st) {
       case StatusMedida.ok:
-        return 'aprovado';
+        return 'OK';
       case StatusMedida.reprovadaAbaixo:
-        return 'reprovada_abaixo';
+        return 'Reprovada abaixo';
       case StatusMedida.reprovadaAcima:
-        return 'reprovada_acima';
+        return 'Reprovada acima';
       case StatusMedida.alertaAbaixo:
-        return 'alerta_abaixo';
+        return 'Alerta abaixo';
       case StatusMedida.alertaAcima:
-        return 'alerta_acima';
+        return 'Alerta acima';
       case StatusMedida.pendente:
         return 'pendente';
     }
@@ -194,7 +202,9 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
         (_maquinaSel ?? '').isEmpty) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Preencha RE, O.S. e máquina para registrar.')),
+        const SnackBar(
+          content: Text('Preencha RE, O.S. e máquina para registrar.'),
+        ),
       );
       return;
     }
@@ -256,7 +266,9 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
 
       if (resp.statusCode == 200) {
         final data = jsonDecode(resp.body);
-        final statusGeral = (data['status_geral'] ?? '').toString().toLowerCase();
+        final statusGeral = (data['status_geral'] ?? '')
+            .toString()
+            .toLowerCase();
         final liberada = statusGeral == 'liberada';
         if (liberada) {
           setState(() => _osLiberada = true);
@@ -276,7 +288,9 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
           setState(() => _osLiberada = true);
         }
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Falha ao registrar: ${data['error'] ?? resp.body}')),
+          SnackBar(
+            content: Text('Falha ao registrar: ${data['error'] ?? resp.body}'),
+          ),
         );
         if (liberada) {
           await Future.delayed(const Duration(seconds: 1));
@@ -285,15 +299,17 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
       } else {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: Text('Falha ao registrar: ${resp.statusCode} ${resp.body}'),
+            content: Text(
+              'Falha ao registrar: ${resp.statusCode} ${resp.body}',
+            ),
           ),
         );
       }
     } catch (e) {
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Erro ao registrar: $e')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('Erro ao registrar: $e')));
     } finally {
       if (mounted) setState(() => _registrando = false);
     }
@@ -308,10 +324,12 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
     final reOk = _reCtrl.text.trim().isNotEmpty;
     final osOk = _osCtrl.text.trim().isNotEmpty;
     final maquinaOk = (_maquinaSel ?? '').isNotEmpty;
-    final todasOk = medidas.isNotEmpty &&
-        medidas.every((m) =>
-        (m.medicao ?? '').isNotEmpty &&
-            m.status != StatusMedida.pendente);
+    final todasOk =
+        medidas.isNotEmpty &&
+        medidas.every(
+          (m) =>
+              (m.medicao ?? '').isNotEmpty && m.status != StatusMedida.pendente,
+        );
     final podeRegistrar =
         reOk && osOk && maquinaOk && todasOk && !_registrando && !_osLiberada;
 
@@ -323,11 +341,13 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
             padding: const EdgeInsets.only(right: 12.0),
             child: Center(
               child: Text(
-                Platform.isWindows ? 'Windows: leitura direta/API' : 'Android: via API',
+                Platform.isWindows
+                    ? 'Windows: leitura direta/API'
+                    : 'Android: via API',
                 style: const TextStyle(fontSize: 12),
               ),
             ),
-          )
+          ),
         ],
       ),
       drawer: const SideMenu(current: SideMenuSection.preparador),
@@ -347,15 +367,19 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
                             controller: _reCtrl,
                             textInputAction: TextInputAction.next,
                             keyboardType: TextInputType.number,
-                            inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                            inputFormatters: [
+                              FilteringTextInputFormatter.digitsOnly,
+                            ],
                             decoration: const InputDecoration(
-                              labelText: 'R.E. do Preparador', // ajuste o texto se for Operador
+                              labelText:
+                                  'R.E. do Preparador', // ajuste o texto se for Operador
                               border: OutlineInputBorder(),
                             ),
                             validator: (v) {
                               final s = (v ?? '').trim();
                               if (s.isEmpty) return 'Obrigatório';
-                              if (!RegExp(r'^\d+$').hasMatch(s)) return 'Apenas números';
+                              if (!RegExp(r'^\d+$').hasMatch(s))
+                                return 'Apenas números';
                               return null;
                             },
                           ),
@@ -367,7 +391,9 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
                             controller: _osCtrl,
                             textInputAction: TextInputAction.next,
                             keyboardType: TextInputType.number,
-                            inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                            inputFormatters: [
+                              FilteringTextInputFormatter.digitsOnly,
+                            ],
                             decoration: const InputDecoration(
                               labelText: 'O.S.',
                               border: OutlineInputBorder(),
@@ -375,14 +401,14 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
                             validator: (v) {
                               final s = (v ?? '').trim();
                               if (s.isEmpty) return 'Obrigatório';
-                              if (!RegExp(r'^\d+$').hasMatch(s)) return 'Apenas números';
+                              if (!RegExp(r'^\d+$').hasMatch(s))
+                                return 'Apenas números';
                               return null;
                             },
                           ),
                         ),
                       ],
                     ),
-
 
                     const SizedBox(height: 12),
 
@@ -396,8 +422,12 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
                               border: OutlineInputBorder(),
                             ),
                             items: _categorias
-                                .map((c) =>
-                                    DropdownMenuItem(value: c, child: Text(c)))
+                                .map(
+                                  (c) => DropdownMenuItem(
+                                    value: c,
+                                    child: Text(c),
+                                  ),
+                                )
                                 .toList(),
                             onChanged: (v) => setState(() {
                               _categoriaSel = v;
@@ -417,11 +447,14 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
                             ),
                             items: _maquinas
                                 .where((m) => m.categoria == _categoriaSel)
-                                .map((m) => DropdownMenuItem(
-                                    value: m.codigo, child: Text(m.codigo)))
+                                .map(
+                                  (m) => DropdownMenuItem(
+                                    value: m.codigo,
+                                    child: Text(m.codigo),
+                                  ),
+                                )
                                 .toList(),
-                            onChanged: (v) =>
-                                setState(() => _maquinaSel = v),
+                            onChanged: (v) => setState(() => _maquinaSel = v),
                             validator: (v) =>
                                 (v == null || v.isEmpty) ? 'Obrigatório' : null,
                           ),
@@ -442,8 +475,9 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
                               labelText: 'Código da peça (PartNumber)',
                               border: OutlineInputBorder(),
                             ),
-                            validator: (v) =>
-                            (v == null || v.trim().isEmpty) ? 'Obrigatório' : null,
+                            validator: (v) => (v == null || v.trim().isEmpty)
+                                ? 'Obrigatório'
+                                : null,
                           ),
                         ),
                         const SizedBox(width: 12),
@@ -452,7 +486,9 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
                           child: TextFormField(
                             controller: _opCtrl,
                             keyboardType: TextInputType.number,
-                            inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                            inputFormatters: [
+                              FilteringTextInputFormatter.digitsOnly,
+                            ],
                             decoration: const InputDecoration(
                               labelText: 'Operação',
                               border: OutlineInputBorder(),
@@ -460,7 +496,8 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
                             validator: (v) {
                               final s = (v ?? '').trim();
                               if (s.isEmpty) return 'Obrigatório';
-                              if (!RegExp(r'^\d+$').hasMatch(s)) return 'Apenas números';
+                              if (!RegExp(r'^\d+$').hasMatch(s))
+                                return 'Apenas números';
                               return null;
                             },
                           ),
@@ -476,11 +513,13 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
                           if (_formKey.currentState!.validate()) {
                             FocusScope.of(context).unfocus();
                             await ref
-                                .read(medidasPreparadorControllerProvider.notifier)
+                                .read(
+                                  medidasPreparadorControllerProvider.notifier,
+                                )
                                 .carregar(
-                              partnumber: normalizeCode(_partCtrl.text),
-                              operacao: normalizeCode(_opCtrl.text),
-                            );
+                                  partnumber: normalizeCode(_partCtrl.text),
+                                  operacao: normalizeCode(_opCtrl.text),
+                                );
                           }
                         },
                         icon: const Icon(Icons.search),
@@ -496,7 +535,9 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
                   data: (list) {
                     if (list.isEmpty) {
                       return const Center(
-                        child: Text('Nenhuma medida encontrada para a chave informada.'),
+                        child: Text(
+                          'Nenhuma medida encontrada para a chave informada.',
+                        ),
                       );
                     }
                     return ListView.separated(
@@ -508,16 +549,18 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
                           index: index,
                           item: item,
                           onChanged: (status, valor) => ref
-                              .read(medidasPreparadorControllerProvider.notifier)
+                              .read(
+                                medidasPreparadorControllerProvider.notifier,
+                              )
                               .setStatusAndMedicao(index, status, valor),
                         );
                       },
                     );
                   },
-                  loading: () => const Center(child: CircularProgressIndicator()),
-                  error: (e, _) => Center(
-                    child: Text('Erro ao carregar:\n${e.toString()}'),
-                  ),
+                  loading: () =>
+                      const Center(child: CircularProgressIndicator()),
+                  error: (e, _) =>
+                      Center(child: Text('Erro ao carregar:\n${e.toString()}')),
                 ),
               ),
               const SizedBox(height: 10),
@@ -527,7 +570,10 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
                   onPressed: podeRegistrar ? _registrarResultado : null,
                   icon: _registrando
                       ? const SizedBox(
-                      width: 18, height: 18, child: CircularProgressIndicator(strokeWidth: 2))
+                          width: 18,
+                          height: 18,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
                       : const Icon(Icons.save_outlined),
                   label: const Text('Registrar resultado'),
                 ),
@@ -575,7 +621,8 @@ class _MeasurementTilePrepState extends State<_MeasurementTilePrep> {
 
   void _setTextFromParent(String? txt) {
     final newText = (txt ?? '');
-    if (newText == _ctrl.text) return; // evita sobrescrever e mexer no cursor à toa
+    if (newText == _ctrl.text)
+      return; // evita sobrescrever e mexer no cursor à toa
     _ctrl.value = TextEditingValue(
       text: newText,
       // cursor no final do texto (sem selecionar tudo)
@@ -643,53 +690,60 @@ class _MeasurementTilePrepState extends State<_MeasurementTilePrep> {
       elevation: 0.5,
       child: Padding(
         padding: const EdgeInsets.all(12.0),
-        child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
-          Row(
-            children: [
-              Container(
-                width: 10,
-                height: 10,
-                decoration:
-                BoxDecoration(color: _statusColor(st), shape: BoxShape.circle),
-              ),
-              const SizedBox(width: 8),
-              Expanded(
-                child: Text(m.titulo.isEmpty ? '(sem título)' : m.titulo,
-                    style: Theme.of(context).textTheme.titleMedium),
-              ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Container(
+                  width: 10,
+                  height: 10,
+                  decoration: BoxDecoration(
+                    color: _statusColor(st),
+                    shape: BoxShape.circle,
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    m.titulo.isEmpty ? '(sem título)' : m.titulo,
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                ),
+              ],
+            ),
+            if (subtitulo.isNotEmpty) ...[
+              const SizedBox(height: 4),
+              Text(subtitulo, style: Theme.of(context).textTheme.bodyMedium),
             ],
-          ),
-          if (subtitulo.isNotEmpty) ...[
-            const SizedBox(height: 4),
-            Text(subtitulo, style: Theme.of(context).textTheme.bodyMedium),
+            const SizedBox(height: 10),
+            TextField(
+              controller: _ctrl,
+              keyboardType: const TextInputType.numberWithOptions(
+                decimal: true,
+                signed: false,
+              ),
+              decoration: InputDecoration(
+                labelText: 'Medição (${m.unidade ?? ''})',
+                border: const OutlineInputBorder(),
+                helperText: st == StatusMedida.ok
+                    ? 'Dentro da tolerância'
+                    : st == StatusMedida.pendente
+                    ? 'Preencha o valor para classificar'
+                    : (st == StatusMedida.reprovadaAbaixo
+                          ? 'Abaixo do mínimo'
+                          : 'Acima do máximo'),
+                helperStyle: TextStyle(color: _statusColor(st)),
+              ),
+              onChanged: (txt) {
+                final v = _toDouble(txt);
+                final novoStatus = _classifica(v, m.minimo, m.maximo);
+                widget.onChanged(novoStatus, txt);
+                setState(() {});
+              },
+            ),
           ],
-          const SizedBox(height: 10),
-          TextField(
-            controller: _ctrl,
-            keyboardType: const TextInputType.numberWithOptions(
-              decimal: true,
-              signed: false,
-            ),
-            decoration: InputDecoration(
-              labelText: 'Medição (${m.unidade ?? ''})',
-              border: const OutlineInputBorder(),
-              helperText: st == StatusMedida.ok
-                  ? 'Dentro da tolerância'
-                  : st == StatusMedida.pendente
-                  ? 'Preencha o valor para classificar'
-                  : (st == StatusMedida.reprovadaAbaixo
-                  ? 'Abaixo do mínimo'
-                  : 'Acima do máximo'),
-              helperStyle: TextStyle(color: _statusColor(st)),
-            ),
-            onChanged: (txt) {
-              final v = _toDouble(txt);
-              final novoStatus = _classifica(v, m.minimo, m.maximo);
-              widget.onChanged(novoStatus, txt);
-              setState(() {});
-            },
-          ),
-        ]),
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- troca o texto dos status de medição para versões legíveis
- ajusta documentação da API para refletir os novos nomes

## Testing
- `python -m py_compile app_db.py`
- `flutter test` *(fails: TextEditingController was used after being disposed)*

------
https://chatgpt.com/codex/tasks/task_e_68b71a44a75483318e62da44789c038f