### PR TITLE
Add finalization stage to FOR07 reports

### DIFF
--- a/app_db.py
+++ b/app_db.py
@@ -430,7 +430,9 @@ def _ensure_schema():
             )
         _ensure_column(c, "operador_amostragem", "maquina", "VARCHAR(128) DEFAULT NULL")
         _ensure_column(c, "preparador_registro", "maquina", "VARCHAR(128) DEFAULT NULL")
-        _ensure_column(c, "preparador_finalizacao", "maquina", "VARCHAR(128) DEFAULT NULL")
+        _ensure_column(
+            c, "preparador_finalizacao", "maquina", "VARCHAR(128) DEFAULT NULL"
+        )
         with c.cursor() as cur:
             cur.execute(
                 """
@@ -1760,7 +1762,7 @@ def operador_encerrar_producao():
             with c.cursor() as cur:
                 cur.execute(
                     "SELECT COUNT(*) AS cnt FROM operador_amostragem WHERE os=%s",
-                    (os_num,)
+                    (os_num,),
                 )
                 if cur.fetchone()["cnt"] == 0:
                     return (
@@ -1864,6 +1866,7 @@ def relatorio_os():
                 os_data = None
                 amostragem = []
                 liberacao = []
+                finalizacao = []
                 if section in ("full", "ordem_servico"):
                     cur.execute("SELECT * FROM ordem_servico WHERE os=%s", (os_num,))
                     os_data = cur.fetchone()
@@ -1908,11 +1911,36 @@ def relatorio_os():
                         liberacao = cur.fetchall()
                     else:
                         liberacao = []
+                if section in ("full", "finalizacao"):
+                    if _tables_exist(
+                        cur,
+                        "preparador_finalizacao",
+                        "preparador_finalizacao_item",
+                    ):
+                        cur.execute(
+                            """
+                        SELECT f.os, f.partnumber, f.operacao, f.re_preparador,
+                               f.maquina,
+                               i.idx_medida, i.titulo, i.faixa_texto,
+                               i.minimo, i.maximo, i.unidade,
+                               CAST(i.medicao AS CHAR) AS medicao,
+                               i.status, i.observacao, i.created_at
+                          FROM preparador_finalizacao f
+                          JOIN preparador_finalizacao_item i ON i.finalizacao_id = f.id
+                         WHERE f.os=%s
+                         ORDER BY i.created_at
+                        """,
+                            (os_num,),
+                        )
+                        finalizacao = cur.fetchall()
+                    else:
+                        finalizacao = []
         return jsonify(
             {
                 "ordem_servico": _serialize(os_data) if os_data else None,
                 "amostragem": _serialize(amostragem),
                 "liberacao": _serialize(liberacao),
+                "finalizacao": _serialize(finalizacao),
             }
         )
     except Exception as e:
@@ -1930,31 +1958,7 @@ def exportar_relatorio_excel():
         with _conn_db(DB_NAME) as c:
             with c.cursor() as cur:
                 if tipo == "FOR07":
-                    if _tables_exist(
-                        cur, "preparador_registro", "preparador_registro_item"
-                    ):
-                        cur.execute(
-                            """
-                        SELECT r.os, r.partnumber, r.operacao, r.re_preparador,
-                               i.idx_medida, i.titulo, i.faixa_texto,
-                               i.minimo, i.maximo, i.unidade,
-                               CAST(i.medicao AS CHAR) AS medicao,
-                                 CASE
-                                   WHEN LOWER(i.status) LIKE '%%reprov%%' OR LOWER(i.status) LIKE '%%recus%%'
-                                     THEN 'recusada'
-                                   ELSE 'liberada'
-                                 END AS status,
-                               i.observacao, i.created_at
-                          FROM preparador_registro r
-                          JOIN preparador_registro_item i ON i.registro_id = r.id
-                         WHERE r.os=%s
-                         ORDER BY i.created_at
-                        """,
-                            (os_num,),
-                        )
-                        rows = cur.fetchall()
-                    else:
-                        rows = []
+                    rows = []
                     headers = [
                         "os",
                         "partnumber",
@@ -1968,9 +1972,58 @@ def exportar_relatorio_excel():
                         "unidade",
                         "medicao",
                         "status",
+                        "etapa",
                         "observacao",
                         "created_at",
                     ]
+                    if _tables_exist(
+                        cur, "preparador_registro", "preparador_registro_item"
+                    ):
+                        cur.execute(
+                            """
+                        SELECT r.os, r.partnumber, r.operacao, r.re_preparador,
+                               i.idx_medida, i.titulo, i.faixa_texto,
+                               i.minimo, i.maximo, i.unidade,
+                               CAST(i.medicao AS CHAR) AS medicao,
+                               CASE
+                                 WHEN LOWER(i.status) LIKE '%%reprov%%' OR LOWER(i.status) LIKE '%%recus%%'
+                                   THEN 'recusada'
+                                 ELSE 'liberada'
+                               END AS status,
+                               i.observacao, i.created_at
+                          FROM preparador_registro r
+                          JOIN preparador_registro_item i ON i.registro_id = r.id
+                         WHERE r.os=%s
+                         ORDER BY i.created_at
+                        """,
+                            (os_num,),
+                        )
+                        for r in cur.fetchall():
+                            r["etapa"] = "liberacao"
+                            rows.append(r)
+                    if _tables_exist(
+                        cur,
+                        "preparador_finalizacao",
+                        "preparador_finalizacao_item",
+                    ):
+                        cur.execute(
+                            """
+                        SELECT f.os, f.partnumber, f.operacao, f.re_preparador,
+                               i.idx_medida, i.titulo, i.faixa_texto,
+                               i.minimo, i.maximo, i.unidade,
+                               CAST(i.medicao AS CHAR) AS medicao,
+                               i.status,
+                               i.observacao, i.created_at
+                          FROM preparador_finalizacao f
+                          JOIN preparador_finalizacao_item i ON i.finalizacao_id = f.id
+                         WHERE f.os=%s
+                         ORDER BY i.created_at
+                        """,
+                            (os_num,),
+                        )
+                        for r in cur.fetchall():
+                            r["etapa"] = "finalizacao"
+                            rows.append(r)
                 else:
                     cur.execute(
                         """

--- a/lib/features/export_relatorios/presentation/visualizar_relatorios_page.dart
+++ b/lib/features/export_relatorios/presentation/visualizar_relatorios_page.dart
@@ -26,22 +26,23 @@ class _VisualizarRelatoriosPageState extends State<VisualizarRelatoriosPage> {
 
   Future<void> _buscar() async {
     setState(() => _loading = true);
-    final section = _tipo == 'FOR07' ? 'liberacao' : 'amostragem';
+    final section = _tipo == 'FOR07' ? 'full' : 'amostragem';
     final data = await ReportService().fetchOsReport(
       _osController.text,
       section: section,
     );
     final List<Map<String, dynamic>> rows = [];
-    if (data != null && data[section] is List) {
-      for (final e in (data[section] as List)) {
-        if (e is Map<String, dynamic>) {
-          final raw = (e['created_at'] ?? '').toString();
-          final createdAt =
-              DateTime.tryParse(raw)?.toLocal().toString().split('.').first ??
-              raw.replaceAll('T', ' ');
-          if (_tipo == 'FOR07') {
+    if (data != null) {
+      if (_tipo == 'FOR07') {
+        for (final e in (data['liberacao'] as List? ?? [])) {
+          if (e is Map<String, dynamic>) {
+            final raw = (e['created_at'] ?? '').toString();
+            final createdAt =
+                DateTime.tryParse(raw)?.toLocal().toString().split('.').first ??
+                raw.replaceAll('T', ' ');
             rows.add({
               'created_at': createdAt,
+              'etapa': 'Liberação',
               'partnumber': e['partnumber'],
               'maquina': e['maquina'],
               'faixa_texto': e['faixa_texto'],
@@ -54,7 +55,34 @@ class _VisualizarRelatoriosPageState extends State<VisualizarRelatoriosPage> {
                   e['status'] ??
                   '',
             });
-          } else {
+          }
+        }
+        for (final e in (data['finalizacao'] as List? ?? [])) {
+          if (e is Map<String, dynamic>) {
+            final raw = (e['created_at'] ?? '').toString();
+            final createdAt =
+                DateTime.tryParse(raw)?.toLocal().toString().split('.').first ??
+                raw.replaceAll('T', ' ');
+            rows.add({
+              'created_at': createdAt,
+              'etapa': 'Finalização',
+              'partnumber': e['partnumber'],
+              'maquina': e['maquina'],
+              'faixa_texto': e['faixa_texto'],
+              'titulo': e['titulo'],
+              'medicao': e['medicao'],
+              'status_medida': e['status_medida'] ?? e['statusMedida'] ?? '',
+              'status_liberacao': e['status'] ?? '',
+            });
+          }
+        }
+      } else if (data[section] is List) {
+        for (final e in (data[section] as List)) {
+          if (e is Map<String, dynamic>) {
+            final raw = (e['created_at'] ?? '').toString();
+            final createdAt =
+                DateTime.tryParse(raw)?.toLocal().toString().split('.').first ??
+                raw.replaceAll('T', ' ');
             rows.add({
               'created_at': createdAt,
               'partnumber': e['partnumber'],
@@ -84,13 +112,14 @@ class _VisualizarRelatoriosPageState extends State<VisualizarRelatoriosPage> {
     final headerMap = _tipo == 'FOR07'
         ? const {
             'created_at': 'Horário',
+            'etapa': 'Etapa',
             'partnumber': 'Partnumber',
             'maquina': 'Máquina',
             'faixa_texto': 'Faixa',
             'titulo': 'Título',
             'medicao': 'Medição',
             'status_medida': 'Status da medida',
-            'status_liberacao': 'Status da liberação',
+            'status_liberacao': 'Status',
           }
         : const {
             'created_at': 'Horário',

--- a/lib/services/report_service.dart
+++ b/lib/services/report_service.dart
@@ -10,8 +10,9 @@ import '../utils/string_utils.dart';
 /// Service responsible for fetching reports from the backend API.
 class ReportService {
   ReportService({http.Client? client, String? baseUrl})
-      : _client = client ?? http.Client(),
-        _baseUrl = baseUrl ?? dotenv.env['API_BASE_URL'] ?? 'http://localhost:5005';
+    : _client = client ?? http.Client(),
+      _baseUrl =
+          baseUrl ?? dotenv.env['API_BASE_URL'] ?? 'http://localhost:5005';
 
   final http.Client _client;
   final String _baseUrl;
@@ -70,9 +71,11 @@ class ReportService {
   }
 
   /// Fetch a comprehensive report for a specific OS.
-  /// [section] can be `full`, `amostragem` or `liberacao`.
-  Future<Map<String, dynamic>?> fetchOsReport(String os,
-      {String section = 'full'}) async {
+  /// [section] can be `full`, `amostragem`, `liberacao` or `finalizacao`.
+  Future<Map<String, dynamic>?> fetchOsReport(
+    String os, {
+    String section = 'full',
+  }) async {
     try {
       final normalized = normalizeCode(os);
       final uri = Uri.parse(_baseUrl)


### PR DESCRIPTION
## Summary
- Include finalização data alongside liberação in `/reports/os` endpoint
- Export FOR07 reports with stage indicator combining liberação and finalização
- Show both stages in report viewer with new Etapa column

## Testing
- `flutter test` *(fails: A TextEditingController was used after being disposed)*

------
https://chatgpt.com/codex/tasks/task_e_68b734b6c7a883318368fe0a80af4b0f