### PR TITLE
Exibir todos registros no relatório FOR007

### DIFF
--- a/app_db.py
+++ b/app_db.py
@@ -1716,7 +1716,7 @@ def listar_relatorios():
             with c.cursor() as cur:
                 cur.execute(
                     """
-                    SELECT l.os, l.partnumber, l.operacao, l.re_preparador,
+                    SELECT r.os, r.partnumber, r.operacao, r.re_preparador,
                            i.idx_medida, i.titulo, i.medicao,
                              CASE
                                WHEN LOWER(i.status) LIKE '%%reprov%%'
@@ -1725,8 +1725,8 @@ def listar_relatorios():
                                ELSE 'liberada'
                              END AS status,
                            i.observacao, i.created_at
-                      FROM preparador_liberacao l
-                      JOIN preparador_liberacao_item i ON i.liberacao_id = l.id
+                      FROM preparador_registro r
+                      JOIN preparador_registro_item i ON i.registro_id = r.id
                      ORDER BY i.created_at
                      LIMIT 200
                     """


### PR DESCRIPTION
## Resumo
- Ajusta consulta de `/reports` para usar `preparador_registro_item`, exibindo itens aprovados e reprovados

## Testes
- `python -m py_compile app_db.py`
- `flutter test` *(falhou: Multiple exceptions em `machine_integration_test.dart`)*

------
https://chatgpt.com/codex/tasks/task_e_68b98880c9d483319d933f4b35903174