### PR TITLE
Exibir todos registros no relatório FOR007

### DIFF
--- a/app_db.py
+++ b/app_db.py
@@ -1149,7 +1149,7 @@ def resultado_preparador():
                     minimo = it.get("min")
                     maximo = it.get("max")
                     unidade = _norm(it.get("unidade"))
-                    medicao = _norm(it.get("medicao"))
+                    medicao = _norm(it.get("medicao")).replace(",", ".")
                     status = _norm(it.get("status")).lower()
                     observacao = _norm(it.get("observacao"))
 
@@ -1229,7 +1229,7 @@ def resultado_preparador():
                     minimo = it.get("min")
                     maximo = it.get("max")
                     unidade = _norm(it.get("unidade"))
-                    medicao_raw = _norm(it.get("medicao"))
+                    medicao_raw = _norm(it.get("medicao")).replace(",", ".")
                     status = _norm(it.get("status")).lower()
                     observacao = _norm(it.get("observacao"))
                     medicao_val = None
@@ -1716,7 +1716,7 @@ def listar_relatorios():
             with c.cursor() as cur:
                 cur.execute(
                     """
-                    SELECT l.os, l.partnumber, l.operacao, l.re_preparador,
+                    SELECT r.os, r.partnumber, r.operacao, r.re_preparador,
                            i.idx_medida, i.titulo, i.medicao,
                              CASE
                                WHEN LOWER(i.status) LIKE '%%reprov%%'
@@ -1725,8 +1725,8 @@ def listar_relatorios():
                                ELSE 'liberada'
                              END AS status,
                            i.observacao, i.created_at
-                      FROM preparador_liberacao l
-                      JOIN preparador_liberacao_item i ON i.liberacao_id = l.id
+                      FROM preparador_registro r
+                      JOIN preparador_registro_item i ON i.registro_id = r.id
                      ORDER BY i.created_at
                      LIMIT 200
                     """
@@ -1814,21 +1814,29 @@ def relatorio_os():
                     amostragem = cur.fetchall()
                 if section in ("full", "liberacao"):
                     if _tables_exist(
-                        cur, "preparador_liberacao", "preparador_liberacao_item"
+                        cur,
+                        "preparador_registro",
+                        "preparador_registro_item",
+                        "preparador_liberacao",
                     ):
                         cur.execute(
                             """
-                        SELECT l.os, l.partnumber, l.operacao, l.re_preparador,
-                               l.maquina,
+                        SELECT r.os, r.partnumber, r.operacao, r.re_preparador,
+                               r.maquina,
                                i.idx_medida, i.titulo, i.faixa_texto,
                                i.minimo, i.maximo, i.unidade,
                                CAST(i.medicao AS CHAR) AS medicao,
                                i.status AS status_medida,
-                               l.status_geral AS status_liberacao,
+                               COALESCE(l.status_geral, 'Pendente') AS status_liberacao,
                                i.observacao, i.created_at
-                          FROM preparador_liberacao l
-                          JOIN preparador_liberacao_item i ON i.liberacao_id = l.id
-                         WHERE l.os=%s
+                          FROM preparador_registro r
+                          JOIN preparador_registro_item i ON i.registro_id = r.id
+                          LEFT JOIN preparador_liberacao l
+                            ON l.os = r.os
+                           AND TRIM(LEADING '0' FROM TRIM(l.partnumber)) = TRIM(LEADING '0' FROM TRIM(r.partnumber))
+                           AND l.operacao = r.operacao
+                           AND l.maquina = r.maquina
+                         WHERE r.os=%s
                          ORDER BY i.created_at
                         """,
                             (os_num,),
@@ -1900,19 +1908,27 @@ def exportar_relatorio_excel():
                         "created_at",
                     ]
                     if _tables_exist(
-                        cur, "preparador_liberacao", "preparador_liberacao_item"
+                        cur,
+                        "preparador_registro",
+                        "preparador_registro_item",
+                        "preparador_liberacao",
                     ):
                         cur.execute(
                             """
-                        SELECT l.os, l.partnumber, l.operacao, l.re_preparador,
+                        SELECT r.os, r.partnumber, r.operacao, r.re_preparador,
                                i.idx_medida, i.titulo, i.faixa_texto,
                                i.minimo, i.maximo, i.unidade,
                                CAST(i.medicao AS CHAR) AS medicao,
-                               l.status_geral AS status,
+                               COALESCE(l.status_geral, 'Pendente') AS status,
                                i.observacao, i.created_at
-                          FROM preparador_liberacao l
-                          JOIN preparador_liberacao_item i ON i.liberacao_id = l.id
-                         WHERE l.os=%s
+                          FROM preparador_registro r
+                          JOIN preparador_registro_item i ON i.registro_id = r.id
+                          LEFT JOIN preparador_liberacao l
+                            ON l.os = r.os
+                           AND TRIM(LEADING '0' FROM TRIM(l.partnumber)) = TRIM(LEADING '0' FROM TRIM(r.partnumber))
+                           AND l.operacao = r.operacao
+                           AND l.maquina = r.maquina
+                         WHERE r.os=%s
                          ORDER BY i.created_at
                         """,
                             (os_num,),


### PR DESCRIPTION
## Resumo
- Normaliza armazenamento de medições do preparador
- Exibe registros de liberação aprovados e reprovados no FOR007

## Testes
- `python -m py_compile app_db.py`
- `flutter test` *(falhou: Multiple exceptions em `machine_integration_test.dart`)*

------
https://chatgpt.com/codex/tasks/task_e_68b98880c9d483319d933f4b35903174