### PR TITLE
fix: use item status for FOR07 liberacao

### DIFF
--- a/app_db.py
+++ b/app_db.py
@@ -1823,7 +1823,7 @@ def relatorio_os():
                                i.minimo, i.maximo, i.unidade,
                                CAST(i.medicao AS CHAR) AS medicao,
                                i.status AS status,
-                               COALESCE(l.status_geral, 'Pendente') AS status_liberacao,
+                               COALESCE(l.status_geral, 'Pendente') AS status_geral,
                                i.observacao, i.created_at
                           FROM preparador_registro r
                           JOIN preparador_registro_item i ON i.registro_id = r.id


### PR DESCRIPTION
## Summary
- expose preparador_registro_item status for FOR07 liberacao items
- keep overall liberacao status in separate field `status_geral`

## Testing
- ⚠️ `dart test` *(command not found)*
- ⚠️ `pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68b991eba6908331ad900f8240cd8b65