### PR TITLE
feat: block finalization when measurements fail

### DIFF
--- a/lib/features/finalizar_os/presentation/finalizar_os_page.dart
+++ b/lib/features/finalizar_os/presentation/finalizar_os_page.dart
@@ -228,6 +228,20 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
       return;
     }
 
+    // Verifica se há alguma medida reprovada
+    final reprovadas = medidas.where((m) =>
+        m.status == StatusMedida.reprovadaAbaixo ||
+        m.status == StatusMedida.reprovadaAcima).toList();
+    if (reprovadas.isNotEmpty) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Uma ou mais medidas foram reprovadas.'),
+        ),
+      );
+      return;
+    }
+
     // Monta payload
     final itens = <Map<String, dynamic>>[];
     for (var i = 0; i < medidas.length; i++) {

--- a/lib/features/preparacao/presentation/preparacao_page.dart
+++ b/lib/features/preparacao/presentation/preparacao_page.dart
@@ -228,6 +228,22 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
       return;
     }
 
+    // Verifica se há alguma medida reprovada
+    final reprovadas = medidas
+        .where(
+          (m) =>
+              m.status == StatusMedida.reprovadaAbaixo ||
+              m.status == StatusMedida.reprovadaAcima,
+        )
+        .toList();
+    if (reprovadas.isNotEmpty) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Uma ou mais medidas foram reprovadas.')),
+      );
+      return;
+    }
+
     // Monta payload
     final itens = <Map<String, dynamic>>[];
     for (var i = 0; i < medidas.length; i++) {


### PR DESCRIPTION
## Summary
- prevent finalization of OS when any measurement is rejected

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9974f80008331bd4c6089581a6878