### PR TITLE
Consolidate final measurements into FOR07 report

### DIFF
--- a/lib/features/export_relatorios/presentation/visualizar_relatorios_page.dart
+++ b/lib/features/export_relatorios/presentation/visualizar_relatorios_page.dart
@@ -34,27 +34,21 @@ class _VisualizarRelatoriosPageState extends State<VisualizarRelatoriosPage> {
     final List<Map<String, dynamic>> rows = [];
     if (data != null) {
       if (_tipo == 'FOR07') {
+        final Map<String, Map<String, dynamic>> combined = {};
         for (final e in (data['liberacao'] as List? ?? [])) {
           if (e is Map<String, dynamic>) {
             final raw = (e['created_at'] ?? '').toString();
             final createdAt =
                 DateTime.tryParse(raw)?.toLocal().toString().split('.').first ??
                 raw.replaceAll('T', ' ');
-            rows.add({
+            final key = '${e['partnumber']}_${e['idx_medida']}';
+            combined[key] = {
               'created_at': createdAt,
-              'etapa': 'Liberação',
               'partnumber': e['partnumber'],
               'maquina': e['maquina'],
               'faixa_texto': e['faixa_texto'],
-              'titulo': e['titulo'],
               'medicao': e['medicao'],
-              'status_medida': e['status_medida'] ?? e['statusMedida'] ?? '',
-              'status_liberacao':
-                  e['status_liberacao'] ??
-                  e['statusLiberacao'] ??
-                  e['status'] ??
-                  '',
-            });
+            };
           }
         }
         for (final e in (data['finalizacao'] as List? ?? [])) {
@@ -63,19 +57,21 @@ class _VisualizarRelatoriosPageState extends State<VisualizarRelatoriosPage> {
             final createdAt =
                 DateTime.tryParse(raw)?.toLocal().toString().split('.').first ??
                 raw.replaceAll('T', ' ');
-            rows.add({
-              'created_at': createdAt,
-              'etapa': 'Encerramento',
-              'partnumber': e['partnumber'],
-              'maquina': e['maquina'],
-              'faixa_texto': e['faixa_texto'],
-              'titulo': e['titulo'],
-              'medicao': e['medicao'],
-              'status_medida': e['status_medida'] ?? e['statusMedida'] ?? '',
-              'status_liberacao': e['status'] ?? '',
+            final key = '${e['partnumber']}_${e['idx_medida']}';
+            final row = combined.putIfAbsent(key, () {
+              return {
+                'created_at': '',
+                'partnumber': e['partnumber'],
+                'maquina': e['maquina'],
+                'faixa_texto': e['faixa_texto'],
+                'medicao': '',
+              };
             });
+            row['created_at_final'] = createdAt;
+            row['medicao_final'] = e['medicao'];
           }
         }
+        rows.addAll(combined.values);
       } else if (data[section] is List) {
         for (final e in (data[section] as List)) {
           if (e is Map<String, dynamic>) {
@@ -111,15 +107,13 @@ class _VisualizarRelatoriosPageState extends State<VisualizarRelatoriosPage> {
   Widget build(BuildContext context) {
     final headerMap = _tipo == 'FOR07'
         ? const {
-            'created_at': 'Horário',
-            'etapa': 'Etapa',
+            'created_at': 'Horário Inicial',
             'partnumber': 'Partnumber',
             'maquina': 'Máquina',
             'faixa_texto': 'Faixa',
-            'titulo': 'Título',
-            'medicao': 'Medição',
-            'status_medida': 'Status da medida',
-            'status_liberacao': 'Status',
+            'medicao': 'Medição Inicial',
+            'medicao_final': 'Medição Final',
+            'created_at_final': 'Horário Final',
           }
         : const {
             'created_at': 'Horário',
@@ -184,78 +178,24 @@ class _VisualizarRelatoriosPageState extends State<VisualizarRelatoriosPage> {
                                 ),
                               )
                               .toList(),
-                          rows: () {
-                            final Map<String, List<Map<String, dynamic>>>
-                            groups = {};
-                            for (final r in _rows) {
-                              final time = r['created_at'] ?? '';
-                              final etapa = r['etapa'] ?? '';
-                              final key = '$time|$etapa';
-                              groups.putIfAbsent(key, () => []).add(r);
-                            }
-                            final sortedKeys = groups.keys.toList()..sort();
-                            final List<DataRow> dataRows = [];
-                            for (final key in sortedKeys) {
-                              final parts = key.split('|');
-                              final time = parts.first;
-                              final etapa = parts.length > 1 ? parts[1] : '';
-                              dataRows.add(
-                                DataRow(
-                                  cells: [
-                                    DataCell(
-                                      Text(
-                                        time,
-                                        style: const TextStyle(fontSize: 12),
-                                      ),
-                                    ),
-                                    DataCell(
-                                      Text(
-                                        etapa,
-                                        style: const TextStyle(fontSize: 12),
-                                      ),
-                                    ),
-                                    ...List.generate(
-                                      headers.length - 2,
-                                      (_) => DataCell(
-                                        Text(
-                                          '',
-                                          style: const TextStyle(fontSize: 12),
-                                        ),
-                                      ),
-                                    ),
-                                  ],
-                                ),
-                              );
-                              for (final r in groups[key]!) {
-                                dataRows.add(
-                                  DataRow(
-                                    cells: [
-                                      DataCell(
-                                        Text(
-                                          '',
-                                          style: const TextStyle(fontSize: 12),
-                                        ),
-                                      ),
-                                      ...headers
-                                          .skip(1)
-                                          .map(
-                                            (h) => DataCell(
-                                              Text(
-                                                '${r[h] ?? ''}',
-                                                style: const TextStyle(
-                                                  fontSize: 12,
-                                                ),
-                                              ),
+                          rows: _rows
+                              .map(
+                                (r) => DataRow(
+                                  cells: headers
+                                      .map(
+                                        (h) => DataCell(
+                                          Text(
+                                            '${r[h] ?? ''}',
+                                            style: const TextStyle(
+                                              fontSize: 12,
                                             ),
-                                          )
-                                          .toList(),
-                                    ],
-                                  ),
-                                );
-                              }
-                            }
-                            return dataRows;
-                          }(),
+                                          ),
+                                        ),
+                                      )
+                                      .toList(),
+                                ),
+                              )
+                              .toList(),
                         ),
                       ),
                     ),


### PR DESCRIPTION
## Summary
- Combine FOR07 liberation and finalization records by measurement index and part number
- Show only initial/final time and measurements in FOR07 report viewer

## Testing
- `python -m py_compile app_db.py`
- `flutter test` *(fails: edits existing machine)*

------
https://chatgpt.com/codex/tasks/task_e_68b9acff6bac833190c1f0d7e37b2e6f