### PR TITLE
Consolidate final measurements into FOR07 report

### DIFF
--- a/app_db.py
+++ b/app_db.py
@@ -1862,12 +1862,47 @@ def relatorio_os():
                         finalizacao = cur.fetchall()
                     else:
                         finalizacao = []
+                # Combina liberações e finalizações em uma única lista por medida
+                combined = {}
+                for r in liberacao:
+                    key = (
+                        str(r["partnumber"]).strip(),
+                        r["idx_medida"],
+                        str(r.get("maquina", "")).strip(),
+                    )
+                    combined[key] = {
+                        "created_at": r.get("created_at"),
+                        "partnumber": r.get("partnumber"),
+                        "maquina": r.get("maquina"),
+                        "faixa_texto": r.get("faixa_texto"),
+                        "medicao": r.get("medicao"),
+                    }
+                for r in finalizacao:
+                    key = (
+                        str(r["partnumber"]).strip(),
+                        r["idx_medida"],
+                        str(r.get("maquina", "")).strip(),
+                    )
+                    row = combined.setdefault(
+                        key,
+                        {
+                            "created_at": None,
+                            "partnumber": r.get("partnumber"),
+                            "maquina": r.get("maquina"),
+                            "faixa_texto": r.get("faixa_texto"),
+                            "medicao": None,
+                        },
+                    )
+                    row["medicao_final"] = r.get("medicao")
+                    row["created_at_final"] = r.get("created_at")
+                for07_rows = list(combined.values())
         return jsonify(
             {
                 "ordem_servico": _serialize(os_data) if os_data else None,
                 "amostragem": _serialize(amostragem),
                 "liberacao": _serialize(liberacao),
                 "finalizacao": _serialize(finalizacao),
+                "for07": _serialize(for07_rows),
             }
         )
     except Exception as e:
@@ -1885,24 +1920,16 @@ def exportar_relatorio_excel():
         with _conn_db(DB_NAME) as c:
             with c.cursor() as cur:
                 if tipo == "FOR07":
-                    rows = []
                     headers = [
-                        "os",
-                        "partnumber",
-                        "operacao",
-                        "re_preparador",
-                        "idx_medida",
-                        "titulo",
-                        "faixa_texto",
-                        "minimo",
-                        "maximo",
-                        "unidade",
-                        "medicao",
-                        "status",
-                        "etapa",
-                        "observacao",
                         "created_at",
+                        "partnumber",
+                        "maquina",
+                        "faixa_texto",
+                        "medicao",
+                        "medicao_final",
+                        "created_at_final",
                     ]
+                    combined = {}
                     if _tables_exist(
                         cur,
                         "preparador_registro",
@@ -1910,12 +1937,10 @@ def exportar_relatorio_excel():
                     ):
                         cur.execute(
                             """
-                        SELECT r.os, r.partnumber, r.operacao, r.re_preparador,
-                               i.idx_medida, i.titulo, i.faixa_texto,
-                               i.minimo, i.maximo, i.unidade,
+                        SELECT r.partnumber, r.maquina,
+                               i.idx_medida, i.faixa_texto,
                                CAST(i.medicao AS CHAR) AS medicao,
-                               i.status,
-                               i.observacao, i.created_at
+                               i.created_at
                           FROM preparador_registro r
                           JOIN preparador_registro_item i ON i.registro_id = r.id
                          WHERE r.os=%s
@@ -1924,19 +1949,27 @@ def exportar_relatorio_excel():
                             (os_num,),
                         )
                         for r in cur.fetchall():
-                            r["etapa"] = "liberacao"
-                            rows.append(r)
+                            key = (
+                                str(r["partnumber"]).strip(),
+                                r["idx_medida"],
+                                str(r.get("maquina", "")).strip(),
+                            )
+                            combined[key] = {
+                                "created_at": r.get("created_at"),
+                                "partnumber": r.get("partnumber"),
+                                "maquina": r.get("maquina"),
+                                "faixa_texto": r.get("faixa_texto"),
+                                "medicao": r.get("medicao"),
+                            }
                     if _tables_exist(
                         cur, "preparador_finalizacao", "preparador_finalizacao_item"
                     ):
                         cur.execute(
                             """
-                        SELECT f.os, f.partnumber, f.operacao, f.re_preparador,
-                               i.idx_medida, i.titulo, i.faixa_texto,
-                               i.minimo, i.maximo, i.unidade,
+                        SELECT f.partnumber, f.maquina,
+                               i.idx_medida, i.faixa_texto,
                                CAST(i.medicao AS CHAR) AS medicao,
-                               i.status,
-                               i.observacao, i.created_at
+                               i.created_at
                           FROM preparador_finalizacao f
                           JOIN preparador_finalizacao_item i ON i.finalizacao_id = f.id
                          WHERE f.os=%s
@@ -1945,8 +1978,24 @@ def exportar_relatorio_excel():
                             (os_num,),
                         )
                         for r in cur.fetchall():
-                            r["etapa"] = "finalizacao"
-                            rows.append(r)
+                            key = (
+                                str(r["partnumber"]).strip(),
+                                r["idx_medida"],
+                                str(r.get("maquina", "")).strip(),
+                            )
+                            row = combined.setdefault(
+                                key,
+                                {
+                                    "created_at": None,
+                                    "partnumber": r.get("partnumber"),
+                                    "maquina": r.get("maquina"),
+                                    "faixa_texto": r.get("faixa_texto"),
+                                    "medicao": None,
+                                },
+                            )
+                            row["medicao_final"] = r.get("medicao")
+                            row["created_at_final"] = r.get("created_at")
+                    rows = list(combined.values())
                 else:
                     cur.execute(
                         """

--- a/lib/features/export_relatorios/presentation/visualizar_relatorios_page.dart
+++ b/lib/features/export_relatorios/presentation/visualizar_relatorios_page.dart
@@ -34,45 +34,28 @@ class _VisualizarRelatoriosPageState extends State<VisualizarRelatoriosPage> {
     final List<Map<String, dynamic>> rows = [];
     if (data != null) {
       if (_tipo == 'FOR07') {
-        for (final e in (data['liberacao'] as List? ?? [])) {
+        for (final e in (data['for07'] as List? ?? [])) {
           if (e is Map<String, dynamic>) {
             final raw = (e['created_at'] ?? '').toString();
             final createdAt =
                 DateTime.tryParse(raw)?.toLocal().toString().split('.').first ??
                 raw.replaceAll('T', ' ');
+            final rawFinal = (e['created_at_final'] ?? '').toString();
+            final createdAtFinal =
+                DateTime.tryParse(rawFinal)
+                        ?.toLocal()
+                        .toString()
+                        .split('.')
+                        .first ??
+                    rawFinal.replaceAll('T', ' ');
             rows.add({
               'created_at': createdAt,
-              'etapa': 'Liberação',
               'partnumber': e['partnumber'],
               'maquina': e['maquina'],
               'faixa_texto': e['faixa_texto'],
-              'titulo': e['titulo'],
               'medicao': e['medicao'],
-              'status_medida': e['status_medida'] ?? e['statusMedida'] ?? '',
-              'status_liberacao':
-                  e['status_liberacao'] ??
-                  e['statusLiberacao'] ??
-                  e['status'] ??
-                  '',
-            });
-          }
-        }
-        for (final e in (data['finalizacao'] as List? ?? [])) {
-          if (e is Map<String, dynamic>) {
-            final raw = (e['created_at'] ?? '').toString();
-            final createdAt =
-                DateTime.tryParse(raw)?.toLocal().toString().split('.').first ??
-                raw.replaceAll('T', ' ');
-            rows.add({
-              'created_at': createdAt,
-              'etapa': 'Encerramento',
-              'partnumber': e['partnumber'],
-              'maquina': e['maquina'],
-              'faixa_texto': e['faixa_texto'],
-              'titulo': e['titulo'],
-              'medicao': e['medicao'],
-              'status_medida': e['status_medida'] ?? e['statusMedida'] ?? '',
-              'status_liberacao': e['status'] ?? '',
+              'medicao_final': e['medicao_final'],
+              'created_at_final': createdAtFinal,
             });
           }
         }
@@ -111,15 +94,13 @@ class _VisualizarRelatoriosPageState extends State<VisualizarRelatoriosPage> {
   Widget build(BuildContext context) {
     final headerMap = _tipo == 'FOR07'
         ? const {
-            'created_at': 'Horário',
-            'etapa': 'Etapa',
+            'created_at': 'Horário Inicial',
             'partnumber': 'Partnumber',
             'maquina': 'Máquina',
             'faixa_texto': 'Faixa',
-            'titulo': 'Título',
-            'medicao': 'Medição',
-            'status_medida': 'Status da medida',
-            'status_liberacao': 'Status',
+            'medicao': 'Medição Inicial',
+            'medicao_final': 'Medição Final',
+            'created_at_final': 'Horário Final',
           }
         : const {
             'created_at': 'Horário',
@@ -184,78 +165,24 @@ class _VisualizarRelatoriosPageState extends State<VisualizarRelatoriosPage> {
                                 ),
                               )
                               .toList(),
-                          rows: () {
-                            final Map<String, List<Map<String, dynamic>>>
-                            groups = {};
-                            for (final r in _rows) {
-                              final time = r['created_at'] ?? '';
-                              final etapa = r['etapa'] ?? '';
-                              final key = '$time|$etapa';
-                              groups.putIfAbsent(key, () => []).add(r);
-                            }
-                            final sortedKeys = groups.keys.toList()..sort();
-                            final List<DataRow> dataRows = [];
-                            for (final key in sortedKeys) {
-                              final parts = key.split('|');
-                              final time = parts.first;
-                              final etapa = parts.length > 1 ? parts[1] : '';
-                              dataRows.add(
-                                DataRow(
-                                  cells: [
-                                    DataCell(
-                                      Text(
-                                        time,
-                                        style: const TextStyle(fontSize: 12),
-                                      ),
-                                    ),
-                                    DataCell(
-                                      Text(
-                                        etapa,
-                                        style: const TextStyle(fontSize: 12),
-                                      ),
-                                    ),
-                                    ...List.generate(
-                                      headers.length - 2,
-                                      (_) => DataCell(
-                                        Text(
-                                          '',
-                                          style: const TextStyle(fontSize: 12),
-                                        ),
-                                      ),
-                                    ),
-                                  ],
-                                ),
-                              );
-                              for (final r in groups[key]!) {
-                                dataRows.add(
-                                  DataRow(
-                                    cells: [
-                                      DataCell(
-                                        Text(
-                                          '',
-                                          style: const TextStyle(fontSize: 12),
-                                        ),
-                                      ),
-                                      ...headers
-                                          .skip(1)
-                                          .map(
-                                            (h) => DataCell(
-                                              Text(
-                                                '${r[h] ?? ''}',
-                                                style: const TextStyle(
-                                                  fontSize: 12,
-                                                ),
-                                              ),
+                          rows: _rows
+                              .map(
+                                (r) => DataRow(
+                                  cells: headers
+                                      .map(
+                                        (h) => DataCell(
+                                          Text(
+                                            '${r[h] ?? ''}',
+                                            style: const TextStyle(
+                                              fontSize: 12,
                                             ),
-                                          )
-                                          .toList(),
-                                    ],
-                                  ),
-                                );
-                              }
-                            }
-                            return dataRows;
-                          }(),
+                                          ),
+                                        ),
+                                      )
+                                      .toList(),
+                                ),
+                              )
+                              .toList(),
                         ),
                       ),
                     ),


### PR DESCRIPTION
## Summary
- Merge liberation and finalization measurements server-side for FOR07 reports
- Export FOR07 entries with initial/final times and measurements only
- Display consolidated FOR07 data in the report viewer

## Testing
- `python -m py_compile app_db.py`
- `flutter test` *(fails: No file or variants found for asset: .env)*

------
https://chatgpt.com/codex/tasks/task_e_68b9acff6bac833190c1f0d7e37b2e6f