### PR TITLE
Add flexible report search form

### DIFF
--- a/lib/screens/dashboard/components/personnel_report_chart.dart
+++ b/lib/screens/dashboard/components/personnel_report_chart.dart
@@ -1,0 +1,208 @@
+import 'package:flutter/material.dart';
+
+import '../../../constants.dart';
+import '../../../models/report.dart';
+import '../../../services/report_service.dart';
+
+/// Form that allows searching reports for either operators or preparers.
+/// The user can choose to search by OS or by Partnumber + Operação.
+class PersonnelReportChart extends StatefulWidget {
+  const PersonnelReportChart({super.key});
+
+  @override
+  State<PersonnelReportChart> createState() => _PersonnelReportChartState();
+}
+
+class _PersonnelReportChartState extends State<PersonnelReportChart> {
+  final _osCtrl = TextEditingController();
+  final _partCtrl = TextEditingController();
+  final _opCtrl = TextEditingController();
+
+  String _tipo = 'operador';
+  String _modo = 'os';
+  Future<List<Report>>? _future;
+
+  @override
+  void dispose() {
+    _osCtrl.dispose();
+    _partCtrl.dispose();
+    _opCtrl.dispose();
+    super.dispose();
+  }
+
+  void _buscar() {
+    final service = ReportService();
+    if (_modo == 'os') {
+      final os = _osCtrl.text.trim();
+      if (os.isEmpty) return;
+      setState(() {
+        _future = service.fetchReleases(tipo: _tipo, os: os);
+      });
+    } else {
+      final part = _partCtrl.text.trim();
+      final op = _opCtrl.text.trim();
+      if (part.isEmpty || op.isEmpty) return;
+      setState(() {
+        _future = service.fetchReleases(
+          tipo: _tipo,
+          partnumber: part,
+          operacao: op,
+        );
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(defaultPadding),
+      decoration: BoxDecoration(
+        color: secondaryColor,
+        borderRadius: const BorderRadius.all(Radius.circular(10)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Relatório de Amostragens',
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          const SizedBox(height: defaultPadding),
+          LayoutBuilder(
+            builder: (context, constraints) {
+              final isNarrow = constraints.maxWidth < 600;
+              final tipoField = DropdownButtonFormField<String>(
+                value: _tipo,
+                decoration: const InputDecoration(
+                  labelText: 'Tipo',
+                  border: OutlineInputBorder(),
+                ),
+                items: const [
+                  DropdownMenuItem(value: 'operador', child: Text('Operador')),
+                  DropdownMenuItem(
+                    value: 'preparador',
+                    child: Text('Preparador'),
+                  ),
+                ],
+                onChanged: (v) => setState(() => _tipo = v ?? 'operador'),
+              );
+              final modoField = DropdownButtonFormField<String>(
+                value: _modo,
+                decoration: const InputDecoration(
+                  labelText: 'Pesquisar por',
+                  border: OutlineInputBorder(),
+                ),
+                items: const [
+                  DropdownMenuItem(value: 'os', child: Text('OS')),
+                  DropdownMenuItem(
+                    value: 'part',
+                    child: Text('Partnumber + Operação'),
+                  ),
+                ],
+                onChanged: (v) => setState(() => _modo = v ?? 'os'),
+              );
+              if (isNarrow) {
+                return Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    tipoField,
+                    const SizedBox(height: defaultPadding),
+                    modoField,
+                  ],
+                );
+              }
+              return Row(
+                children: [
+                  Expanded(child: tipoField),
+                  const SizedBox(width: defaultPadding),
+                  Expanded(child: modoField),
+                ],
+              );
+            },
+          ),
+          const SizedBox(height: defaultPadding),
+          if (_modo == 'os')
+            TextField(
+              controller: _osCtrl,
+              decoration: const InputDecoration(
+                labelText: 'Número da OS',
+                border: OutlineInputBorder(),
+              ),
+            )
+          else
+            LayoutBuilder(
+              builder: (context, constraints) {
+                final isNarrow = constraints.maxWidth < 600;
+                final partField = TextField(
+                  controller: _partCtrl,
+                  decoration: const InputDecoration(
+                    labelText: 'Partnumber',
+                    border: OutlineInputBorder(),
+                  ),
+                );
+                final opField = TextField(
+                  controller: _opCtrl,
+                  decoration: const InputDecoration(
+                    labelText: 'Operação',
+                    border: OutlineInputBorder(),
+                  ),
+                );
+                if (isNarrow) {
+                  return Column(
+                    children: [
+                      partField,
+                      const SizedBox(height: defaultPadding),
+                      opField,
+                    ],
+                  );
+                }
+                return Row(
+                  children: [
+                    Expanded(child: partField),
+                    const SizedBox(width: defaultPadding),
+                    Expanded(child: opField),
+                  ],
+                );
+              },
+            ),
+          const SizedBox(height: defaultPadding),
+          Align(
+            alignment: Alignment.centerRight,
+            child: ElevatedButton(
+              onPressed: _buscar,
+              child: const Text('Buscar'),
+            ),
+          ),
+          const SizedBox(height: defaultPadding),
+          FutureBuilder<List<Report>>(
+            future: _future,
+            builder: (context, snapshot) {
+              if (_future == null) {
+                return const Text(
+                  'Realize a busca para visualizar os resultados.',
+                );
+              }
+              if (snapshot.connectionState == ConnectionState.waiting) {
+                return const Center(child: CircularProgressIndicator());
+              }
+              final dados = snapshot.data ?? [];
+              if (dados.isEmpty) {
+                return const Text('Nenhum dado encontrado.');
+              }
+              return SizedBox(
+                height: 200,
+                child: ListView.builder(
+                  itemCount: dados.length,
+                  itemBuilder: (context, index) {
+                    final r = dados[index];
+                    return Text('${r.os} - ${r.partnumber} - ${r.operacao}');
+                  },
+                ),
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/dashboard/dashboard_screen.dart
+++ b/lib/screens/dashboard/dashboard_screen.dart
@@ -9,6 +9,7 @@ import 'components/recent_files.dart';
 import 'components/reports_table.dart';
 import 'components/storage_details.dart';
 import 'components/operator_report_chart.dart';
+import 'components/personnel_report_chart.dart';
 
 class DashboardScreen extends StatelessWidget {
   @override
@@ -36,6 +37,8 @@ class DashboardScreen extends StatelessWidget {
                       ReportsTable(),
                       SizedBox(height: defaultPadding),
                       OperatorReportChart(),
+                      SizedBox(height: defaultPadding),
+                      PersonnelReportChart(),
                       if (Responsive.isMobile(context))
                         SizedBox(height: defaultPadding),
                       if (Responsive.isMobile(context)) StorageDetails(),
@@ -46,12 +49,9 @@ class DashboardScreen extends StatelessWidget {
                   SizedBox(width: defaultPadding),
                 // On Mobile means if the screen is less than 850 we don't want to show it
                 if (!Responsive.isMobile(context))
-                  Expanded(
-                    flex: 2,
-                    child: StorageDetails(),
-                  ),
+                  Expanded(flex: 2, child: StorageDetails()),
               ],
-            )
+            ),
           ],
         ),
       ),

--- a/lib/services/report_service.dart
+++ b/lib/services/report_service.dart
@@ -70,6 +70,40 @@ class ReportService {
     return [];
   }
 
+  /// Generic search for releases filtering by [tipo] ("operador" or
+  /// "preparador"). The caller can provide either [os] or a combination of
+  /// [partnumber] and [operacao] to filter the results.
+  Future<List<Report>> fetchReleases({
+    required String tipo,
+    String? os,
+    String? partnumber,
+    String? operacao,
+  }) async {
+    try {
+      final endpoint = tipo.toLowerCase() == 'preparador'
+          ? 'preparador'
+          : 'operador';
+      final params = <String, String>{};
+      if (os != null && os.isNotEmpty) {
+        params['os'] = normalizeCode(os);
+      } else if (partnumber != null &&
+          operacao != null &&
+          partnumber.isNotEmpty &&
+          operacao.isNotEmpty) {
+        params['partnumber'] = normalizeCode(partnumber);
+        params['operacao'] = normalizeCode(operacao);
+      }
+      final uri = Uri.parse(
+        _baseUrl,
+      ).resolve('reports/$endpoint').replace(queryParameters: params);
+      final response = await _client.get(uri);
+      if (response.statusCode == 200) {
+        return Report.listFromResponse(response.body);
+      }
+    } catch (_) {}
+    return [];
+  }
+
   /// Fetch a comprehensive report for a specific OS.
   /// [section] can be `full`, `amostragem`, `liberacao` or `finalizacao`.
   Future<Map<String, dynamic>?> fetchOsReport(

--- a/test/report_service_test.dart
+++ b/test/report_service_test.dart
@@ -28,6 +28,26 @@ void main() {
     expect(requestedUri.queryParameters['os'], '123');
   });
 
+  test(
+    'fetchReleases builds params for preparador partnumber search',
+    () async {
+      late Uri requestedUri;
+      final client = MockClient((req) async {
+        requestedUri = req.url;
+        return http.Response('[]', 200);
+      });
+      final service = ReportService(client: client, baseUrl: 'http://dummy');
+      await service.fetchReleases(
+        tipo: 'preparador',
+        partnumber: '0001',
+        operacao: '0002',
+      );
+      expect(requestedUri.path, '/reports/preparador');
+      expect(requestedUri.queryParameters['partnumber'], '1');
+      expect(requestedUri.queryParameters['operacao'], '2');
+    },
+  );
+
   test('fetchOsReport normalizes OS and forwards section parameter', () async {
     late Uri requestedUri;
     final client = MockClient((req) async {


### PR DESCRIPTION
## Summary
- extend report service with generic release fetch supporting OS or Part/Op filters
- add dashboard form allowing operator or preparer search modes
- test request building for new service method

## Testing
- `flutter test` *(fails: edits existing machine)*
- `flutter test test/report_service_test.dart`

------
https://chatgpt.com/codex/tasks/task_e_68b9c99887d083318ccd56d51e59f761