### PR TITLE
Exibe OS e RE nos relatórios

### DIFF
--- a/lib/features/export_relatorios/presentation/visualizar_relatorios_page.dart
+++ b/lib/features/export_relatorios/presentation/visualizar_relatorios_page.dart
@@ -43,6 +43,8 @@ class _VisualizarRelatoriosPageState extends State<VisualizarRelatoriosPage> {
                 raw.replaceAll('T', ' ');
             final key = '${e['partnumber']}_${e['idx_medida']}';
             combined[key] = {
+              'os': e['os'],
+              're_preparador': e['re_preparador'],
               'created_at': createdAt,
               'partnumber': e['partnumber'],
               'maquina': e['maquina'],
@@ -60,6 +62,8 @@ class _VisualizarRelatoriosPageState extends State<VisualizarRelatoriosPage> {
             final key = '${e['partnumber']}_${e['idx_medida']}';
             final row = combined.putIfAbsent(key, () {
               return {
+                'os': e['os'],
+                're_preparador': e['re_preparador'],
                 'created_at': '',
                 'partnumber': e['partnumber'],
                 'maquina': e['maquina'],
@@ -80,6 +84,8 @@ class _VisualizarRelatoriosPageState extends State<VisualizarRelatoriosPage> {
                 DateTime.tryParse(raw)?.toLocal().toString().split('.').first ??
                 raw.replaceAll('T', ' ');
             rows.add({
+              'os': e['os'],
+              're_operador': e['re_operador'],
               'created_at': createdAt,
               'partnumber': e['partnumber'],
               'maquina': e['maquina'],
@@ -107,6 +113,8 @@ class _VisualizarRelatoriosPageState extends State<VisualizarRelatoriosPage> {
   Widget build(BuildContext context) {
     final headerMap = _tipo == 'FOR07'
         ? const {
+            'os': 'OS',
+            're_preparador': 'RE',
             'partnumber': 'Partnumber',
             'maquina': 'Máquina',
             'faixa_texto': 'Faixa',
@@ -117,6 +125,8 @@ class _VisualizarRelatoriosPageState extends State<VisualizarRelatoriosPage> {
 
           }
         : const {
+            'os': 'OS',
+            're_operador': 'RE',
             'created_at': 'Horário',
             'partnumber': 'Partnumber',
             'maquina': 'Máquina',

--- a/lib/screens/dashboard/components/personnel_report_chart.dart
+++ b/lib/screens/dashboard/components/personnel_report_chart.dart
@@ -50,6 +50,8 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
                     raw.replaceAll('T', ' ');
                 final key = '${e['partnumber']}_${e['idx_medida']}';
                 combined[key] = {
+                  'os': e['os'],
+                  're_preparador': e['re_preparador'],
                   'created_at': createdAt,
                   'partnumber': e['partnumber'],
                   'maquina': e['maquina'],
@@ -69,6 +71,8 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
                 final key = '${e['partnumber']}_${e['idx_medida']}';
                 final row = combined.putIfAbsent(key, () {
                   return {
+                    'os': e['os'],
+                    're_preparador': e['re_preparador'],
                     'created_at': '',
                     'partnumber': e['partnumber'],
                     'maquina': e['maquina'],
@@ -93,6 +97,8 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
                       )?.toLocal().toString().split('.').first ??
                       raw.replaceAll('T', ' ');
                   rows.add({
+                    'os': e['os'],
+                    're_operador': e['re_operador'],
                     'created_at': createdAt,
                     'partnumber': e['partnumber'],
                     'maquina': e['maquina'],
@@ -266,6 +272,8 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
               }
               final headerMap = _tipo == 'preparador'
                   ? const {
+                      'os': 'OS',
+                      're_preparador': 'RE',
                       'partnumber': 'Partnumber',
                       'maquina': 'Máquina',
                       'faixa_texto': 'Faixa',
@@ -275,6 +283,8 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
                       'created_at_final': 'Horário Final',
                     }
                   : const {
+                      'os': 'OS',
+                      're_operador': 'RE',
                       'created_at': 'Horário',
                       'partnumber': 'Partnumber',
                       'maquina': 'Máquina',


### PR DESCRIPTION
## Summary
- mostrar número da OS e RE do responsável nos relatórios de operador e preparador
- expor as mesmas colunas na página de visualização de relatórios

## Testing
- `flutter test` *(falhou: TextEditingController was used after being disposed)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d7d871548331912f7a483820a47d