### PR TITLE
Prefix tampão status values with LP/LNP

### DIFF
--- a/app_db.py
+++ b/app_db.py
@@ -474,6 +474,16 @@ def _norm_op(text):
     return _strip_leading_zeros(t)
 
 
+def _strip_side_prefix(part: str) -> str:
+    """Remove prefixos de lado (LP/LNP) e retorna o status em minúsculas."""
+    p = _norm(part).lower()
+    if p.startswith("lp "):
+        return p[3:]
+    if p.startswith("lnp "):
+        return p[4:]
+    return p
+
+
 def _to_float(s):
     try:
         return float(str(s).replace(",", ".").strip())
@@ -1018,7 +1028,7 @@ def resultado_preparador():
       ]
     }
     (Para medições de tampão, o campo `status` envia os dois lados como
-    "aprovado|reprovado".)
+    "LP Aprovado | LNP Reprovado".)
     """
 
     payload = request.get_json(silent=True) or {}
@@ -1179,11 +1189,11 @@ def resultado_preparador():
 
                 # Consolida liberação
                 has_reprov = any(
-                    any(parte.strip().startswith("reprov") for parte in s.split("|"))
+                    any(_strip_side_prefix(parte).startswith("reprov") for parte in s.split("|"))
                     for s in all_status
                 )
                 all_ok = len(all_status) > 0 and all(
-                    all(parte.strip() in ("ok", "aprovado") for parte in s.split("|"))
+                    all(_strip_side_prefix(parte) in ("ok", "aprovado") for parte in s.split("|"))
                     for s in all_status
                 )
                 status_geral = "Liberada" if all_ok else "Pendente"
@@ -1402,11 +1412,11 @@ def preparador_finalizar_os():
                     all_status.append(status)
 
                 has_reprov = any(
-                    any(parte.strip().startswith("reprov") for parte in s.split("|"))
+                    any(_strip_side_prefix(parte).startswith("reprov") for parte in s.split("|"))
                     for s in all_status
                 )
                 all_ok = len(all_status) > 0 and all(
-                    all(parte.strip() in ("ok", "aprovado") for parte in s.split("|"))
+                    all(_strip_side_prefix(parte) in ("ok", "aprovado") for parte in s.split("|"))
                     for s in all_status
                 )
                 status_geral = "Liberada" if all_ok else "Pendente"
@@ -1489,7 +1499,7 @@ def operador_registrar():
       ]
     }
     (Para medições de tampão, o campo `status` envia os dois lados como
-    "aprovado|reprovado".)
+    "LP Aprovado | LNP Reprovado".)
     """
 
     payload = request.get_json(silent=True) or {}

--- a/lib/features/operador/presentation/operador_page.dart
+++ b/lib/features/operador/presentation/operador_page.dart
@@ -187,24 +187,24 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
       // escolha = texto selecionado (OK / Aprovado / Reprovado / pílula etc.)
       map['escolha'] = m.medicao ?? '';
 
-      // status como string; tampão envia "aprovado|reprovado" com ambos os lados
+      // status como string; tampão envia "LP Aprovado | LNP Reprovado" com ambos os lados
 
       String status;
       final med = m.medicao ?? '';
       if (med.contains('Lado passa') && med.contains('Lado não passa')) {
         // Tampão: avalia cada lado separadamente
-        var passa = 'aprovado';
-        var naoPassa = 'aprovado';
+        var passa = 'LP Aprovado';
+        var naoPassa = 'LNP Aprovado';
         for (final part in med.split('|')) {
           final p = part.trim();
           if (p.startsWith('Lado passa') && p.endsWith('Reprovado')) {
-            passa = 'reprovado';
+            passa = 'LP Reprovado';
           }
           if (p.startsWith('Lado não passa') && p.endsWith('Reprovado')) {
-            naoPassa = 'reprovado';
+            naoPassa = 'LNP Reprovado';
           }
         }
-        status = '$passa|$naoPassa';
+        status = '$passa | $naoPassa';
       } else {
         status = statusToString(m.status);
       }


### PR DESCRIPTION
## Summary
- Prefix tampão side results as "LP" and "LNP" when submitting from the operador page
- Strip new side prefixes on the server when aggregating tampão status values

## Testing
- ⚠️ `flutter test` *(missing .env asset)*
- ✅ `python -m py_compile app_db.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb08f8fe9c833181e29b9ee1bdfa40