### PR TITLE
Add preparer RE fields to FOR07 reports

### DIFF
--- a/lib/features/export_relatorios/presentation/visualizar_relatorios_page.dart
+++ b/lib/features/export_relatorios/presentation/visualizar_relatorios_page.dart
@@ -44,7 +44,8 @@ class _VisualizarRelatoriosPageState extends State<VisualizarRelatoriosPage> {
             final key = '${e['partnumber']}_${e['idx_medida']}';
             combined[key] = {
               'os': e['os'],
-              're_preparador': e['re_preparador'],
+              're_liberacao': e['re_preparador'],
+              're_finalizacao': '',
               'created_at': createdAt,
               'partnumber': e['partnumber'],
               'maquina': e['maquina'],
@@ -63,7 +64,7 @@ class _VisualizarRelatoriosPageState extends State<VisualizarRelatoriosPage> {
             final row = combined.putIfAbsent(key, () {
               return {
                 'os': e['os'],
-                're_preparador': e['re_preparador'],
+                're_liberacao': '',
                 'created_at': '',
                 'partnumber': e['partnumber'],
                 'maquina': e['maquina'],
@@ -73,6 +74,7 @@ class _VisualizarRelatoriosPageState extends State<VisualizarRelatoriosPage> {
             });
             row['created_at_final'] = createdAt;
             row['medicao_final'] = e['medicao'];
+            row['re_finalizacao'] = e['re_preparador'];
           }
         }
         rows.addAll(combined.values);
@@ -114,7 +116,8 @@ class _VisualizarRelatoriosPageState extends State<VisualizarRelatoriosPage> {
     final headerMap = _tipo == 'FOR07'
         ? const {
             'os': 'OS',
-            're_preparador': 'RE',
+            're_liberacao': 'RE Liberação',
+            're_finalizacao': 'RE Finalização',
             'partnumber': 'Partnumber',
             'maquina': 'Máquina',
             'faixa_texto': 'Faixa',
@@ -122,7 +125,6 @@ class _VisualizarRelatoriosPageState extends State<VisualizarRelatoriosPage> {
             'medicao': 'Medição Inicial',
             'medicao_final': 'Medição Final',
             'created_at_final': 'Horário Final',
-
           }
         : const {
             'os': 'OS',

--- a/lib/screens/dashboard/components/personnel_report_chart.dart
+++ b/lib/screens/dashboard/components/personnel_report_chart.dart
@@ -63,7 +63,8 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
                 final key = '${e['partnumber']}_${e['idx_medida']}';
                 combined[key] = {
                   'os': e['os'],
-                  're_preparador': e['re_preparador'],
+                  're_liberacao': e['re_preparador'],
+                  're_finalizacao': '',
                   'created_at': createdAt,
                   'partnumber': e['partnumber'],
                   'maquina': e['maquina'],
@@ -79,7 +80,7 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
                 final row = combined.putIfAbsent(key, () {
                   return {
                     'os': e['os'],
-                    're_preparador': e['re_preparador'],
+                    're_liberacao': '',
                     'created_at': '',
                     'partnumber': e['partnumber'],
                     'maquina': e['maquina'],
@@ -89,6 +90,7 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
                 });
                 row['created_at_final'] = createdAt;
                 row['medicao_final'] = e['medicao'];
+                row['re_finalizacao'] = e['re_preparador'];
               }
             }
             rows.addAll(combined.values);
@@ -291,7 +293,8 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
               final headerMap = _tipo == 'preparador'
                   ? const {
                       'os': 'OS',
-                      're_preparador': 'RE',
+                      're_liberacao': 'RE Liberação',
+                      're_finalizacao': 'RE Finalização',
                       'partnumber': 'Partnumber',
                       'maquina': 'Máquina',
                       'faixa_texto': 'Faixa',


### PR DESCRIPTION
## Summary
- show RE for preparer who releases and who finalizes in FOR07 report view
- expose release and finalization REs in dashboard personnel report

## Testing
- `flutter test` *(fails: Multiple exceptions (2) were detected...)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0aded6308331a5b799a8c22f4715