### PR TITLE
Return RE data for partnumber/operation report searches

### DIFF
--- a/app_db.py
+++ b/app_db.py
@@ -1737,6 +1737,7 @@ def listar_relatorios():
                         cur.execute(
                             """
                             SELECT l.os, l.partnumber, l.operacao, l.maquina,
+                                   l.re_preparador,
                                    i.idx_medida, i.titulo, i.faixa_texto,
                                    CAST(i.medicao AS CHAR) AS medicao,
                                    i.created_at
@@ -1751,11 +1752,15 @@ def listar_relatorios():
                         for r in cur.fetchall():
                             key = (r["os"], r["idx_medida"])
                             combined[key] = {
+                                "os": r["os"],
                                 "partnumber": r["partnumber"],
+                                "operacao": r["operacao"],
                                 "maquina": r["maquina"],
                                 "faixa_texto": r["faixa_texto"],
                                 "medicao": r["medicao"],
                                 "created_at": r["created_at"],
+                                "re_liberacao": r["re_preparador"],
+                                "re_finalizacao": "",
                             }
                     if _tables_exist(
                             cur,
@@ -1765,6 +1770,7 @@ def listar_relatorios():
                         cur.execute(
                             """
                             SELECT f.os, f.partnumber, f.operacao, f.maquina,
+                                   f.re_preparador,
                                    i.idx_medida, i.titulo, i.faixa_texto,
                                    CAST(i.medicao AS CHAR) AS medicao,
                                    i.created_at
@@ -1781,15 +1787,19 @@ def listar_relatorios():
                             row = combined.setdefault(
                                 key,
                                 {
+                                    "os": r["os"],
                                     "partnumber": r["partnumber"],
+                                    "operacao": r["operacao"],
                                     "maquina": r["maquina"],
                                     "faixa_texto": r["faixa_texto"],
                                     "medicao": None,
                                     "created_at": None,
+                                    "re_liberacao": "",
                                 },
                             )
                             row["medicao_final"] = r["medicao"]
                             row["created_at_final"] = r["created_at"]
+                            row["re_finalizacao"] = r["re_preparador"]
                     rows = list(combined.values())
                 else:
                     cur.execute(


### PR DESCRIPTION
## Summary
- include re_preparador, os and operation fields when fetching preparador reports by partnumber and operation
- attach finalization RE and measurement data to combined rows so UI columns populate correctly

## Testing
- `python -m py_compile app_db.py`
- `flutter test` *(fails: No file or variants found for asset: .env)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0c5acdd88331ad906a29f7be3e8e