### PR TITLE
Add OS time report and navigation entry

### DIFF
--- a/lib/features/cadastro_maquinas/presentation/cadastro_maquinas_page.dart
+++ b/lib/features/cadastro_maquinas/presentation/cadastro_maquinas_page.dart
@@ -4,7 +4,7 @@ import '../../../controllers/machine_controller.dart';
 
 class CadastroMaquinasPage extends StatefulWidget {
   CadastroMaquinasPage({super.key, MachineController? controller})
-      : controller = controller ?? MachineController();
+    : controller = controller ?? MachineController();
 
   final MachineController controller;
 
@@ -27,8 +27,7 @@ class _CadastroMaquinasPageState extends State<CadastroMaquinasPage> {
     if (!mounted) return;
     final err = widget.controller.error;
     if (err != null) {
-      ScaffoldMessenger.of(context)
-          .showSnackBar(SnackBar(content: Text(err)));
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(err)));
     }
     setState(() {});
   }
@@ -57,16 +56,18 @@ class _CadastroMaquinasPageState extends State<CadastroMaquinasPage> {
                       Expanded(
                         child: TextField(
                           controller: _categoriaCtrl,
-                          decoration:
-                              const InputDecoration(labelText: 'Categoria'),
+                          decoration: const InputDecoration(
+                            labelText: 'Categoria',
+                          ),
                         ),
                       ),
                       const SizedBox(width: 8),
                       Expanded(
                         child: TextField(
                           controller: _codigoCtrl,
-                          decoration:
-                              const InputDecoration(labelText: 'Código da máquina'),
+                          decoration: const InputDecoration(
+                            labelText: 'Código da máquina',
+                          ),
                         ),
                       ),
                       const SizedBox(width: 8),
@@ -102,10 +103,12 @@ class _CadastroMaquinasPageState extends State<CadastroMaquinasPage> {
                         trailing: IconButton(
                           icon: const Icon(Icons.edit),
                           onPressed: () async {
-                            final catCtrl =
-                                TextEditingController(text: m.categoria);
-                            final codCtrl =
-                                TextEditingController(text: m.codigo);
+                            final catCtrl = TextEditingController(
+                              text: m.categoria,
+                            );
+                            final codCtrl = TextEditingController(
+                              text: m.codigo,
+                            );
                             final result = await showDialog<bool>(
                               context: context,
                               builder: (context) {
@@ -117,12 +120,14 @@ class _CadastroMaquinasPageState extends State<CadastroMaquinasPage> {
                                       TextField(
                                         controller: catCtrl,
                                         decoration: const InputDecoration(
-                                            labelText: 'Categoria'),
+                                          labelText: 'Categoria',
+                                        ),
                                       ),
                                       TextField(
                                         controller: codCtrl,
                                         decoration: const InputDecoration(
-                                            labelText: 'Código da máquina'),
+                                          labelText: 'Código da máquina',
+                                        ),
                                       ),
                                     ],
                                   ),
@@ -143,12 +148,11 @@ class _CadastroMaquinasPageState extends State<CadastroMaquinasPage> {
                             );
                             if (result == true) {
                               await ctrl.updateMaquina(
-                                  m.codigo,
-                                  codCtrl.text.trim(),
-                                  catCtrl.text.trim());
+                                m.codigo,
+                                codCtrl.text.trim(),
+                                catCtrl.text.trim(),
+                              );
                             }
-                            catCtrl.dispose();
-                            codCtrl.dispose();
                           },
                         ),
                       );

--- a/lib/features/export_relatorios/presentation/tempo_os_page.dart
+++ b/lib/features/export_relatorios/presentation/tempo_os_page.dart
@@ -1,0 +1,187 @@
+import 'package:flutter/material.dart';
+
+import '../../../screens/main/components/side_menu.dart';
+import '../../../services/report_service.dart';
+
+/// Page that displays the time spent on an OS based on release and
+/// finalization timestamps.
+class TempoOsPage extends StatefulWidget {
+  const TempoOsPage({super.key});
+
+  @override
+  State<TempoOsPage> createState() => _TempoOsPageState();
+}
+
+class _TempoOsPageState extends State<TempoOsPage> {
+  final _osController = TextEditingController();
+  bool _loading = false;
+  List<Map<String, String>> _rows = [];
+
+  @override
+  void dispose() {
+    _osController.dispose();
+    super.dispose();
+  }
+
+  String _formatDuration(Duration d) {
+    final hours = d.inHours.toString().padLeft(2, '0');
+    final minutes = (d.inMinutes % 60).toString().padLeft(2, '0');
+    final seconds = (d.inSeconds % 60).toString().padLeft(2, '0');
+    return '$hours:$minutes:$seconds';
+  }
+
+  Future<void> _buscar() async {
+    setState(() => _loading = true);
+    final data = await ReportService().fetchOsReport(
+      _osController.text,
+      section: 'full',
+    );
+    final rows = <Map<String, String>>[];
+    if (data != null) {
+      final Map<String, Map<String, dynamic>> combined = {};
+      for (final e in (data['liberacao'] as List? ?? [])) {
+        if (e is Map<String, dynamic>) {
+          final raw = (e['created_at'] ?? '').toString();
+          final dt = DateTime.tryParse(raw)?.toLocal();
+          final createdAt =
+              dt?.toString().split('.').first ?? raw.replaceAll('T', ' ');
+          final key = '${e['partnumber']}_${e['idx_medida']}';
+          combined[key] = {
+            'os': e['os'],
+            're_liberacao': e['re_preparador'],
+            're_finalizacao': '',
+            'inicio': createdAt,
+            'fim': '',
+            'start': dt,
+            'end': null,
+          };
+        }
+      }
+      for (final e in (data['finalizacao'] as List? ?? [])) {
+        if (e is Map<String, dynamic>) {
+          final raw = (e['created_at'] ?? '').toString();
+          final dt = DateTime.tryParse(raw)?.toLocal();
+          final createdAt =
+              dt?.toString().split('.').first ?? raw.replaceAll('T', ' ');
+          final key = '${e['partnumber']}_${e['idx_medida']}';
+          final row = combined.putIfAbsent(key, () {
+            return {
+              'os': e['os'],
+              're_liberacao': '',
+              're_finalizacao': '',
+              'inicio': '',
+              'fim': createdAt,
+              'start': null,
+              'end': dt,
+            };
+          });
+          row['fim'] = createdAt;
+          row['re_finalizacao'] = e['re_preparador'];
+          row['end'] = dt;
+        }
+      }
+      for (final value in combined.values) {
+        final start = value['start'] as DateTime?;
+        final end = value['end'] as DateTime?;
+        var tempo = '';
+        if (start != null && end != null) {
+          tempo = _formatDuration(end.difference(start));
+        }
+        rows.add({
+          'os': value['os']?.toString() ?? '',
+          're_liberacao': value['re_liberacao']?.toString() ?? '',
+          're_finalizacao': value['re_finalizacao']?.toString() ?? '',
+          'inicio': value['inicio']?.toString() ?? '',
+          'fim': value['fim']?.toString() ?? '',
+          'tempo': tempo,
+        });
+      }
+    }
+    if (!mounted) return;
+    rows.sort((a, b) => (a['inicio'] ?? '').compareTo(b['inicio'] ?? ''));
+    setState(() {
+      _rows = rows;
+      _loading = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    const headerMap = {
+      'os': 'OS',
+      're_liberacao': 'RE Liberação',
+      're_finalizacao': 'RE Finalização',
+      'inicio': 'Horário Liberação',
+      'fim': 'Horário Finalização',
+      'tempo': 'Tempo Gasto',
+    };
+    final headers = headerMap.keys.toList();
+    return Scaffold(
+      appBar: AppBar(title: const Text('Tempo por OS')),
+      drawer: const SideMenu(current: SideMenuSection.dashboard),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            TextField(
+              controller: _osController,
+              decoration: const InputDecoration(labelText: 'O.S'),
+            ),
+            const SizedBox(height: 24),
+            FilledButton(
+              onPressed: _loading ? null : _buscar,
+              child: _loading
+                  ? const SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Text('Buscar'),
+            ),
+            const SizedBox(height: 24),
+            Expanded(
+              child: _rows.isEmpty
+                  ? const Center(child: Text('Nenhum dado'))
+                  : SingleChildScrollView(
+                      scrollDirection: Axis.horizontal,
+                      child: SingleChildScrollView(
+                        child: DataTable(
+                          columns: headers
+                              .map(
+                                (h) => DataColumn(
+                                  label: Text(
+                                    headerMap[h] ?? h,
+                                    style: const TextStyle(fontSize: 12),
+                                  ),
+                                ),
+                              )
+                              .toList(),
+                          rows: _rows
+                              .map(
+                                (r) => DataRow(
+                                  cells: headers
+                                      .map(
+                                        (h) => DataCell(
+                                          Text(
+                                            r[h] ?? '',
+                                            style: const TextStyle(
+                                              fontSize: 12,
+                                            ),
+                                          ),
+                                        ),
+                                      )
+                                      .toList(),
+                                ),
+                              )
+                              .toList(),
+                        ),
+                      ),
+                    ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/main/components/side_menu.dart
+++ b/lib/screens/main/components/side_menu.dart
@@ -10,6 +10,7 @@ import 'package:admin/features/cadastro_itens/presentation/cadastro_itens_page.d
 import 'package:admin/features/cadastro_preparadores/presentation/cadastro_preparadores_page.dart';
 import 'package:admin/features/export_relatorios/presentation/export_relatorios_page.dart';
 import 'package:admin/features/export_relatorios/presentation/visualizar_relatorios_page.dart';
+import 'package:admin/features/export_relatorios/presentation/tempo_os_page.dart';
 import 'package:admin/features/cadastro_maquinas/presentation/cadastro_maquinas_page.dart';
 import 'package:admin/features/login/login_page.dart';
 import 'package:admin/features/users/users_page.dart';
@@ -60,6 +61,11 @@ class SideMenu extends ConsumerWidget {
           title: 'Visualizar relatórios',
           svgSrc: 'assets/icons/menu_doc.svg',
           press: () => _navigate(context, const VisualizarRelatoriosPage()),
+        ),
+        DrawerListTile(
+          title: 'Tempo por OS',
+          svgSrc: 'assets/icons/menu_doc.svg',
+          press: () => _navigate(context, const TempoOsPage()),
         ),
       ]);
     }
@@ -162,8 +168,11 @@ class SideMenu extends ConsumerWidget {
                 auth = ref.read(authServiceProvider);
               }
               if (auth == null || !auth.isAdmin) {
-                ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
-                    content: Text('Acesso restrito a administradores')));
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(
+                    content: Text('Acesso restrito a administradores'),
+                  ),
+                );
                 return;
               }
               _navigate(context, MainScreen());
@@ -175,9 +184,7 @@ class SideMenu extends ConsumerWidget {
     return Drawer(
       child: ListView(
         children: [
-          DrawerHeader(
-            child: Image.asset('assets/images/logo.png'),
-          ),
+          DrawerHeader(child: Image.asset('assets/images/logo.png')),
           ...items,
         ],
       ),
@@ -207,10 +214,7 @@ class DrawerListTile extends StatelessWidget {
         colorFilter: const ColorFilter.mode(Colors.white54, BlendMode.srcIn),
         height: 16,
       ),
-      title: Text(
-        title,
-        style: const TextStyle(color: Colors.white54),
-      ),
+      title: Text(title, style: const TextStyle(color: Colors.white54)),
     );
   }
 }


### PR DESCRIPTION
## Summary
- add TempoOsPage to compute time between OS release and finalization
- expose the new report in the dashboard side menu
- clean up machine edit dialog controllers

## Testing
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_68bb0ea275408331bd1ad9042508f31a