### PR TITLE
Add custom window bar and window controls

### DIFF
--- a/lib/features/cadastro_itens/presentation/cadastro_itens_page.dart
+++ b/lib/features/cadastro_itens/presentation/cadastro_itens_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:admin/screens/main/components/side_menu.dart';
+import 'package:admin/widgets/window_bar.dart';
 
 import '../../../services/supervisao_service.dart';
 
@@ -39,18 +40,14 @@ class _CadastroItensPageState extends State<CadastroItensPage>
       // portanto não deve aparecer para o usuário
       _camposAdd = [
         for (var c in campos)
-          if (c != 'idx_medida') c
+          if (c != 'idx_medida') c,
       ];
-      _controllersAdd = {
-        for (var c in _camposAdd) c: TextEditingController()
-      };
+      _controllersAdd = {for (var c in _camposAdd) c: TextEditingController()};
     });
   }
 
   Future<void> _adicionar() async {
-    final dados = {
-      for (var c in _camposAdd) c: _controllersAdd[c]!.text
-    };
+    final dados = {for (var c in _camposAdd) c: _controllersAdd[c]!.text};
     final ok = await _service.inserir(_tabelaAdd, dados);
     if (!mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(
@@ -71,18 +68,22 @@ class _CadastroItensPageState extends State<CadastroItensPage>
 
   Future<void> _buscarRegistros() async {
     final regs = await _service.fetchRegistros(
-        _tabelaEdit, _partCtrl.text, _opCtrl.text);
+      _tabelaEdit,
+      _partCtrl.text,
+      _opCtrl.text,
+    );
     final lista = regs
         .map((e) => Map<String, dynamic>.from(e)..remove('id'))
         .toList();
     setState(() {
       _registros = lista;
       _editControllers = lista
-          .map((item) => {
-                for (var entry in item.entries)
-                  entry.key:
-                      TextEditingController(text: '${entry.value ?? ''}')
-              })
+          .map(
+            (item) => {
+              for (var entry in item.entries)
+                entry.key: TextEditingController(text: '${entry.value ?? ''}'),
+            },
+          )
           .toList();
     });
   }
@@ -100,22 +101,20 @@ class _CadastroItensPageState extends State<CadastroItensPage>
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Cadastro de novos itens')),
+      appBar: const WindowBar(title: 'Cadastro de novos itens'),
       drawer: const SideMenu(current: SideMenuSection.dashboard),
       body: DefaultTabController(
         length: 2,
         child: Column(
           children: [
             const TabBar(
-              tabs: [Tab(text: 'Adicionar'), Tab(text: 'Editar')],
+              tabs: [
+                Tab(text: 'Adicionar'),
+                Tab(text: 'Editar'),
+              ],
             ),
             Expanded(
-              child: TabBarView(
-                children: [
-                  _buildAdicionar(),
-                  _buildEditar(),
-                ],
-              ),
+              child: TabBarView(children: [_buildAdicionar(), _buildEditar()]),
             ),
           ],
         ),
@@ -184,7 +183,9 @@ class _CadastroItensPageState extends State<CadastroItensPage>
               ),
               const SizedBox(height: 8),
               FilledButton(
-                  onPressed: _buscarRegistros, child: const Text('Buscar')),
+                onPressed: _buscarRegistros,
+                child: const Text('Buscar'),
+              ),
             ],
           ),
         ),
@@ -206,8 +207,11 @@ class _CadastroItensPageState extends State<CadastroItensPage>
                           child: TextField(
                             controller: ctrls[k],
                             decoration: InputDecoration(labelText: k),
-                            enabled: !['idx_medida', 'partnumber', 'operacao']
-                                .contains(k),
+                            enabled: ![
+                              'idx_medida',
+                              'partnumber',
+                              'operacao',
+                            ].contains(k),
                           ),
                         ),
                       ),
@@ -216,13 +220,13 @@ class _CadastroItensPageState extends State<CadastroItensPage>
                         child: FilledButton(
                           onPressed: () {
                             final data = {
-                              for (var k in ctrls.keys) k: ctrls[k]!.text
+                              for (var k in ctrls.keys) k: ctrls[k]!.text,
                             };
                             _salvarEdicao(data);
                           },
                           child: const Text('Salvar'),
                         ),
-                      )
+                      ),
                     ],
                   ),
                 ),

--- a/lib/features/cadastro_maquinas/presentation/cadastro_maquinas_page.dart
+++ b/lib/features/cadastro_maquinas/presentation/cadastro_maquinas_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../../../controllers/machine_controller.dart';
+import 'package:admin/widgets/window_bar.dart';
 
 class CadastroMaquinasPage extends StatefulWidget {
   CadastroMaquinasPage({super.key, MachineController? controller})
@@ -44,7 +45,7 @@ class _CadastroMaquinasPageState extends State<CadastroMaquinasPage> {
   Widget build(BuildContext context) {
     final ctrl = widget.controller;
     return Scaffold(
-      appBar: AppBar(title: const Text('Cadastro de máquinas')),
+      appBar: const WindowBar(title: 'Cadastro de máquinas'),
       body: ctrl.isLoading
           ? const Center(child: CircularProgressIndicator())
           : Column(

--- a/lib/features/cadastro_preparadores/presentation/cadastro_preparadores_page.dart
+++ b/lib/features/cadastro_preparadores/presentation/cadastro_preparadores_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:admin/screens/main/components/side_menu.dart';
+import 'package:admin/widgets/window_bar.dart';
 
 class CadastroPreparadoresPage extends StatelessWidget {
   const CadastroPreparadoresPage({super.key});
@@ -7,7 +8,7 @@ class CadastroPreparadoresPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Cadastro de Preparadores')),
+      appBar: const WindowBar(title: 'Cadastro de Preparadores'),
       drawer: const SideMenu(current: SideMenuSection.dashboard),
       body: const Center(child: Text('Cadastro de Preparadores')),
     );

--- a/lib/features/export_relatorios/presentation/export_relatorios_page.dart
+++ b/lib/features/export_relatorios/presentation/export_relatorios_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../../../screens/main/components/side_menu.dart';
+import 'package:admin/widgets/window_bar.dart';
 import '../../../services/report_service.dart';
 
 /// Page that allows the user to export reports to an Excel file.
@@ -24,8 +25,10 @@ class _ExportRelatoriosPageState extends State<ExportRelatoriosPage> {
 
   Future<void> _exportar() async {
     setState(() => _loading = true);
-    final ok = await ReportService()
-        .exportToExcel(os: _osController.text, tipo: _tipo);
+    final ok = await ReportService().exportToExcel(
+      os: _osController.text,
+      tipo: _tipo,
+    );
     if (!mounted) return;
     setState(() => _loading = false);
     final msg = ok ? 'Relatório salvo com sucesso' : 'Falha ao exportar';
@@ -35,7 +38,7 @@ class _ExportRelatoriosPageState extends State<ExportRelatoriosPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Exportar relatórios')),
+      appBar: const WindowBar(title: 'Exportar relatórios'),
       drawer: const SideMenu(current: SideMenuSection.dashboard),
       body: Padding(
         padding: const EdgeInsets.all(16),

--- a/lib/features/export_relatorios/presentation/tempo_os_page.dart
+++ b/lib/features/export_relatorios/presentation/tempo_os_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../../../screens/main/components/side_menu.dart';
+import 'package:admin/widgets/window_bar.dart';
 import '../../../services/report_service.dart';
 
 /// Page that displays the time spent on an OS based on release and
@@ -117,7 +118,7 @@ class _TempoOsPageState extends State<TempoOsPage> {
     };
     final headers = headerMap.keys.toList();
     return Scaffold(
-      appBar: AppBar(title: const Text('Tempo por OS')),
+      appBar: const WindowBar(title: 'Tempo por OS'),
       drawer: const SideMenu(current: SideMenuSection.dashboard),
       body: Padding(
         padding: const EdgeInsets.all(16),

--- a/lib/features/export_relatorios/presentation/visualizar_relatorios_page.dart
+++ b/lib/features/export_relatorios/presentation/visualizar_relatorios_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../../../screens/main/components/side_menu.dart';
+import 'package:admin/widgets/window_bar.dart';
 import '../../../services/report_service.dart';
 
 /// Page that displays report data directly without exporting to Excel.
@@ -140,7 +141,7 @@ class _VisualizarRelatoriosPageState extends State<VisualizarRelatoriosPage> {
           };
     final headers = headerMap.keys.toList();
     return Scaffold(
-      appBar: AppBar(title: const Text('Visualizar relatórios')),
+      appBar: const WindowBar(title: 'Visualizar relatórios'),
       drawer: const SideMenu(current: SideMenuSection.dashboard),
       body: Padding(
         padding: const EdgeInsets.all(16),

--- a/lib/features/finalizar_os/presentation/finalizar_os_page.dart
+++ b/lib/features/finalizar_os/presentation/finalizar_os_page.dart
@@ -10,6 +10,7 @@ import 'package:http/http.dart' as http;
 import 'package:admin/features/preparacao/data/models.dart';
 import 'package:admin/features/preparacao/data/repository_provider.dart';
 import 'package:admin/screens/main/components/side_menu.dart';
+import 'package:admin/widgets/window_bar.dart';
 import 'package:admin/utils/string_utils.dart';
 import 'package:admin/services/machine_service.dart';
 import 'package:admin/models/machine.dart';
@@ -229,15 +230,17 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
     }
 
     // Verifica se há alguma medida reprovada
-    final reprovadas = medidas.where((m) =>
-        m.status == StatusMedida.reprovadaAbaixo ||
-        m.status == StatusMedida.reprovadaAcima).toList();
+    final reprovadas = medidas
+        .where(
+          (m) =>
+              m.status == StatusMedida.reprovadaAbaixo ||
+              m.status == StatusMedida.reprovadaAcima,
+        )
+        .toList();
     if (reprovadas.isNotEmpty) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text('Uma ou mais medidas foram reprovadas.'),
-        ),
+        const SnackBar(content: Text('Uma ou mais medidas foram reprovadas.')),
       );
       return;
     }
@@ -338,8 +341,8 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
         reOk && osOk && maquinaOk && todasOk && !_registrando && !_osFinalizada;
 
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Finalizar OS'),
+      appBar: WindowBar(
+        title: 'Finalizar OS',
         actions: [
           Padding(
             padding: const EdgeInsets.only(right: 12.0),

--- a/lib/features/main_menu/main_menu_page.dart
+++ b/lib/features/main_menu/main_menu_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:admin/screens/main/main_screen.dart';
 import 'package:admin/screens/main/components/side_menu.dart';
+import 'package:admin/widgets/window_bar.dart';
 import '../preparacao/presentation/preparacao_page.dart';
 import '../operador/presentation/operador_page.dart';
 import '../finalizar_os/presentation/finalizar_os_page.dart';
@@ -15,13 +16,11 @@ class MainMenuPage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     void open(BuildContext context, Widget page) {
-      Navigator.of(context).push(
-        MaterialPageRoute(builder: (_) => page),
-      );
+      Navigator.of(context).push(MaterialPageRoute(builder: (_) => page));
     }
 
     return Scaffold(
-      appBar: AppBar(title: const Text('Menu Principal')),
+      appBar: const WindowBar(title: 'Menu Principal'),
       drawer: const SideMenu(current: SideMenuSection.mainMenu),
       body: Column(
         children: [
@@ -49,12 +48,11 @@ class MainMenuPage extends ConsumerWidget {
                 ),
                 _MenuCard(
                   title: 'Administração',
-                    onTap: () async {
+                  onTap: () async {
                     var auth = ref.read(authServiceProvider);
                     if (auth == null) {
                       final ok = await Navigator.of(context).push<bool>(
-                        MaterialPageRoute(
-                            builder: (_) => const LoginPage()),
+                        MaterialPageRoute(builder: (_) => const LoginPage()),
                       );
                       if (ok != true) return;
                       auth = ref.read(authServiceProvider);
@@ -62,7 +60,8 @@ class MainMenuPage extends ConsumerWidget {
                     if (auth == null || !auth.isAdmin) {
                       ScaffoldMessenger.of(context).showSnackBar(
                         const SnackBar(
-                            content: Text('Acesso restrito a administradores')),
+                          content: Text('Acesso restrito a administradores'),
+                        ),
                       );
                       return;
                     }

--- a/lib/features/operador/presentation/operador_page.dart
+++ b/lib/features/operador/presentation/operador_page.dart
@@ -3,7 +3,6 @@ import 'dart:io';
 import 'dart:convert';
 import 'package:flutter/services.dart';
 
-
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:http/http.dart' as http;
@@ -11,6 +10,7 @@ import 'package:http/http.dart' as http;
 import '../../preparacao/data/models.dart';
 import '../data/repository_provider.dart';
 import 'package:admin/screens/main/components/side_menu.dart';
+import 'package:admin/widgets/window_bar.dart';
 import 'package:admin/utils/string_utils.dart';
 import 'package:admin/services/machine_service.dart';
 import 'package:admin/models/machine.dart';
@@ -18,10 +18,13 @@ import 'package:admin/models/machine.dart';
 /// >>>>> Ajuste para o endereço/porta do seu Flask <<<<<
 const String kBaseUrl = 'http://192.168.0.241:5005';
 
-final medidasOperadorControllerProvider = StateNotifierProvider.autoDispose<
-    MedidasOperadorController, AsyncValue<List<MedidaItem>>>((ref) {
-  return MedidasOperadorController(ref);
-});
+final medidasOperadorControllerProvider =
+    StateNotifierProvider.autoDispose<
+      MedidasOperadorController,
+      AsyncValue<List<MedidaItem>>
+    >((ref) {
+      return MedidasOperadorController(ref);
+    });
 
 class MedidasOperadorController
     extends StateNotifier<AsyncValue<List<MedidaItem>>> {
@@ -35,8 +38,10 @@ class MedidasOperadorController
     state = const AsyncValue.loading();
     try {
       final repo = _ref.read(operadorRepositoryProvider);
-      final itens =
-      await repo.getMedidas(partnumber: partnumber, operacao: operacao);
+      final itens = await repo.getMedidas(
+        partnumber: partnumber,
+        operacao: operacao,
+      );
       state = AsyncValue.data(itens);
     } catch (e, st) {
       state = AsyncValue.error(e, st);
@@ -121,13 +126,15 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
         setState(() {
           _maquinas.addAll(list);
           _categorias.addAll(
-              _maquinas.map((e) => e.categoria).toSet().toList()..sort());
+            _maquinas.map((e) => e.categoria).toSet().toList()..sort(),
+          );
         });
       }
     } catch (e) {
       if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(SnackBar(content: Text('Erro ao carregar máquinas: $e')));
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Erro ao carregar máquinas: $e')),
+        );
       }
     }
   }
@@ -150,7 +157,9 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
         (_maquinaSel ?? '').isEmpty) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Preencha RE, O.S. e máquina para registrar.')),
+        const SnackBar(
+          content: Text('Preencha RE, O.S. e máquina para registrar.'),
+        ),
       );
       return;
     }
@@ -168,8 +177,8 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-            content:
-            Text('Faltam ${faltando.length} medições para selecionar.')),
+          content: Text('Faltam ${faltando.length} medições para selecionar.'),
+        ),
       );
       return;
     }
@@ -241,15 +250,17 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
       } else {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-              content: Text(
-                  'Falha ao registrar: ${resp.statusCode} ${resp.body}')),
+            content: Text(
+              'Falha ao registrar: ${resp.statusCode} ${resp.body}',
+            ),
+          ),
         );
       }
     } catch (e) {
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Erro ao registrar: $e')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('Erro ao registrar: $e')));
     } finally {
       if (mounted) setState(() => _registrando = false);
     }
@@ -278,9 +289,9 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
           .timeout(const Duration(seconds: 20));
       if (!mounted) return;
       if (resp.statusCode == 200) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Jornada pausada.')),
-        );
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(const SnackBar(content: Text('Jornada pausada.')));
       } else {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text('Falha: ${resp.statusCode} ${resp.body}')),
@@ -288,8 +299,9 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
       }
     } catch (e) {
       if (!mounted) return;
-      ScaffoldMessenger.of(context)
-          .showSnackBar(SnackBar(content: Text('Erro: $e')));
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('Erro: $e')));
     }
   }
 
@@ -310,9 +322,9 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
           .timeout(const Duration(seconds: 20));
       if (!mounted) return;
       if (resp.statusCode == 200) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Produção encerrada.')),
-        );
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(const SnackBar(content: Text('Produção encerrada.')));
       } else {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text('Falha: ${resp.statusCode} ${resp.body}')),
@@ -320,8 +332,9 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
       }
     } catch (e) {
       if (!mounted) return;
-      ScaffoldMessenger.of(context)
-          .showSnackBar(SnackBar(content: Text('Erro: $e')));
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('Erro: $e')));
     }
   }
 
@@ -357,26 +370,31 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
     final maquinaOk = (_maquinaSel ?? '').isNotEmpty;
 
     // todas respondidas?
-    final todasRespondidas = medidas.isNotEmpty &&
-        medidas.every((m) =>
-        m.status != StatusMedida.pendente && (m.medicao ?? '').isNotEmpty);
+    final todasRespondidas =
+        medidas.isNotEmpty &&
+        medidas.every(
+          (m) =>
+              m.status != StatusMedida.pendente && (m.medicao ?? '').isNotEmpty,
+        );
 
     final podeRegistrar =
         reOk && osOk && maquinaOk && todasRespondidas && !_registrando;
 
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Área do Operador'),
+      appBar: WindowBar(
+        title: 'Área do Operador',
         actions: [
           Padding(
             padding: const EdgeInsets.only(right: 12.0),
             child: Center(
               child: Text(
-                Platform.isWindows ? 'Windows: leitura direta/API' : 'Android: via API',
+                Platform.isWindows
+                    ? 'Windows: leitura direta/API'
+                    : 'Android: via API',
                 style: const TextStyle(fontSize: 12),
               ),
             ),
-          )
+          ),
         ],
       ),
       drawer: const SideMenu(current: SideMenuSection.operador),
@@ -396,15 +414,19 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                             controller: _reCtrl,
                             textInputAction: TextInputAction.next,
                             keyboardType: TextInputType.number,
-                            inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                            inputFormatters: [
+                              FilteringTextInputFormatter.digitsOnly,
+                            ],
                             decoration: const InputDecoration(
-                              labelText: 'R.E. do Preparador', // ajuste o texto se for Operador
+                              labelText:
+                                  'R.E. do Preparador', // ajuste o texto se for Operador
                               border: OutlineInputBorder(),
                             ),
                             validator: (v) {
                               final s = (v ?? '').trim();
                               if (s.isEmpty) return 'Obrigatório';
-                              if (!RegExp(r'^\d+$').hasMatch(s)) return 'Apenas números';
+                              if (!RegExp(r'^\d+$').hasMatch(s))
+                                return 'Apenas números';
                               return null;
                             },
                           ),
@@ -416,7 +438,9 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                             controller: _osCtrl,
                             textInputAction: TextInputAction.next,
                             keyboardType: TextInputType.number,
-                            inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                            inputFormatters: [
+                              FilteringTextInputFormatter.digitsOnly,
+                            ],
                             decoration: const InputDecoration(
                               labelText: 'O.S.',
                               border: OutlineInputBorder(),
@@ -424,7 +448,8 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                             validator: (v) {
                               final s = (v ?? '').trim();
                               if (s.isEmpty) return 'Obrigatório';
-                              if (!RegExp(r'^\d+$').hasMatch(s)) return 'Apenas números';
+                              if (!RegExp(r'^\d+$').hasMatch(s))
+                                return 'Apenas números';
                               return null;
                             },
                           ),
@@ -444,8 +469,12 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                               border: OutlineInputBorder(),
                             ),
                             items: _categorias
-                                .map((c) =>
-                                    DropdownMenuItem(value: c, child: Text(c)))
+                                .map(
+                                  (c) => DropdownMenuItem(
+                                    value: c,
+                                    child: Text(c),
+                                  ),
+                                )
                                 .toList(),
                             onChanged: (v) => setState(() {
                               _categoriaSel = v;
@@ -465,11 +494,14 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                             ),
                             items: _maquinas
                                 .where((m) => m.categoria == _categoriaSel)
-                                .map((m) => DropdownMenuItem(
-                                    value: m.codigo, child: Text(m.codigo)))
+                                .map(
+                                  (m) => DropdownMenuItem(
+                                    value: m.codigo,
+                                    child: Text(m.codigo),
+                                  ),
+                                )
                                 .toList(),
-                            onChanged: (v) =>
-                                setState(() => _maquinaSel = v),
+                            onChanged: (v) => setState(() => _maquinaSel = v),
                             validator: (v) =>
                                 (v == null || v.isEmpty) ? 'Obrigatório' : null,
                           ),
@@ -490,8 +522,9 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                               labelText: 'Código da peça (PartNumber)',
                               border: OutlineInputBorder(),
                             ),
-                            validator: (v) =>
-                            (v == null || v.trim().isEmpty) ? 'Obrigatório' : null,
+                            validator: (v) => (v == null || v.trim().isEmpty)
+                                ? 'Obrigatório'
+                                : null,
                           ),
                         ),
                         const SizedBox(width: 12),
@@ -500,7 +533,9 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                           child: TextFormField(
                             controller: _opCtrl,
                             keyboardType: TextInputType.number,
-                            inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                            inputFormatters: [
+                              FilteringTextInputFormatter.digitsOnly,
+                            ],
                             decoration: const InputDecoration(
                               labelText: 'Operação',
                               border: OutlineInputBorder(),
@@ -508,7 +543,8 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                             validator: (v) {
                               final s = (v ?? '').trim();
                               if (s.isEmpty) return 'Obrigatório';
-                              if (!RegExp(r'^\d+$').hasMatch(s)) return 'Apenas números';
+                              if (!RegExp(r'^\d+$').hasMatch(s))
+                                return 'Apenas números';
                               return null;
                             },
                           ),
@@ -524,11 +560,13 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                           if (_formKey.currentState!.validate()) {
                             FocusScope.of(context).unfocus();
                             await ref
-                                .read(medidasOperadorControllerProvider.notifier)
+                                .read(
+                                  medidasOperadorControllerProvider.notifier,
+                                )
                                 .carregar(
-                              partnumber: normalizeCode(_partCtrl.text),
-                              operacao: normalizeCode(_opCtrl.text),
-                            );
+                                  partnumber: normalizeCode(_partCtrl.text),
+                                  operacao: normalizeCode(_opCtrl.text),
+                                );
                           }
                         },
                         icon: const Icon(Icons.search),
@@ -544,7 +582,9 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                   data: (list) {
                     if (list.isEmpty) {
                       return const Center(
-                        child: Text('Nenhuma medida encontrada para a chave informada.'),
+                        child: Text(
+                          'Nenhuma medida encontrada para a chave informada.',
+                        ),
                       );
                     }
                     return ListView.separated(
@@ -562,10 +602,10 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                       },
                     );
                   },
-                  loading: () => const Center(child: CircularProgressIndicator()),
-                  error: (e, _) => Center(
-                    child: Text('Erro ao carregar:\n${e.toString()}'),
-                  ),
+                  loading: () =>
+                      const Center(child: CircularProgressIndicator()),
+                  error: (e, _) =>
+                      Center(child: Text('Erro ao carregar:\n${e.toString()}')),
                 ),
               ),
               const SizedBox(height: 10),
@@ -577,17 +617,13 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                     if (value == 'encerrar') _confirmEncerrarProducao();
                   },
                   itemBuilder: (context) => const [
-                    PopupMenuItem(
-                      value: 'fim',
-                      child: Text('Fim de Jornada'),
-                    ),
+                    PopupMenuItem(value: 'fim', child: Text('Fim de Jornada')),
                     PopupMenuItem(
                       value: 'encerrar',
                       child: Text('Encerrar produção'),
                     ),
                   ],
                 ),
-
               ),
               const SizedBox(height: 10),
               SizedBox(
@@ -598,7 +634,8 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                       ? const SizedBox(
                           width: 18,
                           height: 18,
-                          child: CircularProgressIndicator(strokeWidth: 2))
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
                       : const Icon(Icons.save_outlined),
                   label: const Text('Registrar amostragem'),
                 ),
@@ -627,16 +664,28 @@ class _MeasurementTile extends StatelessWidget {
   String _nfd(String s) {
     // normalização simples (sem pacote intl)
     const rep = {
-      'á': 'a', 'à': 'a', 'ã': 'a', 'â': 'a',
-      'é': 'e', 'ê': 'e',
+      'á': 'a',
+      'à': 'a',
+      'ã': 'a',
+      'â': 'a',
+      'é': 'e',
+      'ê': 'e',
       'í': 'i',
-      'ó': 'o', 'ô': 'o', 'õ': 'o',
+      'ó': 'o',
+      'ô': 'o',
+      'õ': 'o',
       'ú': 'u',
       'ç': 'c',
-      'Á': 'A', 'À': 'A', 'Ã': 'A', 'Â': 'A',
-      'É': 'E', 'Ê': 'E',
+      'Á': 'A',
+      'À': 'A',
+      'Ã': 'A',
+      'Â': 'A',
+      'É': 'E',
+      'Ê': 'E',
       'Í': 'I',
-      'Ó': 'O', 'Ô': 'O', 'Õ': 'O',
+      'Ó': 'O',
+      'Ô': 'O',
+      'Õ': 'O',
       'Ú': 'U',
       'Ç': 'C',
     };
@@ -653,8 +702,24 @@ class _MeasurementTile extends StatelessWidget {
   bool get _isVisualRugParalelismoOrAfins {
     final t = _norm(item.titulo);
     final inst = _norm(item.instrumento);
-    return _containsAny(t, ['visual', 'rug', 'paralelismo', 'anel de rosca passa', 'cqf', 'simetria', 'concentricidade']) ||
-        _containsAny(inst, ['visual', 'rug', 'rugosimetro', 'paralelismo', 'anel de rosca passa', 'cqf', 'simetria']);
+    return _containsAny(t, [
+          'visual',
+          'rug',
+          'paralelismo',
+          'anel de rosca passa',
+          'cqf',
+          'simetria',
+          'concentricidade',
+        ]) ||
+        _containsAny(inst, [
+          'visual',
+          'rug',
+          'rugosimetro',
+          'paralelismo',
+          'anel de rosca passa',
+          'cqf',
+          'simetria',
+        ]);
   }
 
   bool get _isTampao {
@@ -664,23 +729,20 @@ class _MeasurementTile extends StatelessWidget {
         _containsAny(inst, ['tamp', 'tampao', 'tampão', 'tampa']);
   }
 
-  Set<String> _partsFromMedicao(String? medicao) =>
-      (medicao ?? '')
-          .split('|')
-          .map((s) => s.trim())
-          .where((s) => s.isNotEmpty)
-          .toSet();
+  Set<String> _partsFromMedicao(String? medicao) => (medicao ?? '')
+      .split('|')
+      .map((s) => s.trim())
+      .where((s) => s.isNotEmpty)
+      .toSet();
 
   String _joinParts(Set<String> parts) => parts.join(' | ');
 
   StatusMedida _statusFromParts(Set<String> parts) {
     final hasPassa = parts.any((p) => p.startsWith('Lado passa'));
-    final hasNaoPassa =
-        parts.any((p) => p.startsWith('Lado não passa'));
+    final hasNaoPassa = parts.any((p) => p.startsWith('Lado não passa'));
     if (hasPassa && hasNaoPassa) {
       final passaReprovado = parts.contains('Lado passa — Reprovado');
-      final naoPassaReprovado =
-          parts.contains('Lado não passa — Reprovado');
+      final naoPassaReprovado = parts.contains('Lado não passa — Reprovado');
       if (passaReprovado && naoPassaReprovado) {
         return StatusMedida.reprovadaAcima;
       }
@@ -700,7 +762,9 @@ class _MeasurementTile extends StatelessWidget {
   bool _near(double a, double b) => (a - b).abs() <= 0.005;
 
   Color _fgOn(Color bg) =>
-      ThemeData.estimateBrightnessForColor(bg) == Brightness.dark ? Colors.white : Colors.black87;
+      ThemeData.estimateBrightnessForColor(bg) == Brightness.dark
+      ? Colors.white
+      : Colors.black87;
 
   Widget _pill({
     required String text,
@@ -726,10 +790,7 @@ class _MeasurementTile extends StatelessWidget {
         ),
         child: Text(
           text,
-          style: TextStyle(
-            fontWeight: FontWeight.w600,
-            color: fgColor,
-          ),
+          style: TextStyle(fontWeight: FontWeight.w600, color: fgColor),
         ),
       ),
     );
@@ -762,111 +823,118 @@ class _MeasurementTile extends StatelessWidget {
       elevation: 0.5,
       child: Padding(
         padding: const EdgeInsets.all(12.0),
-        child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
-          Text(item.titulo.isEmpty ? '(sem título)' : item.titulo, style: styleLabel),
-          if (subtitulo.isNotEmpty) ...[
-            const SizedBox(height: 4),
-            Text(subtitulo, style: styleSpec),
-          ],
-          if ((item.periodicidade ?? '').isNotEmpty) ...[
-            const SizedBox(height: 4),
-            Text('Periodicidade: ${item.periodicidade}', style: styleSpec),
-          ],
-          if ((item.instrumento ?? '').isNotEmpty) ...[
-            const SizedBox(height: 2),
-            Text('Instrumento: ${item.instrumento}', style: styleSpec),
-          ],
-          const SizedBox(height: 10),
-
-          // Modo 1: Visual/Rug/Paralelismo/Anel de rosca passa/CQF/Simetria (binário)
-          if (_isVisualRugParalelismoOrAfins) ...[
-            Wrap(
-              spacing: 8,
-              runSpacing: 8,
-              children: [
-                _pill(
-                  text: 'Aprovado',
-                  bg: Colors.green.shade200,
-                  border: Colors.green.shade600,
-                  fg: Colors.green.shade900,
-                  selected: item.medicao == 'Aprovado',
-                  onTap: () => onSelect(StatusMedida.ok, 'Aprovado'),
-                ),
-                _pill(
-                  text: 'Reprovado',
-                  bg: Colors.red.shade100,
-                  border: Colors.red.shade400,
-                  selected: item.medicao == 'Reprovado',
-                  onTap: () =>
-                      onSelect(StatusMedida.reprovadaAcima, 'Reprovado'),
-                ),
-              ],
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              item.titulo.isEmpty ? '(sem título)' : item.titulo,
+              style: styleLabel,
             ),
-          ]
-          // Modo 2: Tampão (4 botões)
-          else if (_isTampao) ...[
-            Builder(builder: (context) {
-              final parts = _partsFromMedicao(item.medicao);
-              return Wrap(
+            if (subtitulo.isNotEmpty) ...[
+              const SizedBox(height: 4),
+              Text(subtitulo, style: styleSpec),
+            ],
+            if ((item.periodicidade ?? '').isNotEmpty) ...[
+              const SizedBox(height: 4),
+              Text('Periodicidade: ${item.periodicidade}', style: styleSpec),
+            ],
+            if ((item.instrumento ?? '').isNotEmpty) ...[
+              const SizedBox(height: 2),
+              Text('Instrumento: ${item.instrumento}', style: styleSpec),
+            ],
+            const SizedBox(height: 10),
+
+            // Modo 1: Visual/Rug/Paralelismo/Anel de rosca passa/CQF/Simetria (binário)
+            if (_isVisualRugParalelismoOrAfins) ...[
+              Wrap(
                 spacing: 8,
                 runSpacing: 8,
                 children: [
                   _pill(
-                    text: 'Lado passa — Aprovado',
+                    text: 'Aprovado',
                     bg: Colors.green.shade200,
                     border: Colors.green.shade600,
                     fg: Colors.green.shade900,
-                    selected: parts.contains('Lado passa — Aprovado'),
-                    onTap: () {
-                      final p = _partsFromMedicao(item.medicao);
-                      p.removeWhere((e) => e.startsWith('Lado passa'));
-                      p.add('Lado passa — Aprovado');
-                      onSelect(_statusFromParts(p), _joinParts(p));
-                    },
+                    selected: item.medicao == 'Aprovado',
+                    onTap: () => onSelect(StatusMedida.ok, 'Aprovado'),
                   ),
                   _pill(
-                    text: 'Lado passa — Reprovado',
+                    text: 'Reprovado',
                     bg: Colors.red.shade100,
                     border: Colors.red.shade400,
-                    selected: parts.contains('Lado passa — Reprovado'),
-                    onTap: () {
-                      final p = _partsFromMedicao(item.medicao);
-                      p.removeWhere((e) => e.startsWith('Lado passa'));
-                      p.add('Lado passa — Reprovado');
-                      onSelect(_statusFromParts(p), _joinParts(p));
-                    },
-                  ),
-                  _pill(
-                    text: 'Lado não passa — Aprovado',
-                    bg: Colors.green.shade200,
-                    border: Colors.green.shade600,
-                    fg: Colors.green.shade900,
-                    selected: parts.contains('Lado não passa — Aprovado'),
-                    onTap: () {
-                      final p = _partsFromMedicao(item.medicao);
-                      p.removeWhere((e) => e.startsWith('Lado não passa'));
-                      p.add('Lado não passa — Aprovado');
-                      onSelect(_statusFromParts(p), _joinParts(p));
-                    },
-                  ),
-                  _pill(
-                    text: 'Lado não passa — Reprovado',
-                    bg: Colors.red.shade100,
-                    border: Colors.red.shade400,
-                    selected: parts.contains('Lado não passa — Reprovado'),
-                    onTap: () {
-                      final p = _partsFromMedicao(item.medicao);
-                      p.removeWhere((e) => e.startsWith('Lado não passa'));
-                      p.add('Lado não passa — Reprovado');
-                      onSelect(_statusFromParts(p), _joinParts(p));
-                    },
+                    selected: item.medicao == 'Reprovado',
+                    onTap: () =>
+                        onSelect(StatusMedida.reprovadaAcima, 'Reprovado'),
                   ),
                 ],
-              );
-            }),
-          ]
-          // Modo 3: Pílulas de tolerância + OK
-          else ...[
+              ),
+            ]
+            // Modo 2: Tampão (4 botões)
+            else if (_isTampao) ...[
+              Builder(
+                builder: (context) {
+                  final parts = _partsFromMedicao(item.medicao);
+                  return Wrap(
+                    spacing: 8,
+                    runSpacing: 8,
+                    children: [
+                      _pill(
+                        text: 'Lado passa — Aprovado',
+                        bg: Colors.green.shade200,
+                        border: Colors.green.shade600,
+                        fg: Colors.green.shade900,
+                        selected: parts.contains('Lado passa — Aprovado'),
+                        onTap: () {
+                          final p = _partsFromMedicao(item.medicao);
+                          p.removeWhere((e) => e.startsWith('Lado passa'));
+                          p.add('Lado passa — Aprovado');
+                          onSelect(_statusFromParts(p), _joinParts(p));
+                        },
+                      ),
+                      _pill(
+                        text: 'Lado passa — Reprovado',
+                        bg: Colors.red.shade100,
+                        border: Colors.red.shade400,
+                        selected: parts.contains('Lado passa — Reprovado'),
+                        onTap: () {
+                          final p = _partsFromMedicao(item.medicao);
+                          p.removeWhere((e) => e.startsWith('Lado passa'));
+                          p.add('Lado passa — Reprovado');
+                          onSelect(_statusFromParts(p), _joinParts(p));
+                        },
+                      ),
+                      _pill(
+                        text: 'Lado não passa — Aprovado',
+                        bg: Colors.green.shade200,
+                        border: Colors.green.shade600,
+                        fg: Colors.green.shade900,
+                        selected: parts.contains('Lado não passa — Aprovado'),
+                        onTap: () {
+                          final p = _partsFromMedicao(item.medicao);
+                          p.removeWhere((e) => e.startsWith('Lado não passa'));
+                          p.add('Lado não passa — Aprovado');
+                          onSelect(_statusFromParts(p), _joinParts(p));
+                        },
+                      ),
+                      _pill(
+                        text: 'Lado não passa — Reprovado',
+                        bg: Colors.red.shade100,
+                        border: Colors.red.shade400,
+                        selected: parts.contains('Lado não passa — Reprovado'),
+                        onTap: () {
+                          final p = _partsFromMedicao(item.medicao);
+                          p.removeWhere((e) => e.startsWith('Lado não passa'));
+                          p.add('Lado não passa — Reprovado');
+                          onSelect(_statusFromParts(p), _joinParts(p));
+                        },
+                      ),
+                    ],
+                  );
+                },
+              ),
+            ]
+            // Modo 3: Pílulas de tolerância + OK
+            else ...[
               Builder(
                 builder: (context) {
                   final chips = <Widget>[];
@@ -902,24 +970,26 @@ class _MeasurementTile extends StatelessWidget {
                         bd = Colors.red.shade400;
                         break;
                       default:
-
                         st = StatusMedida.alertaAbaixo;
 
                         bg = Colors.amber.shade100;
                         bd = Colors.amber.shade400;
                     }
 
-                    final label =
-                        d != null ? d.toStringAsFixed(2) : raw.toString();
+                    final label = d != null
+                        ? d.toStringAsFixed(2)
+                        : raw.toString();
                     final selected = item.medicao == label;
 
-                    chips.add(_pill(
-                      text: label,
-                      bg: bg,
-                      border: bd,
-                      selected: selected,
-                      onTap: () => onSelect(st, label),
-                    ));
+                    chips.add(
+                      _pill(
+                        text: label,
+                        bg: bg,
+                        border: bd,
+                        selected: selected,
+                        onTap: () => onSelect(st, label),
+                      ),
+                    );
                   }
 
                   // Insere OK central
@@ -936,15 +1006,12 @@ class _MeasurementTile extends StatelessWidget {
                     ),
                   );
 
-                  return Wrap(
-                    spacing: 8,
-                    runSpacing: 8,
-                    children: chips,
-                  );
+                  return Wrap(spacing: 8, runSpacing: 8, children: chips);
                 },
               ),
             ],
-        ]),
+          ],
+        ),
       ),
     );
   }

--- a/lib/features/preparacao/presentation/preparacao_page.dart
+++ b/lib/features/preparacao/presentation/preparacao_page.dart
@@ -10,6 +10,7 @@ import 'package:http/http.dart' as http;
 import 'package:admin/features/preparacao/data/models.dart';
 import 'package:admin/features/operador/data/repository_provider.dart';
 import 'package:admin/screens/main/components/side_menu.dart';
+import 'package:admin/widgets/window_bar.dart';
 import 'package:admin/utils/string_utils.dart';
 import 'package:admin/services/machine_service.dart';
 import 'package:admin/models/machine.dart';
@@ -350,8 +351,8 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
         reOk && osOk && maquinaOk && todasOk && !_registrando && !_osLiberada;
 
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Liberação de Máquina (FOR 007)'),
+      appBar: WindowBar(
+        title: 'Liberação de Máquina (FOR 007)',
         actions: [
           Padding(
             padding: const EdgeInsets.only(right: 12.0),

--- a/lib/features/users/users_page.dart
+++ b/lib/features/users/users_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../models/user.dart';
 import '../../services/auth_service.dart';
 import '../../services/user_service.dart';
+import 'package:admin/widgets/window_bar.dart';
 
 class UsersPage extends ConsumerStatefulWidget {
   const UsersPage({super.key});
@@ -36,7 +37,7 @@ class _UsersPageState extends ConsumerState<UsersPage> {
       return const Scaffold(body: Center(child: Text('Acesso negado')));
     }
     return Scaffold(
-      appBar: AppBar(title: const Text('Gerenciar Acessos')),
+      appBar: const WindowBar(title: 'Gerenciar Acessos'),
       body: FutureBuilder<List<AppUser>>(
         future: _future,
         builder: (context, snapshot) {
@@ -49,11 +50,14 @@ class _UsersPageState extends ConsumerState<UsersPage> {
               Expanded(
                 child: ListView(
                   children: users
-                      .map((u) => ListTile(
-                            title: Text(u.username),
-                            subtitle: Text(
-                                u.isAdmin ? 'Administrador' : 'Usuário'),
-                          ))
+                      .map(
+                        (u) => ListTile(
+                          title: Text(u.username),
+                          subtitle: Text(
+                            u.isAdmin ? 'Administrador' : 'Usuário',
+                          ),
+                        ),
+                      )
                       .toList(),
                 ),
               ),
@@ -63,13 +67,13 @@ class _UsersPageState extends ConsumerState<UsersPage> {
                   children: [
                     TextField(
                       controller: _userCtrl,
-                      decoration:
-                          const InputDecoration(labelText: 'Novo usuário'),
+                      decoration: const InputDecoration(
+                        labelText: 'Novo usuário',
+                      ),
                     ),
                     TextField(
                       controller: _passCtrl,
-                      decoration:
-                          const InputDecoration(labelText: 'Senha'),
+                      decoration: const InputDecoration(labelText: 'Senha'),
                       obscureText: true,
                     ),
                     SwitchListTile(
@@ -80,11 +84,12 @@ class _UsersPageState extends ConsumerState<UsersPage> {
                     ElevatedButton(
                       onPressed: () async {
                         final ok = await UserService().createUser(
-                            _userCtrl.text,
-                            _passCtrl.text,
-                            _isAdmin,
-                            auth.username,
-                            auth.password);
+                          _userCtrl.text,
+                          _passCtrl.text,
+                          _isAdmin,
+                          auth.username,
+                          auth.password,
+                        );
                         if (ok) {
                           setState(() {
                             _future = _load();
@@ -95,10 +100,10 @@ class _UsersPageState extends ConsumerState<UsersPage> {
                         }
                       },
                       child: const Text('Adicionar'),
-                    )
+                    ),
                   ],
                 ),
-              )
+              ),
             ],
           );
         },

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,9 +6,19 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:provider/provider.dart' as pv;
+import 'package:window_manager/window_manager.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+
+  await windowManager.ensureInitialized();
+  windowManager.waitUntilReadyToShow(
+    const WindowOptions(titleBarStyle: TitleBarStyle.hidden),
+    () async {
+      await windowManager.show();
+      await windowManager.focus();
+    },
+  );
 
   // Carrega .env de forma segura (não quebra se não existir)
   try {
@@ -28,9 +38,7 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return pv.MultiProvider(
       providers: [
-        pv.ChangeNotifierProvider(
-          create: (_) => MenuAppController(),
-        ),
+        pv.ChangeNotifierProvider(create: (_) => MenuAppController()),
       ],
       child: MaterialApp(
         debugShowCheckedModeBanner: false,

--- a/lib/widgets/window_bar.dart
+++ b/lib/widgets/window_bar.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:window_manager/window_manager.dart';
+
+/// Custom title bar with window controls and drag support.
+class WindowBar extends StatefulWidget implements PreferredSizeWidget {
+  const WindowBar({super.key, this.title, this.actions});
+
+  final String? title;
+  final List<Widget>? actions;
+
+  @override
+  Size get preferredSize => const Size.fromHeight(40);
+
+  @override
+  State<WindowBar> createState() => _WindowBarState();
+}
+
+class _WindowBarState extends State<WindowBar> {
+  bool _isMaximized = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _syncMaximized();
+  }
+
+  Future<void> _syncMaximized() async {
+    _isMaximized = await windowManager.isMaximized();
+    if (mounted) setState(() {});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      behavior: HitTestBehavior.translucent,
+      onPanStart: (_) => windowManager.startDragging(),
+      onDoubleTap: () async {
+        _isMaximized
+            ? await windowManager.unmaximize()
+            : await windowManager.maximize();
+        _syncMaximized();
+      },
+      child: Container(
+        height: widget.preferredSize.height,
+        color: const Color(0xFF2D2F33),
+        padding: const EdgeInsets.symmetric(horizontal: 8),
+        child: Row(
+          children: [
+            if (widget.title != null)
+              Text(
+                widget.title!,
+                style: Theme.of(context).textTheme.titleSmall,
+              ),
+            const Spacer(),
+            if (widget.actions != null) ...widget.actions!,
+            _buildButton(Icons.remove, () => windowManager.minimize()),
+            _buildButton(
+              _isMaximized ? Icons.filter_none : Icons.crop_square,
+              () async {
+                _isMaximized
+                    ? await windowManager.unmaximize()
+                    : await windowManager.maximize();
+                _syncMaximized();
+              },
+            ),
+            _buildButton(Icons.close, () => windowManager.close()),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildButton(IconData icon, VoidCallback onPressed) {
+    return IconButton(
+      icon: Icon(icon, size: 16),
+      padding: EdgeInsets.zero,
+      constraints: const BoxConstraints(minWidth: 40, minHeight: 40),
+      onPressed: onPressed,
+    );
+  }
+}

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,7 +6,11 @@ import FlutterMacOS
 import Foundation
 
 import path_provider_foundation
+import screen_retriever
+import window_manager
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
+  ScreenRetrieverPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverPlugin"))
+  WindowManagerPlugin.register(with: registry.registrar(forPlugin: "WindowManagerPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -263,26 +263,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: "8dcda04c3fc16c14f48a7bb586d4be1f0d1572731b6d81d51772ef47c02081e0"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "11.0.1"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -435,6 +435,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.6.1"
+  screen_retriever:
+    dependency: transitive
+    description:
+      name: screen_retriever
+      sha256: "6ee02c8a1158e6dae7ca430da79436e3b1c9563c8cf02f524af997c201ac2b90"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.9"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -492,10 +500,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.6"
   typed_data:
     dependency: transitive
     description:
@@ -532,10 +540,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:
@@ -552,6 +560,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
+  window_manager:
+    dependency: "direct main"
+    description:
+      name: window_manager
+      sha256: "8699323b30da4cdbe2aa2e7c9de567a6abd8a97d9a5c850a3c86dcd0b34bbfbf"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.9"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
   hive: ^2.2.3
   hive_flutter: ^1.1.0
   flutter_launcher_icons: ^0.13.1
+  window_manager: ^0.3.9
 
 flutter_icons:
   android: true

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,12 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <screen_retriever/screen_retriever_plugin.h>
+#include <window_manager/window_manager_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  ScreenRetrieverPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("ScreenRetrieverPlugin"));
+  WindowManagerPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("WindowManagerPlugin"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,8 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  screen_retriever
+  window_manager
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
## Summary
- integrate window_manager to hide native title bar
- implement reusable WindowBar with drag, minimize, maximize, close
- replace AppBar across pages with WindowBar for consistent window controls

## Testing
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_68c003414c1883319105eaa3f1e36c4b