### PR TITLE
Guard window manager usage on non-desktop platforms

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,20 +7,23 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:provider/provider.dart' as pv;
 import 'package:window_manager/window_manager.dart';
+import 'package:admin/utils/platform_utils.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  await windowManager.ensureInitialized();
-  windowManager.waitUntilReadyToShow(
-    const WindowOptions(
-      titleBarStyle: TitleBarStyle.hidden, // oculta a barra do sistema
-      size: Size(1000, 700),
-    ),
-        () async {
-      await windowManager.show();
-      await windowManager.focus();
-    },
-  );
+  if (isDesktop) {
+    await windowManager.ensureInitialized();
+    windowManager.waitUntilReadyToShow(
+      const WindowOptions(
+        titleBarStyle: TitleBarStyle.hidden, // oculta a barra do sistema
+        size: Size(1000, 700),
+      ),
+      () async {
+        await windowManager.show();
+        await windowManager.focus();
+      },
+    );
+  }
   // Carrega .env de forma segura (não quebra se não existir)
   try {
     await dotenv.load(fileName: ".env");
@@ -39,9 +42,7 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return pv.MultiProvider(
       providers: [
-        pv.ChangeNotifierProvider(
-          create: (_) => MenuAppController(),
-        ),
+        pv.ChangeNotifierProvider(create: (_) => MenuAppController()),
       ],
       child: MaterialApp(
         debugShowCheckedModeBanner: false,

--- a/lib/utils/platform_utils.dart
+++ b/lib/utils/platform_utils.dart
@@ -1,0 +1,8 @@
+import 'package:flutter/foundation.dart';
+
+/// Returns true if the current platform is a desktop platform.
+bool get isDesktop =>
+    !kIsWeb &&
+    (defaultTargetPlatform == TargetPlatform.windows ||
+        defaultTargetPlatform == TargetPlatform.linux ||
+        defaultTargetPlatform == TargetPlatform.macOS);

--- a/lib/widgets/window_bar.dart
+++ b/lib/widgets/window_bar.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:window_manager/window_manager.dart';
+import 'package:admin/utils/platform_utils.dart';
 
 /// Custom title bar with window controls and drag support.
 class WindowBar extends StatefulWidget implements PreferredSizeWidget {
@@ -21,16 +22,26 @@ class _WindowBarState extends State<WindowBar> {
   @override
   void initState() {
     super.initState();
-    _syncMaximized();
+    if (isDesktop) {
+      _syncMaximized();
+    }
   }
 
   Future<void> _syncMaximized() async {
+    if (!isDesktop) return;
     _isMaximized = await windowManager.isMaximized();
     if (mounted) setState(() {});
   }
 
   @override
   Widget build(BuildContext context) {
+    if (!isDesktop) {
+      return AppBar(
+        toolbarHeight: widget.preferredSize.height,
+        title: widget.title != null ? Text(widget.title!) : null,
+        actions: widget.actions,
+      );
+    }
     return GestureDetector(
       behavior: HitTestBehavior.translucent,
       onPanStart: (_) => windowManager.startDragging(),


### PR DESCRIPTION
## Summary
- add `isDesktop` helper
- skip `window_manager` initialization and custom window bar on non-desktop platforms

## Testing
- `flutter analyze`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_68c00ead39608331ba106180d3d8ba44