### PR TITLE
Enable immersive full-screen mode on Android

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:admin/constants.dart';
 import 'package:admin/controllers/menu_app_controller.dart';
 import 'package:admin/features/main_menu/main_menu_page.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -11,6 +12,9 @@ import 'package:admin/utils/platform_utils.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  if (isAndroid) {
+    SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky);
+  }
   if (isDesktop) {
     await windowManager.ensureInitialized();
     windowManager.waitUntilReadyToShow(

--- a/lib/utils/platform_utils.dart
+++ b/lib/utils/platform_utils.dart
@@ -6,3 +6,7 @@ bool get isDesktop =>
     (defaultTargetPlatform == TargetPlatform.windows ||
         defaultTargetPlatform == TargetPlatform.linux ||
         defaultTargetPlatform == TargetPlatform.macOS);
+
+/// Returns true if the current platform is Android.
+bool get isAndroid =>
+    !kIsWeb && defaultTargetPlatform == TargetPlatform.android;


### PR DESCRIPTION
## Summary
- Hide Android status and navigation bars using immersive sticky mode
- Add platform utility helper for detecting Android

## Testing
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_68c01174bc808331b34b9e4de74e3c49