### PR TITLE
Restore side menu on admin pages

### DIFF
--- a/lib/features/cadastro_maquinas/presentation/cadastro_maquinas_page.dart
+++ b/lib/features/cadastro_maquinas/presentation/cadastro_maquinas_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../../../controllers/machine_controller.dart';
 import 'package:admin/widgets/window_bar.dart';
+import 'package:admin/screens/main/components/side_menu.dart';
 
 class CadastroMaquinasPage extends StatefulWidget {
   CadastroMaquinasPage({super.key, MachineController? controller})
@@ -46,6 +47,7 @@ class _CadastroMaquinasPageState extends State<CadastroMaquinasPage> {
     final ctrl = widget.controller;
     return Scaffold(
       appBar: const WindowBar(title: 'Cadastro de máquinas'),
+      drawer: const SideMenu(current: SideMenuSection.dashboard),
       body: ctrl.isLoading
           ? const Center(child: CircularProgressIndicator())
           : Column(

--- a/lib/features/users/users_page.dart
+++ b/lib/features/users/users_page.dart
@@ -5,6 +5,7 @@ import '../../models/user.dart';
 import '../../services/auth_service.dart';
 import '../../services/user_service.dart';
 import 'package:admin/widgets/window_bar.dart';
+import 'package:admin/screens/main/components/side_menu.dart';
 
 class UsersPage extends ConsumerStatefulWidget {
   const UsersPage({super.key});
@@ -34,10 +35,14 @@ class _UsersPageState extends ConsumerState<UsersPage> {
   Widget build(BuildContext context) {
     final auth = ref.watch(authServiceProvider);
     if (auth == null || !auth.isAdmin) {
-      return const Scaffold(body: Center(child: Text('Acesso negado')));
+      return Scaffold(
+        drawer: const SideMenu(current: SideMenuSection.dashboard),
+        body: const Center(child: Text('Acesso negado')),
+      );
     }
     return Scaffold(
       appBar: const WindowBar(title: 'Gerenciar Acessos'),
+      drawer: const SideMenu(current: SideMenuSection.dashboard),
       body: FutureBuilder<List<AppUser>>(
         future: _future,
         builder: (context, snapshot) {


### PR DESCRIPTION
## Summary
- Reintroduce SideMenu to UsersPage for authenticated and access-denied states
- Reintroduce SideMenu to CadastroMaquinasPage to keep navigation consistent

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_68c024aab45c833189c57131efca398b