### PR TITLE
Restore side menu on Windows pages

### DIFF
--- a/lib/features/cadastro_itens/presentation/cadastro_itens_page.dart
+++ b/lib/features/cadastro_itens/presentation/cadastro_itens_page.dart
@@ -101,7 +101,7 @@ class _CadastroItensPageState extends State<CadastroItensPage>
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: const WindowBar(title: 'Cadastro de novos itens'),
+      appBar: const WindowBar(title: 'Cadastro de novos itens', showMenu: true),
       drawer: const SideMenu(current: SideMenuSection.dashboard),
       body: DefaultTabController(
         length: 2,

--- a/lib/features/cadastro_maquinas/presentation/cadastro_maquinas_page.dart
+++ b/lib/features/cadastro_maquinas/presentation/cadastro_maquinas_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../../../controllers/machine_controller.dart';
 import 'package:admin/widgets/window_bar.dart';
+import 'package:admin/screens/main/components/side_menu.dart';
 
 class CadastroMaquinasPage extends StatefulWidget {
   CadastroMaquinasPage({super.key, MachineController? controller})
@@ -45,7 +46,8 @@ class _CadastroMaquinasPageState extends State<CadastroMaquinasPage> {
   Widget build(BuildContext context) {
     final ctrl = widget.controller;
     return Scaffold(
-      appBar: const WindowBar(title: 'Cadastro de máquinas'),
+      appBar: const WindowBar(title: 'Cadastro de máquinas', showMenu: true),
+      drawer: const SideMenu(current: SideMenuSection.dashboard),
       body: ctrl.isLoading
           ? const Center(child: CircularProgressIndicator())
           : Column(

--- a/lib/features/cadastro_preparadores/presentation/cadastro_preparadores_page.dart
+++ b/lib/features/cadastro_preparadores/presentation/cadastro_preparadores_page.dart
@@ -8,7 +8,10 @@ class CadastroPreparadoresPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: const WindowBar(title: 'Cadastro de Preparadores'),
+      appBar: const WindowBar(
+        title: 'Cadastro de Preparadores',
+        showMenu: true,
+      ),
       drawer: const SideMenu(current: SideMenuSection.dashboard),
       body: const Center(child: Text('Cadastro de Preparadores')),
     );

--- a/lib/features/export_relatorios/presentation/export_relatorios_page.dart
+++ b/lib/features/export_relatorios/presentation/export_relatorios_page.dart
@@ -38,7 +38,7 @@ class _ExportRelatoriosPageState extends State<ExportRelatoriosPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: const WindowBar(title: 'Exportar relatórios'),
+      appBar: const WindowBar(title: 'Exportar relatórios', showMenu: true),
       drawer: const SideMenu(current: SideMenuSection.dashboard),
       body: Padding(
         padding: const EdgeInsets.all(16),

--- a/lib/features/export_relatorios/presentation/tempo_os_page.dart
+++ b/lib/features/export_relatorios/presentation/tempo_os_page.dart
@@ -118,7 +118,7 @@ class _TempoOsPageState extends State<TempoOsPage> {
     };
     final headers = headerMap.keys.toList();
     return Scaffold(
-      appBar: const WindowBar(title: 'Tempo por OS'),
+      appBar: const WindowBar(title: 'Tempo por OS', showMenu: true),
       drawer: const SideMenu(current: SideMenuSection.dashboard),
       body: Padding(
         padding: const EdgeInsets.all(16),

--- a/lib/features/export_relatorios/presentation/visualizar_relatorios_page.dart
+++ b/lib/features/export_relatorios/presentation/visualizar_relatorios_page.dart
@@ -141,7 +141,7 @@ class _VisualizarRelatoriosPageState extends State<VisualizarRelatoriosPage> {
           };
     final headers = headerMap.keys.toList();
     return Scaffold(
-      appBar: const WindowBar(title: 'Visualizar relatórios'),
+      appBar: const WindowBar(title: 'Visualizar relatórios', showMenu: true),
       drawer: const SideMenu(current: SideMenuSection.dashboard),
       body: Padding(
         padding: const EdgeInsets.all(16),

--- a/lib/features/finalizar_os/presentation/finalizar_os_page.dart
+++ b/lib/features/finalizar_os/presentation/finalizar_os_page.dart
@@ -343,6 +343,7 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
     return Scaffold(
       appBar: WindowBar(
         title: 'Finalizar OS',
+        showMenu: true,
         actions: [
           Padding(
             padding: const EdgeInsets.only(right: 12.0),

--- a/lib/features/main_menu/main_menu_page.dart
+++ b/lib/features/main_menu/main_menu_page.dart
@@ -20,7 +20,7 @@ class MainMenuPage extends ConsumerWidget {
     }
 
     return Scaffold(
-      appBar: const WindowBar(title: 'Menu Principal'),
+      appBar: const WindowBar(title: 'Menu Principal', showMenu: true),
       drawer: const SideMenu(current: SideMenuSection.mainMenu),
       body: Column(
         children: [

--- a/lib/features/operador/presentation/operador_page.dart
+++ b/lib/features/operador/presentation/operador_page.dart
@@ -383,6 +383,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
     return Scaffold(
       appBar: WindowBar(
         title: 'Área do Operador',
+        showMenu: true,
         actions: [
           Padding(
             padding: const EdgeInsets.only(right: 12.0),

--- a/lib/features/preparacao/presentation/preparacao_page.dart
+++ b/lib/features/preparacao/presentation/preparacao_page.dart
@@ -353,6 +353,7 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
     return Scaffold(
       appBar: WindowBar(
         title: 'Liberação de Máquina (FOR 007)',
+        showMenu: true,
         actions: [
           Padding(
             padding: const EdgeInsets.only(right: 12.0),

--- a/lib/features/users/users_page.dart
+++ b/lib/features/users/users_page.dart
@@ -5,6 +5,7 @@ import '../../models/user.dart';
 import '../../services/auth_service.dart';
 import '../../services/user_service.dart';
 import 'package:admin/widgets/window_bar.dart';
+import 'package:admin/screens/main/components/side_menu.dart';
 
 class UsersPage extends ConsumerStatefulWidget {
   const UsersPage({super.key});
@@ -34,10 +35,15 @@ class _UsersPageState extends ConsumerState<UsersPage> {
   Widget build(BuildContext context) {
     final auth = ref.watch(authServiceProvider);
     if (auth == null || !auth.isAdmin) {
-      return const Scaffold(body: Center(child: Text('Acesso negado')));
+      return Scaffold(
+        appBar: const WindowBar(title: 'Gerenciar Acessos', showMenu: true),
+        drawer: const SideMenu(current: SideMenuSection.dashboard),
+        body: const Center(child: Text('Acesso negado')),
+      );
     }
     return Scaffold(
-      appBar: const WindowBar(title: 'Gerenciar Acessos'),
+      appBar: const WindowBar(title: 'Gerenciar Acessos', showMenu: true),
+      drawer: const SideMenu(current: SideMenuSection.dashboard),
       body: FutureBuilder<List<AppUser>>(
         future: _future,
         builder: (context, snapshot) {

--- a/lib/widgets/window_bar.dart
+++ b/lib/widgets/window_bar.dart
@@ -4,10 +4,11 @@ import 'package:admin/utils/platform_utils.dart';
 
 /// Custom title bar with window controls and drag support.
 class WindowBar extends StatefulWidget implements PreferredSizeWidget {
-  const WindowBar({super.key, this.title, this.actions});
+  const WindowBar({super.key, this.title, this.actions, this.showMenu = false});
 
   final String? title;
   final List<Widget>? actions;
+  final bool showMenu;
 
   @override
   Size get preferredSize => const Size.fromHeight(40);
@@ -57,10 +58,23 @@ class _WindowBarState extends State<WindowBar> {
         padding: const EdgeInsets.symmetric(horizontal: 8),
         child: Row(
           children: [
+            if (widget.showMenu)
+              Builder(
+                builder: (context) => IconButton(
+                  icon: const Icon(Icons.menu),
+                  onPressed: () => Scaffold.of(context).openDrawer(),
+                  tooltip: MaterialLocalizations.of(
+                    context,
+                  ).openAppDrawerTooltip,
+                ),
+              ),
             if (widget.title != null)
-              Text(
-                widget.title!,
-                style: Theme.of(context).textTheme.titleSmall,
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 8),
+                child: Text(
+                  widget.title!,
+                  style: Theme.of(context).textTheme.titleSmall,
+                ),
               ),
             const Spacer(),
             if (widget.actions != null) ...widget.actions!,


### PR DESCRIPTION
## Summary
- Add optional menu button to WindowBar for opening the drawer on desktop
- Enable menu button across admin pages so side navigation works on Windows

## Testing
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_68c024aab45c833189c57131efca398b