### PR TITLE
Add WindowBar to supervision and login screens

### DIFF
--- a/lib/features/login/login_page.dart
+++ b/lib/features/login/login_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../services/auth_service.dart';
+import 'package:admin/widgets/window_bar.dart';
 
 class LoginPage extends ConsumerStatefulWidget {
   const LoginPage({super.key});
@@ -39,6 +40,7 @@ class _LoginPageState extends ConsumerState<LoginPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      appBar: const WindowBar(title: 'Login'),
       body: Center(
         child: SingleChildScrollView(
           padding: const EdgeInsets.all(32),

--- a/lib/screens/main/main_screen.dart
+++ b/lib/screens/main/main_screen.dart
@@ -3,6 +3,7 @@ import 'package:admin/responsive.dart';
 import 'package:admin/screens/dashboard/dashboard_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:admin/widgets/window_bar.dart';
 
 import 'components/side_menu.dart';
 
@@ -11,6 +12,7 @@ class MainScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       key: context.read<MenuAppController>().scaffoldKey,
+      appBar: const WindowBar(title: 'Supervisão', showMenu: true),
       drawer: const SideMenu(current: SideMenuSection.dashboard),
       body: SafeArea(
         child: Row(


### PR DESCRIPTION
## Summary
- show custom WindowBar on supervision dashboard screen with menu access
- ensure login page also includes WindowBar for window controls

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c04691d9bc8331be5dbc46c82016be