### PR TITLE
feat: smooth hover and press animations

### DIFF
--- a/lib/features/main_menu/main_menu_page.dart
+++ b/lib/features/main_menu/main_menu_page.dart
@@ -109,9 +109,8 @@ class _MenuImageButtonState extends State<_MenuImageButton> {
           onTapUp: (_) => setState(() => _pressed = false),
           onTapCancel: () => setState(() => _pressed = false),
           mouseCursor: SystemMouseCursors.click,
-          hoverColor: Colors.transparent,
-          highlightColor: Colors.transparent,
-          splashColor: Colors.transparent,
+          overlayColor: MaterialStateProperty.all(Colors.transparent),
+          splashFactory: NoSplash.splashFactory,
           child: ClipRRect(
             borderRadius: BorderRadius.circular(8),
             child: Image.asset(widget.image, fit: BoxFit.cover),


### PR DESCRIPTION
## Summary
- refine main menu button feedback with hover/press scale animations and transparent InkWell

## Testing
- `flutter test` *(fails: NotInitializedError in ProfileButton and layout overflow in AppBar)*

------
https://chatgpt.com/codex/tasks/task_e_68c06701e64c8331b33389c045df6d69