### PR TITLE
Fix main menu icon cropping

### DIFF
--- a/lib/features/main_menu/main_menu_page.dart
+++ b/lib/features/main_menu/main_menu_page.dart
@@ -113,7 +113,7 @@ class _MenuImageButtonState extends State<_MenuImageButton> {
           splashFactory: NoSplash.splashFactory,
           child: ClipRRect(
             borderRadius: BorderRadius.circular(8),
-            child: Image.asset(widget.image, fit: BoxFit.cover),
+            child: Image.asset(widget.image, fit: BoxFit.contain),
           ),
         ),
       ),


### PR DESCRIPTION
## Summary
- prevent icon images in main menu from being clipped by using `BoxFit.contain`

## Testing
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_68c06a50d06c83319e9dff50ab6ffa0f