### PR TITLE
feat: organize main menu buttons vertically

### DIFF
--- a/lib/features/main_menu/main_menu_page.dart
+++ b/lib/features/main_menu/main_menu_page.dart
@@ -47,23 +47,21 @@ class MainMenuPage extends ConsumerWidget {
           Expanded(
             child: SingleChildScrollView(
               child: Center(
-                child: Wrap(
-                  spacing: 0,
-                  runSpacing: 0,
+                child: Column(
                   children: [
-                    _MenuCard(
+                    _MenuButton(
                       image: 'assets/images/FOR007.png',
                       onPressed: () => open(context, const PreparacaoPage()),
                     ),
-                    _MenuCard(
+                    _MenuButton(
                       image: 'assets/images/Amostragem.png',
                       onPressed: () => open(context, const OperadorPage()),
                     ),
-                    _MenuCard(
+                    _MenuButton(
                       image: 'assets/images/FOR008.png',
                       onPressed: () => open(context, const OperadorPage()),
                     ),
-                    _MenuCard(
+                    _MenuButton(
                       image: 'assets/images/dashboard.png',
                       onPressed: openAdmin,
                     ),
@@ -78,17 +76,17 @@ class MainMenuPage extends ConsumerWidget {
   }
 }
 
-class _MenuCard extends StatefulWidget {
-  const _MenuCard({required this.image, required this.onPressed});
+class _MenuButton extends StatefulWidget {
+  const _MenuButton({required this.image, required this.onPressed});
 
   final String image;
   final VoidCallback onPressed;
 
   @override
-  State<_MenuCard> createState() => _MenuCardState();
+  State<_MenuButton> createState() => _MenuButtonState();
 }
 
-class _MenuCardState extends State<_MenuCard> {
+class _MenuButtonState extends State<_MenuButton> {
   bool _hovering = false;
   bool _pressed = false;
 
@@ -96,29 +94,30 @@ class _MenuCardState extends State<_MenuCard> {
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
-      width: 200,
-      height: 150,
+    final width = MediaQuery.of(context).size.width;
+    final buttonWidth = width < 500 ? width * 0.8 : 300.0;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8.0),
       child: AnimatedScale(
         scale: _scale,
         duration: const Duration(milliseconds: 150),
-        child: Card(
-          clipBehavior: Clip.hardEdge,
-          child: InkWell(
-            onTap: widget.onPressed,
-            onHover: (v) => setState(() => _hovering = v),
-            onTapDown: (_) => setState(() => _pressed = true),
-            onTapUp: (_) => setState(() => _pressed = false),
-            onTapCancel: () => setState(() => _pressed = false),
-            mouseCursor: SystemMouseCursors.click,
-            hoverColor: Colors.transparent,
-            highlightColor: Colors.transparent,
-            splashColor: Colors.transparent,
-            child: Center(
-              child: Image.asset(
-                widget.image,
-                fit: BoxFit.contain,
-              ),
+        child: SizedBox(
+          width: buttonWidth,
+          height: 150,
+          child: Material(
+            color: Colors.transparent,
+            child: InkWell(
+              onTap: widget.onPressed,
+              onHover: (v) => setState(() => _hovering = v),
+              onTapDown: (_) => setState(() => _pressed = true),
+              onTapUp: (_) => setState(() => _pressed = false),
+              onTapCancel: () => setState(() => _pressed = false),
+              mouseCursor: SystemMouseCursors.click,
+              hoverColor: Colors.transparent,
+              highlightColor: Colors.transparent,
+              splashColor: Colors.transparent,
+              child: Image.asset(widget.image, fit: BoxFit.contain),
             ),
           ),
         ),


### PR DESCRIPTION
## Summary
- show main menu options one per line with responsive buttons
- remove card-based layout in favor of image buttons

## Testing
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_68c2d0c73c6c8331a06403232429a100