### PR TITLE
Animate main menu logo to alternate images

### DIFF
--- a/lib/features/main_menu/main_menu_page.dart
+++ b/lib/features/main_menu/main_menu_page.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -9,11 +11,51 @@ import '../operador/presentation/operador_page.dart';
 import '../login/login_page.dart';
 import '../../services/auth_service.dart';
 
-class MainMenuPage extends ConsumerWidget {
+class MainMenuPage extends ConsumerStatefulWidget {
   const MainMenuPage({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<MainMenuPage> createState() => _MainMenuPageState();
+}
+
+/// Configuration for a single alternating logo.
+///
+/// Edit the width and height here to change each logo's size individually.
+class LogoConfig {
+  const LogoConfig({required this.asset, this.width, this.height});
+
+  final String asset;
+  final double? width;
+  final double? height;
+}
+
+class _MainMenuPageState extends ConsumerState<MainMenuPage> {
+  int _logoIndex = 0;
+  Timer? _timer;
+
+  /// List of logos that the header alternates between. Adjust each entry to
+  /// customize its asset path or dimensions.
+  static const logoConfigs = <LogoConfig>[
+    LogoConfig(asset: 'assets/images/logo.png', width: 100, height: 100),
+    LogoConfig(asset: 'assets/images/logo1.png', width: 100, height: 100),
+  ];
+
+  @override
+  void initState() {
+    super.initState();
+    _timer = Timer.periodic(const Duration(seconds: 3), (_) {
+      setState(() => _logoIndex = 1 - _logoIndex);
+    });
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
     void open(BuildContext context, Widget page) {
       Navigator.of(context).push(MaterialPageRoute(builder: (_) => page));
     }
@@ -36,29 +78,51 @@ class MainMenuPage extends ConsumerWidget {
       open(context, MainScreen());
     }
 
+    final logo = logoConfigs[_logoIndex];
     return Scaffold(
       appBar: const WindowBar(title: 'Menu Principal', showMenu: true),
       drawer: const SideMenu(current: SideMenuSection.mainMenu),
       body: Column(
         children: [
           const SizedBox(height: 20),
-          Image.asset('assets/images/logo.png', height: 100),
+          AnimatedSwitcher(
+            duration: const Duration(milliseconds: 500),
+            child: Image.asset(
+              logo.asset,
+              key: ValueKey(_logoIndex),
+              height: logo.height,
+              width: logo.width,
+            ),
+          ),
           const SizedBox(height: 0),
-      Expanded(
-        child: Center(
-          child: FittedBox(
-            fit: BoxFit.scaleDown,
-            child: Column( // sem scroll
-                children: [
-                  _MenuButton(image: 'assets/images/FOR007.png', onPressed: () => open(context, const PreparacaoPage())),
-                  _MenuButton(image: 'assets/images/Amostragem.png', onPressed: () => open(context, const OperadorPage())),
-                  _MenuButton(image: 'assets/images/FOR008.png', onPressed: () => open(context, const OperadorPage())),
-                  _MenuButton(image: 'assets/images/dashboard.png', onPressed: openAdmin),
-                ],
+          Expanded(
+            child: Center(
+              child: FittedBox(
+                fit: BoxFit.scaleDown,
+                child: Column(
+                  // sem scroll
+                  children: [
+                    _MenuButton(
+                      image: 'assets/images/FOR007.png',
+                      onPressed: () => open(context, const PreparacaoPage()),
+                    ),
+                    _MenuButton(
+                      image: 'assets/images/Amostragem.png',
+                      onPressed: () => open(context, const OperadorPage()),
+                    ),
+                    _MenuButton(
+                      image: 'assets/images/FOR008.png',
+                      onPressed: () => open(context, const OperadorPage()),
+                    ),
+                    _MenuButton(
+                      image: 'assets/images/dashboard.png',
+                      onPressed: openAdmin,
+                    ),
+                  ],
+                ),
               ),
             ),
           ),
-      ),
         ],
       ),
     );


### PR DESCRIPTION
## Summary
- Make `MainMenuPage` stateful and use a timer to alternate between two logo images
- Introduce `LogoConfig` so each alternating logo can define its own dimensions
- Rename logo list to `logoConfigs` and document how to adjust individual logo sizes

## Testing
- `flutter analyze` (9 issues found in unrelated files)
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_68c300851bcc8331bebfcbc75fdbe3db