### PR TITLE
Use custom divider image across menus and dashboard

### DIFF
--- a/lib/features/main_menu/main_menu_page.dart
+++ b/lib/features/main_menu/main_menu_page.dart
@@ -31,7 +31,11 @@ class _MainMenuPageState extends ConsumerState<MainMenuPage> {
   Timer? _timer;
   static const _logos = [
     _LogoConfig(asset: 'assets/images/logo.png', width: 250, height: 110),
-    _LogoConfig(asset: 'assets/images/logotuptech.png', width: 250 , height: 110),
+    _LogoConfig(
+      asset: 'assets/images/logotuptech.png',
+      width: 250,
+      height: 110,
+    ),
   ];
 
   @override
@@ -88,7 +92,9 @@ class _MainMenuPageState extends ConsumerState<MainMenuPage> {
               width: logo.width,
             ),
           ),
-          const SizedBox(height: 0),
+          const SizedBox(height: 10),
+          Image.asset('assets/images/traco.png'),
+          const SizedBox(height: 10),
           Expanded(
             child: Center(
               child: FittedBox(

--- a/lib/screens/dashboard/dashboard_screen.dart
+++ b/lib/screens/dashboard/dashboard_screen.dart
@@ -1,11 +1,9 @@
 import 'package:admin/responsive.dart';
-import 'package:admin/screens/dashboard/components/my_fields.dart';
 import 'package:flutter/material.dart';
 
 import '../../constants.dart';
 import 'components/operator_report_chart.dart';
 import 'components/personnel_report_chart.dart';
-
 
 class DashboardScreen extends StatelessWidget {
   @override
@@ -24,6 +22,8 @@ class DashboardScreen extends StatelessWidget {
                   child: Column(
                     children: [
                       OperatorReportChart(),
+                      SizedBox(height: defaultPadding),
+                      Image.asset('assets/images/traco.png'),
                       SizedBox(height: defaultPadding),
                       PersonnelReportChart(),
                       if (Responsive.isMobile(context))

--- a/lib/screens/main/components/side_menu.dart
+++ b/lib/screens/main/components/side_menu.dart
@@ -195,6 +195,7 @@ class SideMenu extends ConsumerWidget {
               ),
             ),
           ),
+          Image.asset('assets/images/traco.png'),
           ...items,
         ],
       ),


### PR DESCRIPTION
## Summary
- Insert `traco.png` divider in main menu between logo and buttons
- Display divider below side menu header
- Separate dashboard reports with divider image

## Testing
- `flutter test`
- `flutter analyze`


------
https://chatgpt.com/codex/tasks/task_e_68c4392481388331885b0c11da0176b7