### PR TITLE
chore: clean svg menu icons

### DIFF
--- a/assets/icons/Amostragem.svg
+++ b/assets/icons/Amostragem.svg
@@ -15,25 +15,6 @@
    xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg">
-  <sodipodi:namedview
-     id="namedview1"
-     pagecolor="#ffffff"
-     bordercolor="#000000"
-     borderopacity="0.25"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1"
-     inkscape:document-units="mm">
-    <inkscape:page
-       x="0"
-       y="-1.4214773e-14"
-       width="180.01323"
-       height="26.134739"
-       id="page2"
-       margin="0"
-       bleed="0" />
-  </sodipodi:namedview>
   <defs
      id="defs1">
     <linearGradient
@@ -66,13 +47,13 @@
      transform="translate(-7.6774047,-14.94367)">
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:25.4px;font-family:Orbitron;-inkscape-font-specification:'Orbitron Bold';text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:url(#linearGradient15);fill-rule:evenodd;stroke:#ffcc00;stroke-width:1.065;stroke-dasharray:none;stroke-opacity:1"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:25.4px;font-family:Orbitron;-inkscape-font-specification:'Orbitron Bold';text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:url(#linearGradient15);fill-rule:evenodd"
        x="6.7367387"
        y="34.729355"
        id="text14"><tspan
          sodipodi:role="line"
          id="tspan14"
-         style="fill:url(#linearGradient15);stroke:#000000;stroke-width:1.065"
+         style="fill:url(#linearGradient15)"
          x="6.7367387"
          y="34.729355">Amostragem</tspan></text>
   </g>

--- a/assets/icons/Dashboard.svg
+++ b/assets/icons/Dashboard.svg
@@ -12,25 +12,6 @@
    xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg">
-  <sodipodi:namedview
-     id="namedview1"
-     pagecolor="#ffffff"
-     bordercolor="#000000"
-     borderopacity="0.25"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1"
-     inkscape:document-units="mm">
-    <inkscape:page
-       x="-2.0165937e-14"
-       y="1.8283324e-16"
-       width="152.68825"
-       height="20.622965"
-       id="page2"
-       margin="0"
-       bleed="0" />
-  </sodipodi:namedview>
   <defs
      id="defs1">
     <linearGradient
@@ -63,13 +44,13 @@
      transform="translate(-10.119956,-9.6618142)">
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:25.4px;font-family:Orbitron;-inkscape-font-specification:'Orbitron Bold';text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:url(#linearGradient21);fill-rule:evenodd;stroke:#000000;stroke-width:1.065;stroke-dasharray:none;stroke-opacity:1"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:25.4px;font-family:Orbitron;-inkscape-font-specification:'Orbitron Bold';text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:url(#linearGradient21);fill-rule:evenodd"
        x="9.1792917"
        y="29.752277"
        id="text19"><tspan
          sodipodi:role="line"
          id="tspan19"
-         style="fill:url(#linearGradient21);stroke-width:1.065"
+         style="fill:url(#linearGradient21)"
          x="9.1792917"
          y="29.752277">Dashboard</tspan></text>
   </g>

--- a/assets/icons/FOR007.svg
+++ b/assets/icons/FOR007.svg
@@ -12,25 +12,6 @@
    xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg">
-  <sodipodi:namedview
-     id="namedview1"
-     pagecolor="#ffffff"
-     bordercolor="#000000"
-     borderopacity="0.25"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1"
-     inkscape:document-units="mm">
-    <inkscape:page
-       x="0"
-       y="-2.3035442e-14"
-       width="142.17232"
-       height="26.337973"
-       id="page2"
-       margin="0"
-       bleed="0" />
-  </sodipodi:namedview>
   <defs
      id="defs1">
     <linearGradient
@@ -63,13 +44,13 @@
      transform="translate(-11.06966,-13.310872)">
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:25.4px;font-family:Orbitron;-inkscape-font-specification:'Orbitron Bold';text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:url(#linearGradient17);fill-rule:evenodd;stroke:#000000;stroke-width:1.065;stroke-dasharray:none;stroke-opacity:1"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:25.4px;font-family:Orbitron;-inkscape-font-specification:'Orbitron Bold';text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:url(#linearGradient17);fill-rule:evenodd"
        x="10.154382"
        y="35.280968"
        id="text15"><tspan
          sodipodi:role="line"
          id="tspan15"
-         style="fill:url(#linearGradient17);stroke-width:1.065"
+         style="fill:url(#linearGradient17)"
          x="10.154382"
          y="35.280968">Liberação</tspan></text>
   </g>

--- a/assets/icons/FOR008.svg
+++ b/assets/icons/FOR008.svg
@@ -15,25 +15,6 @@
    xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg">
-  <sodipodi:namedview
-     id="namedview1"
-     pagecolor="#ffffff"
-     bordercolor="#000000"
-     borderopacity="0.25"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1"
-     inkscape:document-units="mm">
-    <inkscape:page
-       x="-1.3054868e-14"
-       y="1.3133975e-16"
-       width="159.77386"
-       height="26.337975"
-       id="page2"
-       margin="0"
-       bleed="0" />
-  </sodipodi:namedview>
   <defs
      id="defs1">
     <linearGradient
@@ -66,13 +47,13 @@
      transform="translate(-10.903883,-8.4168783)">
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:25.4px;font-family:Orbitron;-inkscape-font-specification:'Orbitron Bold';text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:url(#linearGradient19);fill-rule:evenodd;stroke:#000000;stroke-width:1.065;stroke-dasharray:none;stroke-opacity:1"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:25.4px;font-family:Orbitron;-inkscape-font-specification:'Orbitron Bold';text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:url(#linearGradient19);fill-rule:evenodd"
        x="9.9632168"
        y="30.386974"
        id="text17"><tspan
          sodipodi:role="line"
          id="tspan17"
-         style="fill:url(#linearGradient19);stroke-width:1.065"
+         style="fill:url(#linearGradient19)"
          x="9.9632168"
          y="30.386974">Finalização</tspan></text>
   </g>


### PR DESCRIPTION
## Summary
- remove stroke outlines and editor metadata from main menu SVG icons to prevent stray rendering artifacts

## Testing
- `flutter test` *(fails: Unable to load asset "assets/images/BOA.jpg")*

------
https://chatgpt.com/codex/tasks/task_e_68c461c6ba288331b9f9d8129c810fe0