### PR TITLE
Registrar pausas na jornada e agrupar histórico por horário

### DIFF
--- a/app_db.py
+++ b/app_db.py
@@ -205,11 +205,22 @@ def _ensure_schema():
                     partnumber VARCHAR(128) DEFAULT NULL,
                     operacao VARCHAR(64) DEFAULT NULL,
                     re_operador VARCHAR(64) NOT NULL,
+                    motivo VARCHAR(128) DEFAULT NULL,
                     pausa_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                    retorno_at TIMESTAMP NULL DEFAULT NULL,
                     KEY idx_oj_os (os),
                     CONSTRAINT fk_oj_os FOREIGN KEY (os) REFERENCES ordem_servico(os) ON UPDATE CASCADE
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
                 """
+            )
+            _ensure_column(
+                c, "operador_jornada", "motivo", "VARCHAR(128) DEFAULT NULL"
+            )
+            _ensure_column(
+                c,
+                "operador_jornada",
+                "retorno_at",
+                "TIMESTAMP NULL DEFAULT NULL",
             )
             # Preparador (registro + itens)
 
@@ -1617,6 +1628,30 @@ def operador_registrar():
                             observacao,
                         ),
                     )
+
+                # Ao registrar uma nova amostragem, considera-se que o operador
+                # retornou de uma pausa (se havia uma aberta).
+                cur.execute(
+                    """
+                    UPDATE operador_jornada
+                       SET retorno_at = CURRENT_TIMESTAMP
+                     WHERE os=%s
+                       AND re_operador=%s
+                       AND retorno_at IS NULL
+                       AND (partnumber IS NULL OR partnumber = %s OR %s IS NULL)
+                       AND (operacao IS NULL OR operacao = %s OR %s IS NULL)
+                     ORDER BY pausa_at DESC
+                     LIMIT 1
+                    """,
+                    (
+                        os_num,
+                        re_op,
+                        part or None,
+                        part or None,
+                        op or None,
+                        op or None,
+                    ),
+                )
             c.commit()
 
         return jsonify(
@@ -1670,20 +1705,44 @@ def operador_fim_jornada():
     re_op = _norm(payload.get("re"))
     part = _norm_part(payload.get("partnumber"))
     op = _norm_op(payload.get("operacao"))
+    motivo = _norm(payload.get("motivo"))
     if not os_num or not re_op:
         return jsonify({"error": "Campos 'os' e 're' são obrigatórios"}), 400
+    if not motivo:
+        return jsonify({"error": "Campo 'motivo' é obrigatório"}), 400
     try:
         with _conn_db(DB_NAME) as c:
             with c.cursor() as cur:
                 cur.execute(
                     "INSERT IGNORE INTO ordem_servico (os) VALUES (%s)", (os_num,)
                 )
+                # Caso exista uma pausa aberta para este operador, encerra-a
+                # antes de registrar a nova pausa, evitando sobreposição.
                 cur.execute(
                     """
-                    INSERT INTO operador_jornada (os, partnumber, operacao, re_operador)
-                    VALUES (%s, %s, %s, %s)
+                    UPDATE operador_jornada
+                       SET retorno_at = CURRENT_TIMESTAMP
+                     WHERE os=%s
+                       AND re_operador=%s
+                       AND retorno_at IS NULL
+                       AND (partnumber IS NULL OR partnumber = %s OR %s IS NULL)
+                       AND (operacao IS NULL OR operacao = %s OR %s IS NULL)
                     """,
-                    (os_num, part or None, op or None, re_op),
+                    (
+                        os_num,
+                        re_op,
+                        part or None,
+                        part or None,
+                        op or None,
+                        op or None,
+                    ),
+                )
+                cur.execute(
+                    """
+                    INSERT INTO operador_jornada (os, partnumber, operacao, re_operador, motivo)
+                    VALUES (%s, %s, %s, %s, %s)
+                    """,
+                    (os_num, part or None, op or None, re_op, motivo or None),
                 )
             c.commit()
         return jsonify({"status": "ok"})
@@ -1829,9 +1888,48 @@ def listar_relatorios_operador():
     os_num = _norm(request.args.get("os"))
     part = _norm_part(request.args.get("partnumber"))
     op = _norm_op(request.args.get("operacao"))
+
+    def _map_amostragem(rows):
+        mapped = []
+        for r in rows:
+            row = dict(r)
+            row.setdefault("retorno_at", None)
+            row.setdefault("motivo", "")
+            row["evento"] = "amostragem"
+            mapped.append(row)
+        return mapped
+
+    def _map_pausas(rows):
+        mapped = []
+        for r in rows:
+            mapped.append(
+                {
+                    "os": r.get("os"),
+                    "partnumber": r.get("partnumber"),
+                    "operacao": r.get("operacao"),
+                    "re_operador": r.get("re_operador"),
+                    "maquina": None,
+                    "idx_medida": None,
+                    "titulo": "Pausa de Jornada",
+                    "instrumento": "",
+                    "faixa_texto": "",
+                    "escolha": "",
+                    "status": "Pausa de jornada",
+                    "observacao": None,
+                    "created_at": r.get("pausa_at"),
+                    "retorno_at": r.get("retorno_at"),
+                    "motivo": r.get("motivo"),
+                    "evento": "pausa_jornada",
+                }
+            )
+        return mapped
+
     try:
         with _conn_db(DB_NAME) as c:
             with c.cursor() as cur:
+                registros = []
+                pausa_filters = []
+                pausa_params = []
                 if os_num:
                     cur.execute(
                         """
@@ -1845,6 +1943,9 @@ def listar_relatorios_operador():
                         """,
                         (os_num,),
                     )
+                    registros.extend(_map_amostragem(cur.fetchall()))
+                    pausa_filters.append("os=%s")
+                    pausa_params.append(os_num)
                 elif part and op:
                     cur.execute(
                         """
@@ -1859,6 +1960,15 @@ def listar_relatorios_operador():
                         """,
                         (part, op),
                     )
+                    registros.extend(_map_amostragem(cur.fetchall()))
+                    pausa_filters.append(
+                        "TRIM(LEADING '0' FROM TRIM(partnumber)) = %s"
+                    )
+                    pausa_params.append(part)
+                    pausa_filters.append(
+                        "TRIM(LEADING '0' FROM TRIM(operacao)) = %s"
+                    )
+                    pausa_params.append(op)
                 else:
                     cur.execute(
                         """
@@ -1876,8 +1986,24 @@ def listar_relatorios_operador():
                           LIMIT 200
                         """,
                     )
-                rows = cur.fetchall()
-        return jsonify(rows)
+                    rows = cur.fetchall()
+                    return jsonify(rows)
+
+                if pausa_filters:
+                    cur.execute(
+                        f"""
+                        SELECT os, partnumber, operacao, re_operador,
+                               motivo, pausa_at, retorno_at
+                          FROM operador_jornada
+                         WHERE {' AND '.join(pausa_filters)}
+                         ORDER BY pausa_at
+                        """,
+                        pausa_params,
+                    )
+                    registros.extend(_map_pausas(cur.fetchall()))
+
+        registros.sort(key=lambda r: r.get("created_at") or datetime.min)
+        return jsonify(_serialize(registros))
     except Exception as e:
         return (
             jsonify({"error": f"Falha ao consultar relatórios do operador: {e}"}),
@@ -1896,6 +2022,7 @@ def relatorio_os():
             with c.cursor() as cur:
                 os_data = None
                 amostragem = []
+                jornada = []
                 liberacao = []
                 finalizacao = []
                 if section in ("full", "ordem_servico"):
@@ -1916,6 +2043,17 @@ def relatorio_os():
                         (os_num,),
                     )
                     amostragem = cur.fetchall()
+                    cur.execute(
+                        """
+                        SELECT os, partnumber, operacao, re_operador,
+                               motivo, pausa_at, retorno_at
+                          FROM operador_jornada
+                         WHERE os=%s
+                         ORDER BY pausa_at
+                        """,
+                        (os_num,),
+                    )
+                    jornada = cur.fetchall()
                 if section in ("full", "liberacao"):
                     if _tables_exist(
                             cur,
@@ -1974,6 +2112,7 @@ def relatorio_os():
             {
                 "ordem_servico": _serialize(os_data) if os_data else None,
                 "amostragem": _serialize(amostragem),
+                "jornada": _serialize(jornada),
                 "liberacao": _serialize(liberacao),
                 "finalizacao": _serialize(finalizacao),
             }

--- a/lib/models/report.dart
+++ b/lib/models/report.dart
@@ -23,6 +23,15 @@ class Report {
   /// Measurement title associated with [idxMedida].
   final String titulo;
 
+  /// Timestamp indicating when a pause ended (if applicable).
+  final String retornoAt;
+
+  /// Event type or category returned by the backend (e.g., pausa_jornada).
+  final String evento;
+
+  /// Optional reason associated with special events such as pauses.
+  final String motivo;
+
   Report({
     required this.os,
     required this.partnumber,
@@ -34,6 +43,9 @@ class Report {
     this.reOperador = '',
     this.idxMedida,
     this.titulo = '',
+    this.retornoAt = '',
+    this.evento = '',
+    this.motivo = '',
   });
 
   factory Report.fromJson(Map<String, dynamic> json) {
@@ -50,6 +62,9 @@ class Report {
           ? int.tryParse(json['idx_medida'].toString())
           : null,
       titulo: json['titulo']?.toString() ?? '',
+      retornoAt: json['retorno_at']?.toString() ?? '',
+      evento: json['evento']?.toString() ?? '',
+      motivo: json['motivo']?.toString() ?? '',
     );
   }
 

--- a/lib/screens/dashboard/components/operator_report_chart.dart
+++ b/lib/screens/dashboard/components/operator_report_chart.dart
@@ -157,9 +157,10 @@ class _OperatorReportChartState extends State<OperatorReportChart> {
                   final verticalLines = <VerticalLine>[];
                   for (var i = 0; i < reports.length; i++) {
                     final r = reports[i];
-                    final status = r.status.toLowerCase();
-                    spots.add(FlSpot(i.toDouble(), _statusToValue(status)));
-                    if (status.contains('fim') && status.contains('jornada')) {
+                    final lowered = r.status.toLowerCase();
+                    spots.add(FlSpot(i.toDouble(), _statusToValue(lowered)));
+                    if (lowered.contains('pausa') &&
+                        lowered.contains('jornada')) {
                       verticalLines.add(
                         VerticalLine(
                           x: i.toDouble(),
@@ -167,8 +168,17 @@ class _OperatorReportChartState extends State<OperatorReportChart> {
                           strokeWidth: 2,
                         ),
                       );
-                    } else if (status.contains('encerrar') ||
-                        status.contains('encerramento')) {
+                    } else if (lowered.contains('fim') &&
+                        lowered.contains('jornada')) {
+                      verticalLines.add(
+                        VerticalLine(
+                          x: i.toDouble(),
+                          color: Colors.orange,
+                          strokeWidth: 2,
+                        ),
+                      );
+                    } else if (lowered.contains('encerrar') ||
+                        lowered.contains('encerramento')) {
                       verticalLines.add(
                         VerticalLine(
                           x: i.toDouble(),

--- a/lib/screens/dashboard/components/personnel_report_chart.dart
+++ b/lib/screens/dashboard/components/personnel_report_chart.dart
@@ -22,20 +22,83 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
   String _modo = 'os';
   Future<List<Map<String, dynamic>>>? _future;
 
-  String _formatDate(dynamic value) {
-    final raw = value?.toString() ?? '';
-    if (raw.isEmpty) return '';
+  DateTime? _parseDateTime(dynamic value) {
+    final raw = value?.toString().trim();
+    if (raw == null || raw.isEmpty) return null;
     DateTime? dt = DateTime.tryParse(raw);
-    if (dt == null) {
+    if (dt != null) return dt.toLocal();
+    if (!raw.contains('T') && raw.contains(' ')) {
+      dt = DateTime.tryParse(raw.replaceFirst(' ', 'T'));
+      if (dt != null) return dt.toLocal();
+    }
+    try {
+      return DateFormat(
+        "EEE, dd MMM yyyy HH:mm:ss 'GMT'",
+        'en_US',
+      ).parseUtc(raw).toLocal();
+    } catch (_) {}
+    for (final pattern in const [
+      'yyyy-MM-dd HH:mm:ss',
+      'yyyy-MM-ddTHH:mm:ss',
+      'dd/MM/yyyy HH:mm:ss',
+      'dd/MM/yyyy HH:mm',
+    ]) {
       try {
-        dt = DateFormat(
-          "EEE, dd MMM yyyy HH:mm:ss 'GMT'",
-          'en_US',
-        ).parseUtc(raw);
+        return DateFormat(pattern).parse(raw).toLocal();
       } catch (_) {}
     }
-    return dt?.toLocal().toString().split('.').first ??
-        raw.replaceAll('T', ' ');
+    return null;
+  }
+
+  String _formatDate(dynamic value) {
+    final dt = _parseDateTime(value);
+    if (dt != null) {
+      return DateFormat('dd/MM/yyyy HH:mm:ss').format(dt);
+    }
+    final raw = value?.toString() ?? '';
+    if (raw.contains('T')) return raw.replaceAll('T', ' ');
+    return raw;
+  }
+
+  int _compareByDate(Map<String, dynamic> a, Map<String, dynamic> b) {
+    final dtA = a['__dt'] as DateTime?;
+    final dtB = b['__dt'] as DateTime?;
+    if (dtA == null && dtB == null) return 0;
+    if (dtA == null) return 1;
+    if (dtB == null) return -1;
+    return dtA.compareTo(dtB);
+  }
+
+  List<Map<String, dynamic>> _withGroupHeaders(
+    List<Map<String, dynamic>> rows,
+  ) {
+    final result = <Map<String, dynamic>>[];
+    DateTime? lastGroup;
+    for (final row in rows) {
+      final dt = row['__dt'] as DateTime?;
+      if (dt != null) {
+        final normalized = DateTime(
+          dt.year,
+          dt.month,
+          dt.day,
+          dt.hour,
+          dt.minute,
+        );
+        if (lastGroup == null || normalized != lastGroup) {
+          final label = DateFormat('dd/MM/yyyy HH:mm').format(dt);
+          result.add({
+            '__isGroup': true,
+            '__dt': normalized,
+            'created_at': label,
+          });
+          lastGroup = normalized;
+        }
+      } else {
+        lastGroup = null;
+      }
+      result.add(row);
+    }
+    return result;
   }
 
   @override
@@ -66,6 +129,7 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
                   're_liberacao': e['re_preparador'],
                   're_finalizacao': '',
                   'created_at': createdAt,
+                  '__dt': _parseDateTime(e['created_at']),
                   'partnumber': e['partnumber'],
                   'maquina': e['maquina'],
                   'faixa_texto': e['faixa_texto'],
@@ -82,6 +146,7 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
                     'os': e['os'],
                     're_liberacao': '',
                     'created_at': '',
+                    '__dt': null,
                     'partnumber': e['partnumber'],
                     'maquina': e['maquina'],
                     'faixa_texto': e['faixa_texto'],
@@ -101,26 +166,49 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
                 if (e is Map<String, dynamic>) {
                   final createdAt = _formatDate(e['created_at']);
                   rows.add({
-                    'os': e['os'],
-                    're_operador': e['re_operador'],
+                    '__dt': _parseDateTime(e['created_at']),
+                    'os': e['os']?.toString() ?? '',
+                    're_operador': e['re_operador']?.toString() ?? '',
                     'created_at': createdAt,
-                    'partnumber': e['partnumber'],
-                    'maquina': e['maquina'],
-                    'titulo': e['titulo'],
-                    'instrumento': e['instrumento'],
-                    'faixa_texto': e['faixa_texto'],
-                    'escolha': e['escolha'],
-                    'status': e['status'],
+                    'retorno_at': '',
+                    'partnumber': e['partnumber']?.toString() ?? '',
+                    'maquina': e['maquina']?.toString() ?? '',
+                    'titulo': e['titulo']?.toString() ?? '',
+                    'instrumento': e['instrumento']?.toString() ?? '',
+                    'faixa_texto': e['faixa_texto']?.toString() ?? '',
+                    'escolha': e['escolha']?.toString() ?? '',
+                    'status': e['status']?.toString() ?? '',
+                    'motivo': (e['motivo'] ?? '').toString(),
+                    'evento': (e['evento'] ?? 'amostragem').toString(),
                   });
                 }
               }
             }
+            for (final e in (data['jornada'] as List? ?? [])) {
+              if (e is Map<String, dynamic>) {
+                final inicioRaw = e['pausa_at'] ?? e['created_at'];
+                rows.add({
+                  '__dt': _parseDateTime(inicioRaw),
+                  'os': e['os']?.toString() ?? '',
+                  're_operador': e['re_operador']?.toString() ?? '',
+                  'created_at': _formatDate(inicioRaw),
+                  'retorno_at': _formatDate(e['retorno_at']),
+                  'partnumber': e['partnumber']?.toString() ?? '',
+                  'maquina': '',
+                  'titulo': 'Pausa de Jornada',
+                  'instrumento': '',
+                  'faixa_texto': '',
+                  'escolha': '',
+                  'status': 'Pausa de jornada',
+                  'motivo': (e['motivo'] ?? '').toString(),
+                  'evento': 'pausa_jornada',
+                });
+              }
+            }
           }
         }
-        rows.sort(
-          (a, b) => (a['created_at'] ?? '').compareTo(b['created_at'] ?? ''),
-        );
-        return rows;
+        rows.sort(_compareByDate);
+        return _withGroupHeaders(rows);
       } else {
         final part = _partCtrl.text.trim();
         final op = _opCtrl.text.trim();
@@ -132,16 +220,24 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
         final rows = <Map<String, dynamic>>[];
         for (final Map<String, dynamic> e in data) {
           final map = Map<String, dynamic>.from(e);
+          map['__dt'] = _parseDateTime(map['created_at']);
           map['created_at'] = _formatDate(e['created_at']);
+          if (map.containsKey('retorno_at')) {
+            map['retorno_at'] = _formatDate(map['retorno_at']);
+          } else if (_tipo == 'operador') {
+            map['retorno_at'] = '';
+          }
           if (map.containsKey('created_at_final')) {
             map['created_at_final'] = _formatDate(e['created_at_final']);
           }
+          if (_tipo == 'operador') {
+            map['evento'] = map['evento'] ?? 'amostragem';
+            map['motivo'] = map['motivo'] ?? '';
+          }
           rows.add(map);
         }
-        rows.sort(
-          (a, b) => (a['created_at'] ?? '').compareTo(b['created_at'] ?? ''),
-        );
-        return rows;
+        rows.sort(_compareByDate);
+        return _withGroupHeaders(rows);
       }
     }
 
@@ -304,17 +400,23 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
                   : const {
                       'os': 'OS',
                       're_operador': 'RE',
-                      'created_at': 'Horário',
+                      'created_at': 'Início',
+                      'retorno_at': 'Retorno',
                       'partnumber': 'Partnumber',
                       'maquina': 'Máquina',
                       'titulo': 'Título',
                       'instrumento': 'Instrumento',
                       'faixa_texto': 'Faixa',
                       'status': 'Status',
+                      'motivo': 'Motivo',
                     };
               final headers = headerMap.keys.toList();
               return LayoutBuilder(
                 builder: (context, constraints) {
+                  final theme = Theme.of(context);
+                  final groupColor = theme.colorScheme.surfaceVariant
+                      .withOpacity(0.25);
+                  final pauseColor = Colors.orange.withOpacity(0.12);
                   return SingleChildScrollView(
                     scrollDirection: Axis.horizontal,
                     child: ConstrainedBox(
@@ -334,22 +436,39 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
                               ),
                             )
                             .toList(),
-                        rows: dados
-                            .map(
-                              (r) => DataRow(
-                                cells: headers
-                                    .map(
-                                      (h) => DataCell(
-                                        Text(
-                                          '${r[h] ?? ''}',
-                                          style: const TextStyle(fontSize: 12),
-                                        ),
-                                      ),
-                                    )
-                                    .toList(),
-                              ),
-                            )
-                            .toList(),
+                        rows: dados.map((r) {
+                          final isGroup = r['__isGroup'] == true;
+                          final isPause = r['evento'] == 'pausa_jornada';
+                          return DataRow(
+                            color: MaterialStateProperty.resolveWith<Color?>((
+                              states,
+                            ) {
+                              if (isGroup) return groupColor;
+                              if (isPause) return pauseColor;
+                              return null;
+                            }),
+                            cells: headers.map((h) {
+                              if (isGroup) {
+                                final text = h == 'created_at'
+                                    ? 'Horário: ${r['created_at'] ?? ''}'
+                                    : '';
+                                final style = theme.textTheme.labelLarge
+                                    ?.copyWith(fontWeight: FontWeight.bold);
+                                return DataCell(Text(text, style: style));
+                              }
+                              final value = r[h];
+                              final display = value == null
+                                  ? ''
+                                  : value.toString();
+                              return DataCell(
+                                Text(
+                                  display,
+                                  style: const TextStyle(fontSize: 12),
+                                ),
+                              );
+                            }).toList(),
+                          );
+                        }).toList(),
                       ),
                     ),
                   );


### PR DESCRIPTION
## Summary
- adicionar coluna de motivo e registro de retorno na tabela de jornada, garantindo que o backend registre motivo e feche a pausa quando houver nova amostragem
- incluir eventos de pausa nos relatórios do operador e na resposta de /reports/os, disponibilizando horário inicial e retorno
- atualizar os relatórios do dashboard para agrupar registros por horário, exibir pausas com colunas de retorno/motivo e destacar eventos de pausa

## Testing
- python -m py_compile app_db.py
- flutter test

------
https://chatgpt.com/codex/tasks/task_e_68cd548a0714833192155a9e548fd0a3