### PR TITLE
Include seconds in personnel report grouping

### DIFF
--- a/lib/screens/dashboard/components/personnel_report_chart.dart
+++ b/lib/screens/dashboard/components/personnel_report_chart.dart
@@ -83,9 +83,10 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
           dt.day,
           dt.hour,
           dt.minute,
+          dt.second,
         );
         if (lastGroup == null || normalized != lastGroup) {
-          final label = DateFormat('dd/MM/yyyy HH:mm').format(dt);
+          final label = DateFormat('dd/MM/yyyy HH:mm:ss').format(dt);
           result.add({
             '__isGroup': true,
             '__dt': normalized,


### PR DESCRIPTION
## Summary
- ensure group headers normalise timestamps with seconds precision to avoid merging multiple samples in the same minute
- display seconds in personnel report group labels so users can distinguish closely timed entries

## Testing
- flutter test

------
https://chatgpt.com/codex/tasks/task_e_68cd5d028f848331a441e70f91677c83