### PR TITLE
Add tool change measurement flow for operator

### DIFF
--- a/lib/features/operador/presentation/operador_page.dart
+++ b/lib/features/operador/presentation/operador_page.dart
@@ -9,6 +9,8 @@ import 'package:http/http.dart' as http;
 
 import '../../preparacao/data/models.dart';
 import '../data/repository_provider.dart';
+import 'package:admin/features/operador/presentation/troca_ferramenta_page.dart';
+import 'package:admin/features/operador/presentation/widgets/measurement_tile.dart';
 import 'package:admin/screens/main/components/side_menu.dart';
 import 'package:admin/widgets/window_bar.dart';
 import 'package:admin/utils/string_utils.dart';
@@ -290,9 +292,9 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
           .timeout(const Duration(seconds: 20));
       if (!mounted) return;
       if (resp.statusCode == 200) {
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(SnackBar(content: Text('Jornada pausada. Motivo: $motivo')));
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Jornada pausada. Motivo: $motivo')),
+        );
       } else {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text('Falha: ${resp.statusCode} ${resp.body}')),
@@ -307,42 +309,122 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
   }
 
   Future<void> _showFimJornadaDialog() async {
+    const motivos = <String>[
+      'Banheiro',
+      'Refeição',
+      'Fim do Turno',
+      'Troca de ferramenta',
+      'Manutenção',
+      'Falta de Material',
+      'Problema de Qualidade',
+      'Outros',
+    ];
+
     final motivo = await showDialog<String>(
       context: context,
-      builder: (context) => AlertDialog(
-        title: const Text('Pausa de Jornada'),
-        content: DropdownButtonFormField<String>(
-          value: null,
-          decoration: const InputDecoration(
-            labelText: 'Selecione o motivo',
-            border: OutlineInputBorder(),
+      builder: (context) {
+        String? selecionado;
+        return StatefulBuilder(
+          builder: (context, setState) => AlertDialog(
+            title: const Text('Pausa de Jornada'),
+            content: SingleChildScrollView(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: motivos
+                    .map(
+                      (m) => RadioListTile<String>(
+                        title: Text(m),
+                        value: m,
+                        groupValue: selecionado,
+                        onChanged: (value) =>
+                            setState(() => selecionado = value),
+                      ),
+                    )
+                    .toList(),
+              ),
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(),
+                child: const Text('Cancelar'),
+              ),
+              FilledButton(
+                onPressed: selecionado == null
+                    ? null
+                    : () => Navigator.of(context).pop(selecionado),
+                child: const Text('Avançar'),
+              ),
+            ],
           ),
-          items: const [
-            DropdownMenuItem(value: 'Banheiro', child: Text('Banheiro')),
-            DropdownMenuItem(value: 'Refeição', child: Text('Refeição')),
-            DropdownMenuItem(value: 'Fim do Turno', child: Text('Fim do Turno')),
-            DropdownMenuItem(value: 'Troca de ferramenta', child: Text('Troca de ferramenta')),
-            DropdownMenuItem(value: 'Manutenção', child: Text('Manutenção')),
-            DropdownMenuItem(value: 'Falta de Material', child: Text('Falta de Material')),
-            DropdownMenuItem(value: 'Problema de Qualidade', child: Text('Problema de Qualidade')),
-            DropdownMenuItem(value: 'Outros', child: Text('Outros')),
-          ],
-          onChanged: (value) {
-            Navigator.of(context).pop(value);
-          },
-        ),
+        );
+      },
+    );
+
+    if (motivo == null) return;
+
+    final confirmado = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Confirmar motivo'),
+        content: Text('Deseja confirmar a opção "$motivo"?'),
         actions: [
           TextButton(
-            onPressed: () => Navigator.of(context).pop(),
-            child: const Text('Cancelar'),
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Não'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Sim'),
           ),
         ],
       ),
     );
 
-    if (motivo != null) {
-      await _fimJornada(motivo);
+    if (confirmado != true) return;
+
+    if (motivo == 'Troca de ferramenta') {
+      final re = _reCtrl.text.trim();
+      final os = _osCtrl.text.trim();
+      final part = _partCtrl.text.trim();
+      final operacao = _opCtrl.text.trim();
+      final maquina = (_maquinaSel ?? '').trim();
+
+      if (re.isEmpty ||
+          os.isEmpty ||
+          part.isEmpty ||
+          operacao.isEmpty ||
+          maquina.isEmpty) {
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text(
+              'Preencha R.E., O.S., peça, operação e máquina antes de trocar a ferramenta.',
+            ),
+          ),
+        );
+        return;
+      }
+
+      final sucesso = await Navigator.of(context).push<bool>(
+        MaterialPageRoute(
+          builder: (_) => TrocaFerramentaPage(
+            baseUrl: kBaseUrl,
+            re: re,
+            os: os,
+            partnumber: part,
+            operacao: operacao,
+            maquina: maquina,
+          ),
+        ),
+      );
+
+      if (sucesso == true) {
+        await _fimJornada(motivo);
+      }
+      return;
     }
+
+    await _fimJornada(motivo);
   }
 
   Future<void> _encerrarProducao() async {
@@ -634,7 +716,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                       separatorBuilder: (_, __) => const SizedBox(height: 8),
                       itemBuilder: (context, index) {
                         final item = list[index];
-                        return _MeasurementTile(
+                        return MeasurementTile(
                           index: index,
                           item: item,
                           onSelect: (status, medicao) => ref
@@ -684,373 +766,6 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
               ),
             ],
           ),
-        ),
-      ),
-    );
-  }
-}
-
-class _MeasurementTile extends StatelessWidget {
-  final int index;
-  final MedidaItem item;
-  final void Function(StatusMedida status, String? medicao) onSelect;
-
-  const _MeasurementTile({
-    required this.index,
-    required this.item,
-    required this.onSelect,
-  });
-
-  // ---------- helpers ----------
-  String _norm(String? s) => (s ?? '').trim();
-  String _nfd(String s) {
-    // normalização simples (sem pacote intl)
-    const rep = {
-      'á': 'a',
-      'à': 'a',
-      'ã': 'a',
-      'â': 'a',
-      'é': 'e',
-      'ê': 'e',
-      'í': 'i',
-      'ó': 'o',
-      'ô': 'o',
-      'õ': 'o',
-      'ú': 'u',
-      'ç': 'c',
-      'Á': 'A',
-      'À': 'A',
-      'Ã': 'A',
-      'Â': 'A',
-      'É': 'E',
-      'Ê': 'E',
-      'Í': 'I',
-      'Ó': 'O',
-      'Ô': 'O',
-      'Õ': 'O',
-      'Ú': 'U',
-      'Ç': 'C',
-    };
-    var t = s;
-    rep.forEach((k, v) => t = t.replaceAll(k, v));
-    return t;
-  }
-
-  bool _containsAny(String hay, List<String> needles) {
-    final h = _nfd(hay.toLowerCase());
-    return needles.any((n) => h.contains(_nfd(n.toLowerCase())));
-  }
-
-  bool get _isVisualRugParalelismoOrAfins {
-    final t = _norm(item.titulo);
-    final inst = _norm(item.instrumento);
-    return _containsAny(t, [
-          'visual',
-          'rug',
-          'paralelismo',
-          'anel de rosca passa',
-          'cqf',
-          'simetria',
-          'concentricidade',
-        ]) ||
-        _containsAny(inst, [
-          'visual',
-          'rug',
-          'rugosimetro',
-          'paralelismo',
-          'anel de rosca passa',
-          'cqf',
-          'simetria',
-        ]);
-  }
-
-  bool get _isTampao {
-    final t = _norm(item.titulo);
-    final inst = _norm(item.instrumento);
-    return _containsAny(t, ['tamp', 'tampao', 'tampão', 'tampa']) ||
-        _containsAny(inst, ['tamp', 'tampao', 'tampão', 'tampa']);
-  }
-
-  Set<String> _partsFromMedicao(String? medicao) => (medicao ?? '')
-      .split('|')
-      .map((s) => s.trim())
-      .where((s) => s.isNotEmpty)
-      .toSet();
-
-  String _joinParts(Set<String> parts) => parts.join(' | ');
-
-  StatusMedida _statusFromParts(Set<String> parts) {
-    final hasPassa = parts.any((p) => p.startsWith('Lado passa'));
-    final hasNaoPassa = parts.any((p) => p.startsWith('Lado não passa'));
-    if (hasPassa && hasNaoPassa) {
-      final passaReprovado = parts.contains('Lado passa — Reprovado');
-      final naoPassaReprovado = parts.contains('Lado não passa — Reprovado');
-      if (passaReprovado && naoPassaReprovado) {
-        return StatusMedida.reprovadaAcima;
-      }
-      if (passaReprovado) return StatusMedida.reprovadaAbaixo;
-      if (naoPassaReprovado) return StatusMedida.reprovadaAcima;
-      return StatusMedida.ok;
-    }
-    return StatusMedida.pendente;
-  }
-
-  double? _toDoubleNum(dynamic v) {
-    if (v == null) return null;
-    if (v is num) return v.toDouble();
-    return double.tryParse(v.toString().replaceAll(',', '.').trim());
-  }
-
-  Color _fgOn(Color bg) =>
-      ThemeData.estimateBrightnessForColor(bg) == Brightness.dark
-      ? Colors.white
-      : Colors.black87;
-
-  Widget _pill({
-    required String text,
-    required Color bg,
-    required Color border,
-    bool selected = false,
-    Color? fg,
-    VoidCallback? onTap,
-  }) {
-    final fgColor = fg ?? _fgOn(bg);
-    return InkWell(
-      onTap: onTap,
-      borderRadius: BorderRadius.circular(999),
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
-        decoration: BoxDecoration(
-          color: bg,
-          borderRadius: BorderRadius.circular(999),
-          border: Border.all(
-            color: selected ? border.withValues(alpha: 0.9) : border,
-            width: selected ? 2 : 1,
-          ),
-        ),
-        child: Text(
-          text,
-          style: TextStyle(fontWeight: FontWeight.w600, color: fgColor),
-        ),
-      ),
-    );
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final styleLabel = Theme.of(context).textTheme.titleMedium;
-    final styleSpec = Theme.of(context).textTheme.bodyMedium;
-
-    String subtitulo = item.faixaTexto;
-    if (subtitulo.isEmpty && (item.minimo != null || item.maximo != null)) {
-      final minStr = item.minimo?.toStringAsFixed(2) ?? '';
-      final maxStr = item.maximo?.toStringAsFixed(2) ?? '';
-      final uni = (item.unidade ?? '').isNotEmpty ? ' ${item.unidade}' : '';
-      if (minStr.isNotEmpty && maxStr.isNotEmpty) {
-        subtitulo = '$minStr – $maxStr$uni';
-      } else if (minStr.isNotEmpty) {
-        subtitulo = '≥ $minStr$uni';
-      } else if (maxStr.isNotEmpty) {
-        subtitulo = '≤ $maxStr$uni';
-      }
-    }
-
-    // NÃO usar ?? [] se tolerancias for não-nulo (evita dead_null_aware_expression)
-    final tolerancias = item.tolerancias;
-
-    // ------- UI -------
-    return Card(
-      elevation: 0.5,
-      child: Padding(
-        padding: const EdgeInsets.all(12.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              item.titulo.isEmpty ? '(sem título)' : item.titulo,
-              style: styleLabel,
-            ),
-            if (subtitulo.isNotEmpty) ...[
-              const SizedBox(height: 4),
-              Text(subtitulo, style: styleSpec),
-            ],
-            if ((item.periodicidade ?? '').isNotEmpty) ...[
-              const SizedBox(height: 4),
-              Text('Periodicidade: ${item.periodicidade}', style: styleSpec),
-            ],
-            if ((item.instrumento ?? '').isNotEmpty) ...[
-              const SizedBox(height: 2),
-              Text('Instrumento: ${item.instrumento}', style: styleSpec),
-            ],
-            const SizedBox(height: 10),
-
-            // Modo 1: Visual/Rug/Paralelismo/Anel de rosca passa/CQF/Simetria (binário)
-            if (_isVisualRugParalelismoOrAfins) ...[
-              Wrap(
-                spacing: 8,
-                runSpacing: 8,
-                children: [
-                  _pill(
-                    text: 'Aprovado',
-                    bg: Colors.green.shade200,
-                    border: Colors.green.shade600,
-                    fg: Colors.green.shade900,
-                    selected: item.medicao == 'Aprovado',
-                    onTap: () => onSelect(StatusMedida.ok, 'Aprovado'),
-                  ),
-                  _pill(
-                    text: 'Reprovado',
-                    bg: Colors.red.shade100,
-                    border: Colors.red.shade400,
-                    selected: item.medicao == 'Reprovado',
-                    onTap: () =>
-                        onSelect(StatusMedida.reprovadaAcima, 'Reprovado'),
-                  ),
-                ],
-              ),
-            ]
-            // Modo 2: Tampão (4 botões)
-            else if (_isTampao) ...[
-              Builder(
-                builder: (context) {
-                  final parts = _partsFromMedicao(item.medicao);
-                  return Wrap(
-                    spacing: 8,
-                    runSpacing: 8,
-                    children: [
-                      _pill(
-                        text: 'Lado passa — Aprovado',
-                        bg: Colors.green.shade200,
-                        border: Colors.green.shade600,
-                        fg: Colors.green.shade900,
-                        selected: parts.contains('Lado passa — Aprovado'),
-                        onTap: () {
-                          final p = _partsFromMedicao(item.medicao);
-                          p.removeWhere((e) => e.startsWith('Lado passa'));
-                          p.add('Lado passa — Aprovado');
-                          onSelect(_statusFromParts(p), _joinParts(p));
-                        },
-                      ),
-                      _pill(
-                        text: 'Lado passa — Reprovado',
-                        bg: Colors.red.shade100,
-                        border: Colors.red.shade400,
-                        selected: parts.contains('Lado passa — Reprovado'),
-                        onTap: () {
-                          final p = _partsFromMedicao(item.medicao);
-                          p.removeWhere((e) => e.startsWith('Lado passa'));
-                          p.add('Lado passa — Reprovado');
-                          onSelect(_statusFromParts(p), _joinParts(p));
-                        },
-                      ),
-                      _pill(
-                        text: 'Lado não passa — Aprovado',
-                        bg: Colors.green.shade200,
-                        border: Colors.green.shade600,
-                        fg: Colors.green.shade900,
-                        selected: parts.contains('Lado não passa — Aprovado'),
-                        onTap: () {
-                          final p = _partsFromMedicao(item.medicao);
-                          p.removeWhere((e) => e.startsWith('Lado não passa'));
-                          p.add('Lado não passa — Aprovado');
-                          onSelect(_statusFromParts(p), _joinParts(p));
-                        },
-                      ),
-                      _pill(
-                        text: 'Lado não passa — Reprovado',
-                        bg: Colors.red.shade100,
-                        border: Colors.red.shade400,
-                        selected: parts.contains('Lado não passa — Reprovado'),
-                        onTap: () {
-                          final p = _partsFromMedicao(item.medicao);
-                          p.removeWhere((e) => e.startsWith('Lado não passa'));
-                          p.add('Lado não passa — Reprovado');
-                          onSelect(_statusFromParts(p), _joinParts(p));
-                        },
-                      ),
-                    ],
-                  );
-                },
-              ),
-            ]
-            // Modo 3: Pílulas de tolerância + OK
-            else ...[
-              Builder(
-                builder: (context) {
-                  final chips = <Widget>[];
-
-                  // Monta as 4 pílulas coloridas na ordem recebida
-                  for (var i = 0; i < tolerancias.length; i++) {
-                    final raw = tolerancias[i];
-                    final d = _toDoubleNum(raw);
-
-                    // Define cores e status conforme a posição
-                    StatusMedida st;
-                    Color bg;
-                    Color bd;
-                    switch (i) {
-                      case 0:
-                        st = StatusMedida.reprovadaAbaixo;
-                        bg = Colors.red.shade100;
-                        bd = Colors.red.shade400;
-                        break;
-                      case 1:
-                        st = StatusMedida.alertaAbaixo;
-                        bg = Colors.amber.shade100;
-                        bd = Colors.amber.shade400;
-                        break;
-                      case 2:
-                        st = StatusMedida.alertaAcima;
-                        bg = Colors.amber.shade100;
-                        bd = Colors.amber.shade400;
-                        break;
-                      case 3:
-                        st = StatusMedida.reprovadaAcima;
-                        bg = Colors.red.shade100;
-                        bd = Colors.red.shade400;
-                        break;
-                      default:
-                        st = StatusMedida.alertaAbaixo;
-
-                        bg = Colors.amber.shade100;
-                        bd = Colors.amber.shade400;
-                    }
-
-                    final label = d != null
-                        ? d.toStringAsFixed(2)
-                        : raw.toString();
-                    final selected = item.medicao == label;
-
-                    chips.add(
-                      _pill(
-                        text: label,
-                        bg: bg,
-                        border: bd,
-                        selected: selected,
-                        onTap: () => onSelect(st, label),
-                      ),
-                    );
-                  }
-
-                  // Insere OK central
-                  final mid = chips.isEmpty ? 0 : (chips.length ~/ 2);
-                  chips.insert(
-                    mid,
-                    _pill(
-                      text: 'OK',
-                      bg: Colors.green.shade200,
-                      border: Colors.green.shade600,
-                      fg: Colors.green.shade900,
-                      selected: item.medicao == 'OK',
-                      onTap: () => onSelect(StatusMedida.ok, 'OK'),
-                    ),
-                  );
-
-                  return Wrap(spacing: 8, runSpacing: 8, children: chips);
-                },
-              ),
-            ],
-          ],
         ),
       ),
     );

--- a/lib/features/operador/presentation/troca_ferramenta_page.dart
+++ b/lib/features/operador/presentation/troca_ferramenta_page.dart
@@ -1,0 +1,464 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+
+import 'package:admin/features/operador/presentation/widgets/measurement_tile.dart';
+import 'package:admin/features/preparacao/data/models.dart';
+import 'package:admin/utils/string_utils.dart';
+
+class TrocaFerramentaPage extends StatefulWidget {
+  final String baseUrl;
+  final String re;
+  final String os;
+  final String partnumber;
+  final String operacao;
+  final String maquina;
+
+  const TrocaFerramentaPage({
+    super.key,
+    required this.baseUrl,
+    required this.re,
+    required this.os,
+    required this.partnumber,
+    required this.operacao,
+    required this.maquina,
+  });
+
+  @override
+  State<TrocaFerramentaPage> createState() => _TrocaFerramentaPageState();
+}
+
+class _TrocaFerramentaPageState extends State<TrocaFerramentaPage> {
+  bool _loading = true;
+  String? _erro;
+  List<MedidaItem> _todas = [];
+  Set<int> _selecionadas = <int>{};
+  List<MedidaItem> _medidasSelecionadas = [];
+  bool _medindo = false;
+  bool _registrando = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _carregarMedidas();
+  }
+
+  Future<void> _carregarMedidas() async {
+    setState(() {
+      _loading = true;
+      _erro = null;
+    });
+
+    final uri = Uri.parse('${widget.baseUrl}/preparador/medidas').replace(
+      queryParameters: {
+        'partnumber': normalizeCode(widget.partnumber),
+        'operacao': normalizeCode(widget.operacao),
+      },
+    );
+
+    try {
+      final resp = await http.get(uri).timeout(const Duration(seconds: 20));
+      if (!mounted) return;
+
+      if (resp.statusCode == 200) {
+        final body = resp.body.isEmpty ? '[]' : resp.body;
+        final data = jsonDecode(body);
+        final itens = data is List
+            ? data
+                  .map<MedidaItem>(
+                    (e) =>
+                        MedidaItem.fromMap((e as Map).cast<String, dynamic>()),
+                  )
+                  .toList()
+            : <MedidaItem>[];
+        setState(() {
+          _todas = itens;
+          _selecionadas = <int>{};
+          _medidasSelecionadas = [];
+          _medindo = false;
+          _loading = false;
+        });
+      } else if (resp.statusCode == 404 || resp.statusCode == 204) {
+        setState(() {
+          _todas = [];
+          _selecionadas = <int>{};
+          _medidasSelecionadas = [];
+          _medindo = false;
+          _loading = false;
+        });
+      } else {
+        throw Exception('Falha ao carregar (${resp.statusCode}) ${resp.body}');
+      }
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _erro = e.toString();
+        _loading = false;
+      });
+    }
+  }
+
+  void _toggleSelecao(int index, bool? value) {
+    setState(() {
+      if (value == true) {
+        _selecionadas.add(index);
+      } else {
+        _selecionadas.remove(index);
+      }
+    });
+  }
+
+  void _avancarParaMedicao() {
+    if (_selecionadas.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Selecione ao menos uma medida.')),
+      );
+      return;
+    }
+
+    final ordenadas = _selecionadas.toList()..sort();
+    final selecionadas = ordenadas.map((idx) {
+      final item = _todas[idx];
+      return MedidaItem(
+        titulo: item.titulo,
+        faixaTexto: item.faixaTexto,
+        minimo: item.minimo,
+        maximo: item.maximo,
+        unidade: item.unidade,
+        status: StatusMedida.pendente,
+        medicao: null,
+        observacao: item.observacao,
+        periodicidade: item.periodicidade,
+        instrumento: item.instrumento,
+        tolerancias: item.tolerancias,
+      );
+    }).toList();
+
+    setState(() {
+      _medidasSelecionadas = selecionadas;
+      _medindo = true;
+    });
+  }
+
+  void _atualizarMedicao(int index, StatusMedida status, String? medicao) {
+    final itens = [..._medidasSelecionadas];
+    if (index < 0 || index >= itens.length) return;
+    final antigo = itens[index];
+    itens[index] = MedidaItem(
+      titulo: antigo.titulo,
+      faixaTexto: antigo.faixaTexto,
+      minimo: antigo.minimo,
+      maximo: antigo.maximo,
+      unidade: antigo.unidade,
+      status: status,
+      medicao: medicao,
+      observacao: antigo.observacao,
+      periodicidade: antigo.periodicidade,
+      instrumento: antigo.instrumento,
+      tolerancias: antigo.tolerancias,
+    );
+    setState(() {
+      _medidasSelecionadas = itens;
+    });
+  }
+
+  String _subtitleFor(MedidaItem item) {
+    if (item.faixaTexto.isNotEmpty) return item.faixaTexto;
+    final min = item.minimo;
+    final max = item.maximo;
+    final uni = (item.unidade ?? '').isNotEmpty ? ' ${item.unidade}' : '';
+    if (min != null && max != null) {
+      return '${min.toStringAsFixed(2)} – ${max.toStringAsFixed(2)}$uni';
+    }
+    if (min != null) {
+      return '≥ ${min.toStringAsFixed(2)}$uni';
+    }
+    if (max != null) {
+      return '≤ ${max.toStringAsFixed(2)}$uni';
+    }
+    return '';
+  }
+
+  Future<void> _registrarMedicoes() async {
+    if (_registrando) return;
+    if (_medidasSelecionadas.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Nenhuma medida selecionada.')),
+      );
+      return;
+    }
+
+    final pendentes = _medidasSelecionadas.where(
+      (m) =>
+          m.status == StatusMedida.pendente ||
+          (m.medicao == null || m.medicao!.trim().isEmpty),
+    );
+    if (pendentes.isNotEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Preencha todas as medições selecionadas.'),
+        ),
+      );
+      return;
+    }
+
+    final naoAprovadas = _medidasSelecionadas.where(
+      (m) => m.status != StatusMedida.ok,
+    );
+    if (naoAprovadas.isNotEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Todas as medições devem estar aprovadas.'),
+        ),
+      );
+      return;
+    }
+
+    final itens = <Map<String, dynamic>>[];
+    for (var i = 0; i < _medidasSelecionadas.length; i++) {
+      final m = _medidasSelecionadas[i];
+      itens.add({
+        'indice': i,
+        'titulo': m.titulo,
+        'faixaTexto': m.faixaTexto,
+        'min': m.minimo,
+        'max': m.maximo,
+        'unidade': m.unidade,
+        'medicao': m.medicao ?? '',
+        'status': statusToString(m.status),
+        'observacao': m.observacao ?? '',
+      });
+    }
+
+    final uri = Uri.parse('${widget.baseUrl}/preparador/resultado');
+    final body = jsonEncode({
+      're': widget.re,
+      'os': widget.os,
+      'partnumber': normalizeCode(widget.partnumber),
+      'operacao': normalizeCode(widget.operacao),
+      'maquina': widget.maquina,
+      'itens': itens,
+    });
+
+    setState(() => _registrando = true);
+    try {
+      final resp = await http
+          .post(uri, headers: {'Content-Type': 'application/json'}, body: body)
+          .timeout(const Duration(seconds: 25));
+
+      if (!mounted) return;
+
+      if (resp.statusCode == 200) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Medições registradas com sucesso.')),
+        );
+        Navigator.of(context).pop(true);
+      } else if (resp.statusCode == 409) {
+        final data = jsonDecode(resp.body);
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              data['error']?.toString() ?? 'Conflito ao registrar medições.',
+            ),
+          ),
+        );
+      } else {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              'Falha ao registrar: ${resp.statusCode} ${resp.body}',
+            ),
+          ),
+        );
+      }
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('Erro ao registrar: $e')));
+    } finally {
+      if (mounted) {
+        setState(() => _registrando = false);
+      }
+    }
+  }
+
+  void _onBack() {
+    if (_medindo) {
+      setState(() {
+        _medindo = false;
+        _medidasSelecionadas = [];
+      });
+    } else {
+      Navigator.of(context).pop(false);
+    }
+  }
+
+  Widget _buildInfoChip(String label, String value) {
+    final theme = Theme.of(context);
+    return SizedBox(
+      width: 160,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(label, style: theme.textTheme.labelSmall),
+          const SizedBox(height: 4),
+          Text(value.isEmpty ? '-' : value, style: theme.textTheme.titleMedium),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return WillPopScope(
+      onWillPop: () async {
+        if (_medindo) {
+          _onBack();
+          return false;
+        }
+        return true;
+      },
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Troca de ferramenta'),
+          leading: IconButton(
+            icon: const Icon(Icons.arrow_back),
+            onPressed: _onBack,
+          ),
+        ),
+        body: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: _loading
+              ? const Center(child: CircularProgressIndicator())
+              : _erro != null
+              ? Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Text(
+                      'Erro ao carregar medidas:\n${_erro!}',
+                      textAlign: TextAlign.center,
+                    ),
+                    const SizedBox(height: 12),
+                    FilledButton.icon(
+                      onPressed: _carregarMedidas,
+                      icon: const Icon(Icons.refresh),
+                      label: const Text('Tentar novamente'),
+                    ),
+                  ],
+                )
+              : Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Card(
+                      margin: EdgeInsets.zero,
+                      child: Padding(
+                        padding: const EdgeInsets.all(16.0),
+                        child: Wrap(
+                          spacing: 24,
+                          runSpacing: 12,
+                          children: [
+                            _buildInfoChip('R.E.', widget.re),
+                            _buildInfoChip('O.S.', widget.os),
+                            _buildInfoChip('Peça', widget.partnumber),
+                            _buildInfoChip('Operação', widget.operacao),
+                            _buildInfoChip('Máquina', widget.maquina),
+                          ],
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+                    if (!_medindo) ...[
+                      Text(
+                        'Selecione as medidas impactadas pela troca da ferramenta.',
+                        style: Theme.of(context).textTheme.titleMedium,
+                      ),
+                      const SizedBox(height: 12),
+                      Expanded(
+                        child: _todas.isEmpty
+                            ? const Center(
+                                child: Text('Nenhuma medida disponível.'),
+                              )
+                            : ListView.separated(
+                                itemCount: _todas.length,
+                                separatorBuilder: (_, __) =>
+                                    const Divider(height: 1),
+                                itemBuilder: (context, index) {
+                                  final item = _todas[index];
+                                  final selecionado = _selecionadas.contains(
+                                    index,
+                                  );
+                                  final subtitulo = _subtitleFor(item);
+                                  return CheckboxListTile(
+                                    value: selecionado,
+                                    onChanged: (value) =>
+                                        _toggleSelecao(index, value),
+                                    title: Text(
+                                      item.titulo.isEmpty
+                                          ? '(sem título)'
+                                          : item.titulo,
+                                    ),
+                                    subtitle: subtitulo.isEmpty
+                                        ? null
+                                        : Text(subtitulo),
+                                  );
+                                },
+                              ),
+                      ),
+                      const SizedBox(height: 12),
+                      Align(
+                        alignment: Alignment.centerRight,
+                        child: FilledButton.icon(
+                          onPressed: _selecionadas.isEmpty
+                              ? null
+                              : _avancarParaMedicao,
+                          icon: const Icon(Icons.playlist_add_check),
+                          label: const Text('Prosseguir para medição (FOR07)'),
+                        ),
+                      ),
+                    ] else ...[
+                      Text(
+                        'Realize as medições selecionadas (FOR07).',
+                        style: Theme.of(context).textTheme.titleMedium,
+                      ),
+                      const SizedBox(height: 12),
+                      Expanded(
+                        child: ListView.builder(
+                          itemCount: _medidasSelecionadas.length,
+                          itemBuilder: (context, index) {
+                            final item = _medidasSelecionadas[index];
+                            return MeasurementTile(
+                              index: index,
+                              item: item,
+                              onSelect: (status, medicao) =>
+                                  _atualizarMedicao(index, status, medicao),
+                            );
+                          },
+                        ),
+                      ),
+                      const SizedBox(height: 12),
+                      Align(
+                        alignment: Alignment.centerRight,
+                        child: FilledButton.icon(
+                          onPressed: _registrando ? null : _registrarMedicoes,
+                          icon: _registrando
+                              ? const SizedBox(
+                                  width: 18,
+                                  height: 18,
+                                  child: CircularProgressIndicator(
+                                    strokeWidth: 2,
+                                  ),
+                                )
+                              : const Icon(Icons.save_outlined),
+                          label: const Text('Registrar medições'),
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/operador/presentation/widgets/measurement_tile.dart
+++ b/lib/features/operador/presentation/widgets/measurement_tile.dart
@@ -1,0 +1,370 @@
+import 'package:flutter/material.dart';
+
+import 'package:admin/features/preparacao/data/models.dart';
+
+class MeasurementTile extends StatelessWidget {
+  final int index;
+  final MedidaItem item;
+  final void Function(StatusMedida status, String? medicao) onSelect;
+
+  const MeasurementTile({
+    super.key,
+    required this.index,
+    required this.item,
+    required this.onSelect,
+  });
+
+  // ---------- helpers ----------
+  String _norm(String? s) => (s ?? '').trim();
+  String _nfd(String s) {
+    // normalização simples (sem pacote intl)
+    const rep = {
+      'á': 'a',
+      'à': 'a',
+      'ã': 'a',
+      'â': 'a',
+      'é': 'e',
+      'ê': 'e',
+      'í': 'i',
+      'ó': 'o',
+      'ô': 'o',
+      'õ': 'o',
+      'ú': 'u',
+      'ç': 'c',
+      'Á': 'A',
+      'À': 'A',
+      'Ã': 'A',
+      'Â': 'A',
+      'É': 'E',
+      'Ê': 'E',
+      'Í': 'I',
+      'Ó': 'O',
+      'Ô': 'O',
+      'Õ': 'O',
+      'Ú': 'U',
+      'Ç': 'C',
+    };
+    var t = s;
+    rep.forEach((k, v) => t = t.replaceAll(k, v));
+    return t;
+  }
+
+  bool _containsAny(String hay, List<String> needles) {
+    final h = _nfd(hay.toLowerCase());
+    return needles.any((n) => h.contains(_nfd(n.toLowerCase())));
+  }
+
+  bool get _isVisualRugParalelismoOrAfins {
+    final t = _norm(item.titulo);
+    final inst = _norm(item.instrumento);
+    return _containsAny(t, [
+          'visual',
+          'rug',
+          'paralelismo',
+          'anel de rosca passa',
+          'cqf',
+          'simetria',
+          'concentricidade',
+        ]) ||
+        _containsAny(inst, [
+          'visual',
+          'rug',
+          'rugosimetro',
+          'paralelismo',
+          'anel de rosca passa',
+          'cqf',
+          'simetria',
+        ]);
+  }
+
+  bool get _isTampao {
+    final t = _norm(item.titulo);
+    final inst = _norm(item.instrumento);
+    return _containsAny(t, ['tamp', 'tampao', 'tampão', 'tampa']) ||
+        _containsAny(inst, ['tamp', 'tampao', 'tampão', 'tampa']);
+  }
+
+  Set<String> _partsFromMedicao(String? medicao) => (medicao ?? '')
+      .split('|')
+      .map((s) => s.trim())
+      .where((s) => s.isNotEmpty)
+      .toSet();
+
+  String _joinParts(Set<String> parts) => parts.join(' | ');
+
+  StatusMedida _statusFromParts(Set<String> parts) {
+    final hasPassa = parts.any((p) => p.startsWith('Lado passa'));
+    final hasNaoPassa = parts.any((p) => p.startsWith('Lado não passa'));
+    if (hasPassa && hasNaoPassa) {
+      final passaReprovado = parts.contains('Lado passa — Reprovado');
+      final naoPassaReprovado = parts.contains('Lado não passa — Reprovado');
+      if (passaReprovado && naoPassaReprovado) {
+        return StatusMedida.reprovadaAcima;
+      }
+      if (passaReprovado) return StatusMedida.reprovadaAbaixo;
+      if (naoPassaReprovado) return StatusMedida.reprovadaAcima;
+      return StatusMedida.ok;
+    }
+    return StatusMedida.pendente;
+  }
+
+  double? _toDoubleNum(dynamic v) {
+    if (v == null) return null;
+    if (v is num) return v.toDouble();
+    return double.tryParse(v.toString().replaceAll(',', '.').trim());
+  }
+
+  Color _fgOn(Color bg) =>
+      ThemeData.estimateBrightnessForColor(bg) == Brightness.dark
+      ? Colors.white
+      : Colors.black87;
+
+  Widget _pill({
+    required String text,
+    required Color bg,
+    required Color border,
+    bool selected = false,
+    Color? fg,
+    VoidCallback? onTap,
+  }) {
+    final fgColor = fg ?? _fgOn(bg);
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(999),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+        decoration: BoxDecoration(
+          color: bg,
+          borderRadius: BorderRadius.circular(999),
+          border: Border.all(
+            color: selected ? border.withValues(alpha: 0.9) : border,
+            width: selected ? 2 : 1,
+          ),
+        ),
+        child: Text(
+          text,
+          style: TextStyle(fontWeight: FontWeight.w600, color: fgColor),
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final styleLabel = Theme.of(context).textTheme.titleMedium;
+    final styleSpec = Theme.of(context).textTheme.bodyMedium;
+
+    String subtitulo = item.faixaTexto;
+    if (subtitulo.isEmpty && (item.minimo != null || item.maximo != null)) {
+      final minStr = item.minimo?.toStringAsFixed(2) ?? '';
+      final maxStr = item.maximo?.toStringAsFixed(2) ?? '';
+      final uni = (item.unidade ?? '').isNotEmpty ? ' ${item.unidade}' : '';
+      if (minStr.isNotEmpty && maxStr.isNotEmpty) {
+        subtitulo = '$minStr – $maxStr$uni';
+      } else if (minStr.isNotEmpty) {
+        subtitulo = '≥ $minStr$uni';
+      } else if (maxStr.isNotEmpty) {
+        subtitulo = '≤ $maxStr$uni';
+      }
+    }
+
+    // NÃO usar ?? [] se tolerancias for não-nulo (evita dead_null_aware_expression)
+    final tolerancias = item.tolerancias;
+
+    // ------- UI -------
+    return Card(
+      elevation: 0.5,
+      child: Padding(
+        padding: const EdgeInsets.all(12.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              item.titulo.isEmpty ? '(sem título)' : item.titulo,
+              style: styleLabel,
+            ),
+            if (subtitulo.isNotEmpty) ...[
+              const SizedBox(height: 4),
+              Text(subtitulo, style: styleSpec),
+            ],
+            if ((item.periodicidade ?? '').isNotEmpty) ...[
+              const SizedBox(height: 4),
+              Text('Periodicidade: ${item.periodicidade}', style: styleSpec),
+            ],
+            if ((item.instrumento ?? '').isNotEmpty) ...[
+              const SizedBox(height: 2),
+              Text('Instrumento: ${item.instrumento}', style: styleSpec),
+            ],
+            const SizedBox(height: 10),
+
+            // Modo 1: Visual/Rug/Paralelismo/Anel de rosca passa/CQF/Simetria (binário)
+            if (_isVisualRugParalelismoOrAfins) ...[
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: [
+                  _pill(
+                    text: 'Aprovado',
+                    bg: Colors.green.shade200,
+                    border: Colors.green.shade600,
+                    fg: Colors.green.shade900,
+                    selected: item.medicao == 'Aprovado',
+                    onTap: () => onSelect(StatusMedida.ok, 'Aprovado'),
+                  ),
+                  _pill(
+                    text: 'Reprovado',
+                    bg: Colors.red.shade100,
+                    border: Colors.red.shade400,
+                    selected: item.medicao == 'Reprovado',
+                    onTap: () =>
+                        onSelect(StatusMedida.reprovadaAcima, 'Reprovado'),
+                  ),
+                ],
+              ),
+            ]
+            // Modo 2: Tampão (4 botões)
+            else if (_isTampao) ...[
+              Builder(
+                builder: (context) {
+                  final parts = _partsFromMedicao(item.medicao);
+                  return Wrap(
+                    spacing: 8,
+                    runSpacing: 8,
+                    children: [
+                      _pill(
+                        text: 'Lado passa — Aprovado',
+                        bg: Colors.green.shade200,
+                        border: Colors.green.shade600,
+                        fg: Colors.green.shade900,
+                        selected: parts.contains('Lado passa — Aprovado'),
+                        onTap: () {
+                          final p = _partsFromMedicao(item.medicao);
+                          p.removeWhere((e) => e.startsWith('Lado passa'));
+                          p.add('Lado passa — Aprovado');
+                          onSelect(_statusFromParts(p), _joinParts(p));
+                        },
+                      ),
+                      _pill(
+                        text: 'Lado passa — Reprovado',
+                        bg: Colors.red.shade100,
+                        border: Colors.red.shade400,
+                        selected: parts.contains('Lado passa — Reprovado'),
+                        onTap: () {
+                          final p = _partsFromMedicao(item.medicao);
+                          p.removeWhere((e) => e.startsWith('Lado passa'));
+                          p.add('Lado passa — Reprovado');
+                          onSelect(_statusFromParts(p), _joinParts(p));
+                        },
+                      ),
+                      _pill(
+                        text: 'Lado não passa — Aprovado',
+                        bg: Colors.green.shade200,
+                        border: Colors.green.shade600,
+                        fg: Colors.green.shade900,
+                        selected: parts.contains('Lado não passa — Aprovado'),
+                        onTap: () {
+                          final p = _partsFromMedicao(item.medicao);
+                          p.removeWhere((e) => e.startsWith('Lado não passa'));
+                          p.add('Lado não passa — Aprovado');
+                          onSelect(_statusFromParts(p), _joinParts(p));
+                        },
+                      ),
+                      _pill(
+                        text: 'Lado não passa — Reprovado',
+                        bg: Colors.red.shade100,
+                        border: Colors.red.shade400,
+                        selected: parts.contains('Lado não passa — Reprovado'),
+                        onTap: () {
+                          final p = _partsFromMedicao(item.medicao);
+                          p.removeWhere((e) => e.startsWith('Lado não passa'));
+                          p.add('Lado não passa — Reprovado');
+                          onSelect(_statusFromParts(p), _joinParts(p));
+                        },
+                      ),
+                    ],
+                  );
+                },
+              ),
+            ]
+            // Modo 3: Pílulas de tolerância + OK
+            else ...[
+              Builder(
+                builder: (context) {
+                  final chips = <Widget>[];
+
+                  // Monta as 4 pílulas coloridas na ordem recebida
+                  for (var i = 0; i < tolerancias.length; i++) {
+                    final raw = tolerancias[i];
+                    final d = _toDoubleNum(raw);
+
+                    // Define cores e status conforme a posição
+                    StatusMedida st;
+                    Color bg;
+                    Color bd;
+                    switch (i) {
+                      case 0:
+                        st = StatusMedida.reprovadaAbaixo;
+                        bg = Colors.red.shade100;
+                        bd = Colors.red.shade400;
+                        break;
+                      case 1:
+                        st = StatusMedida.alertaAbaixo;
+                        bg = Colors.amber.shade100;
+                        bd = Colors.amber.shade400;
+                        break;
+                      case 2:
+                        st = StatusMedida.alertaAcima;
+                        bg = Colors.amber.shade100;
+                        bd = Colors.amber.shade400;
+                        break;
+                      case 3:
+                        st = StatusMedida.reprovadaAcima;
+                        bg = Colors.red.shade100;
+                        bd = Colors.red.shade400;
+                        break;
+                      default:
+                        st = StatusMedida.alertaAbaixo;
+                        bg = Colors.amber.shade100;
+                        bd = Colors.amber.shade400;
+                    }
+
+                    final label = d != null
+                        ? d.toStringAsFixed(2)
+                        : raw.toString();
+                    final selected = item.medicao == label;
+
+                    chips.add(
+                      _pill(
+                        text: label,
+                        bg: bg,
+                        border: bd,
+                        selected: selected,
+                        onTap: () => onSelect(st, label),
+                      ),
+                    );
+                  }
+
+                  // Insere OK central
+                  final mid = chips.isEmpty ? 0 : (chips.length ~/ 2);
+                  chips.insert(
+                    mid,
+                    _pill(
+                      text: 'OK',
+                      bg: Colors.green.shade200,
+                      border: Colors.green.shade600,
+                      fg: Colors.green.shade900,
+                      selected: item.medicao == 'OK',
+                      onTap: () => onSelect(StatusMedida.ok, 'OK'),
+                    ),
+                  );
+
+                  return Wrap(spacing: 8, runSpacing: 8, children: chips);
+                },
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- require confirming pause reasons in the operator view and route "Troca de ferramenta" to a dedicated flow
- extract the measurement tile widget for reuse and create a tool-change page that loads FOR07 measures
- ensure the tool-change flow validates approvals before returning to sampling

## Testing
- flutter test

------
https://chatgpt.com/codex/tasks/task_e_68cd7271f65483319e6273128655a2a9