### PR TITLE
Adjust tool change measurement flow to support manual entry and dual logging

### DIFF
--- a/app_db.py
+++ b/app_db.py
@@ -755,6 +755,39 @@ def _medidas_operador_db(part: str, op: str):
 
 
 # ========= HELPERS DE NEGÓCIO =========
+def _outra_os_em_andamento(
+    conn, os_num: str, maquina: str
+) -> Tuple[bool, Optional[str]]:
+    os_num = _norm(os_num)
+    maquina = _norm(maquina)
+    if not os_num or not maquina:
+        return (False, None)
+
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT DISTINCT os
+              FROM preparador_liberacao
+             WHERE maquina=%s
+               AND os<>%s
+            """,
+            (maquina, os_num),
+        )
+        outros = [row.get("os") for row in cur.fetchall() if row.get("os")]
+
+    for outro in outros:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT status FROM ordem_servico WHERE os=%s", (outro,)
+            )
+            st_row = cur.fetchone()
+        status = (st_row.get("status") or "").strip().lower() if st_row else ""
+        if status != "encerrada":
+            return (True, outro)
+
+    return (False, None)
+
+
 def _maquina_liberada(
         conn, os_num: str, part: str, op: str, maquina: str
 ) -> Tuple[bool, str, str]:
@@ -1053,6 +1086,8 @@ def resultado_preparador():
     part = _norm_part(payload.get("partnumber"))
     op = _norm_op(payload.get("operacao"))
     maquina = _norm(payload.get("maquina"))
+    contexto = _norm(payload.get("contexto"))
+    contexto_tipo = contexto.lower()
     itens = payload.get("itens", [])
 
     if not os_num or not re_prep or not part or not op or not maquina:
@@ -1108,8 +1143,26 @@ def resultado_preparador():
                         409,
                     )
 
+            conflito_os, os_bloqueadora = _outra_os_em_andamento(
+                c, os_num, maquina
+            )
+            if conflito_os and os_bloqueadora:
+                return (
+                    jsonify(
+                        {
+                            "code": "maquina_ocupada",
+                            "error": (
+                                f"Máquina {maquina} já está liberada para a OS "
+                                f"{os_bloqueadora}. Finalize essa OS antes de registrar uma nova."
+                            ),
+                            "os_em_andamento": os_bloqueadora,
+                        }
+                    ),
+                    409,
+                )
+
             ok, fonte, detalhe = _maquina_liberada(c, os_num, part, op, maquina)
-            if ok:
+            if ok and contexto_tipo != "troca_ferramenta":
                 return (
                     jsonify(
                         {
@@ -1136,7 +1189,7 @@ def resultado_preparador():
                     (os_num, part, maquina),
                 )
                 row_os = cur.fetchone()
-                if row_os:
+                if row_os and contexto_tipo != "troca_ferramenta":
                     return (
                         jsonify(
                             {
@@ -1154,6 +1207,8 @@ def resultado_preparador():
                     "INSERT IGNORE INTO ordem_servico (os) VALUES (%s)", (os_num,)
                 )
 
+                amostragem_id = None
+
                 # cabeçalho
                 cur.execute(
                     """
@@ -1165,6 +1220,7 @@ def resultado_preparador():
                 registro_id = cur.lastrowid
 
                 # itens
+                parsed_items = []
                 all_status = []
                 for it in itens:
                     idx = int(it.get("indice", 0))
@@ -1173,9 +1229,37 @@ def resultado_preparador():
                     minimo = it.get("min")
                     maximo = it.get("max")
                     unidade = _norm(it.get("unidade"))
-                    medicao = _norm(it.get("medicao")).replace(",", ".")
-                    status = _norm(it.get("status")).lower()
+                    medicao_txt = _norm(it.get("medicao"))
+                    medicao_sanitizada = medicao_txt.replace(",", ".")
+                    status_original = _norm(it.get("status"))
+                    status_lower = status_original.lower()
                     observacao = _norm(it.get("observacao"))
+                    periodicidade = _norm(it.get("periodicidade"))
+                    instrumento = _norm(it.get("instrumento"))
+                    tolerancias = it.get("tolerancias", [])
+                    if isinstance(tolerancias, (list, tuple)):
+                        tolerancias = list(tolerancias)
+                    else:
+                        tolerancias = []
+
+                    parsed = {
+                        "idx": idx,
+                        "titulo": titulo,
+                        "faixa_texto": faixa_texto,
+                        "minimo": minimo,
+                        "maximo": maximo,
+                        "unidade": unidade,
+                        "medicao_txt": medicao_txt,
+                        "medicao_sanitizada": medicao_sanitizada,
+                        "medicao_float": _to_float(medicao_sanitizada),
+                        "status_original": status_original,
+                        "status_lower": status_lower,
+                        "observacao": observacao,
+                        "periodicidade": periodicidade,
+                        "instrumento": instrumento,
+                        "tolerancias": tolerancias,
+                    }
+                    parsed_items.append(parsed)
 
                     cur.execute(
                         """
@@ -1194,12 +1278,12 @@ def resultado_preparador():
                             minimo,
                             maximo,
                             unidade,
-                            medicao,
-                            status,
+                            medicao_sanitizada,
+                            status_lower,
                             observacao,
                         ),
                     )
-                    all_status.append(status)
+                    all_status.append(status_lower)
 
                 # Consolida liberação
                 has_reprov = any(
@@ -1246,21 +1330,7 @@ def resultado_preparador():
                     "DELETE FROM preparador_liberacao_item WHERE liberacao_id=%s",
                     (liberacao_id,),
                 )
-                for it in itens:
-                    idx = int(it.get("indice", 0))
-                    titulo = _norm(it.get("titulo"))
-                    faixa_texto = _norm(it.get("faixaTexto"))
-                    minimo = it.get("min")
-                    maximo = it.get("max")
-                    unidade = _norm(it.get("unidade"))
-                    medicao_raw = _norm(it.get("medicao")).replace(",", ".")
-                    status = _norm(it.get("status")).lower()
-                    observacao = _norm(it.get("observacao"))
-                    medicao_val = None
-                    try:
-                        medicao_val = float(medicao_raw) if medicao_raw else None
-                    except Exception:
-                        medicao_val = None
+                for parsed in parsed_items:
                     cur.execute(
                         """
                         INSERT INTO preparador_liberacao_item
@@ -1272,29 +1342,79 @@ def resultado_preparador():
                         """,
                         (
                             liberacao_id,
-                            idx,
-                            titulo,
-                            faixa_texto,
-                            minimo,
-                            maximo,
-                            unidade,
-                            medicao_val,
-                            status,
-                            None,
-                            None,
-                            observacao,
+                            parsed["idx"],
+                            parsed["titulo"],
+                            parsed["faixa_texto"],
+                            parsed["minimo"],
+                            parsed["maximo"],
+                            parsed["unidade"],
+                            parsed["medicao_float"],
+                            parsed["status_lower"],
+                            parsed["periodicidade"] or None,
+                            parsed["instrumento"] or None,
+                            parsed["observacao"],
                         ),
                     )
 
+                if contexto_tipo == "troca_ferramenta":
+                    cur.execute(
+                        """
+                        INSERT INTO operador_amostragem (os, partnumber, operacao, re_operador, maquina)
+                        VALUES (%s, %s, %s, %s, %s)
+                        """,
+                        (os_num, part, op, re_prep, maquina),
+                    )
+                    amostragem_id = cur.lastrowid
+
+                    for parsed in parsed_items:
+                        tolerancias = parsed["tolerancias"]
+                        tol_txt = None
+                        if tolerancias:
+                            try:
+                                tol_txt = json.dumps(tolerancias, ensure_ascii=False)
+                            except Exception:
+                                tol_txt = None
+
+                        cur.execute(
+                            """
+                            INSERT INTO operador_amostragem_item
+                              (amostragem_id, idx_medida, titulo, instrumento, faixa_texto,
+                               minimo, maximo, unidade, periodicidade, tolerancias,
+                               escolha, status, observacao)
+                            VALUES
+                              (%s, %s, %s, %s, %s,
+                               %s, %s, %s, %s, %s,
+                               %s, %s, %s)
+                            """,
+                            (
+                                amostragem_id,
+                                parsed["idx"],
+                                parsed["titulo"],
+                                parsed["instrumento"] or None,
+                                parsed["faixa_texto"],
+                                parsed["minimo"],
+                                parsed["maximo"],
+                                parsed["unidade"],
+                                parsed["periodicidade"] or None,
+                                tol_txt,
+                                parsed["medicao_txt"],
+                                parsed["status_original"]
+                                or parsed["status_lower"],
+                                parsed["observacao"] or "Troca de ferramenta",
+                            ),
+                        )
+
             c.commit()
 
-            return jsonify(
-                {
-                    "status": "ok",
-                    "registro_id": registro_id,
-                    "status_geral": status_geral,
-                }
-            )
+            resposta = {
+                "status": "ok",
+                "registro_id": registro_id,
+                "status_geral": status_geral,
+            }
+            if amostragem_id is not None:
+                resposta["amostragem_id"] = amostragem_id
+
+            return jsonify(resposta)
 
     except Exception as e:
         return jsonify({"error": f"Falha ao inserir registro do preparador: {e}"}), 500

--- a/lib/features/operador/presentation/operador_page.dart
+++ b/lib/features/operador/presentation/operador_page.dart
@@ -9,6 +9,8 @@ import 'package:http/http.dart' as http;
 
 import '../../preparacao/data/models.dart';
 import '../data/repository_provider.dart';
+import 'package:admin/features/operador/presentation/troca_ferramenta_page.dart';
+import 'package:admin/features/operador/presentation/widgets/measurement_tile.dart';
 import 'package:admin/screens/main/components/side_menu.dart';
 import 'package:admin/widgets/window_bar.dart';
 import 'package:admin/utils/string_utils.dart';
@@ -290,9 +292,9 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
           .timeout(const Duration(seconds: 20));
       if (!mounted) return;
       if (resp.statusCode == 200) {
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(SnackBar(content: Text('Jornada pausada. Motivo: $motivo')));
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Jornada pausada. Motivo: $motivo')),
+        );
       } else {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text('Falha: ${resp.statusCode} ${resp.body}')),
@@ -307,42 +309,122 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
   }
 
   Future<void> _showFimJornadaDialog() async {
+    const motivos = <String>[
+      'Banheiro',
+      'Refeição',
+      'Fim do Turno',
+      'Troca de ferramenta',
+      'Manutenção',
+      'Falta de Material',
+      'Problema de Qualidade',
+      'Outros',
+    ];
+
     final motivo = await showDialog<String>(
       context: context,
-      builder: (context) => AlertDialog(
-        title: const Text('Pausa de Jornada'),
-        content: DropdownButtonFormField<String>(
-          value: null,
-          decoration: const InputDecoration(
-            labelText: 'Selecione o motivo',
-            border: OutlineInputBorder(),
+      builder: (context) {
+        String? selecionado;
+        return StatefulBuilder(
+          builder: (context, setState) => AlertDialog(
+            title: const Text('Pausa de Jornada'),
+            content: SingleChildScrollView(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: motivos
+                    .map(
+                      (m) => RadioListTile<String>(
+                        title: Text(m),
+                        value: m,
+                        groupValue: selecionado,
+                        onChanged: (value) =>
+                            setState(() => selecionado = value),
+                      ),
+                    )
+                    .toList(),
+              ),
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(),
+                child: const Text('Cancelar'),
+              ),
+              FilledButton(
+                onPressed: selecionado == null
+                    ? null
+                    : () => Navigator.of(context).pop(selecionado),
+                child: const Text('Avançar'),
+              ),
+            ],
           ),
-          items: const [
-            DropdownMenuItem(value: 'Banheiro', child: Text('Banheiro')),
-            DropdownMenuItem(value: 'Refeição', child: Text('Refeição')),
-            DropdownMenuItem(value: 'Fim do Turno', child: Text('Fim do Turno')),
-            DropdownMenuItem(value: 'Troca de ferramenta', child: Text('Troca de ferramenta')),
-            DropdownMenuItem(value: 'Manutenção', child: Text('Manutenção')),
-            DropdownMenuItem(value: 'Falta de Material', child: Text('Falta de Material')),
-            DropdownMenuItem(value: 'Problema de Qualidade', child: Text('Problema de Qualidade')),
-            DropdownMenuItem(value: 'Outros', child: Text('Outros')),
-          ],
-          onChanged: (value) {
-            Navigator.of(context).pop(value);
-          },
-        ),
+        );
+      },
+    );
+
+    if (motivo == null) return;
+
+    final confirmado = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Confirmar motivo'),
+        content: Text('Deseja confirmar a opção "$motivo"?'),
         actions: [
           TextButton(
-            onPressed: () => Navigator.of(context).pop(),
-            child: const Text('Cancelar'),
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Não'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Sim'),
           ),
         ],
       ),
     );
 
-    if (motivo != null) {
-      await _fimJornada(motivo);
+    if (confirmado != true) return;
+
+    if (motivo == 'Troca de ferramenta') {
+      final re = _reCtrl.text.trim();
+      final os = _osCtrl.text.trim();
+      final part = _partCtrl.text.trim();
+      final operacao = _opCtrl.text.trim();
+      final maquina = (_maquinaSel ?? '').trim();
+
+      if (re.isEmpty ||
+          os.isEmpty ||
+          part.isEmpty ||
+          operacao.isEmpty ||
+          maquina.isEmpty) {
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text(
+              'Preencha R.E., O.S., peça, operação e máquina antes de trocar a ferramenta.',
+            ),
+          ),
+        );
+        return;
+      }
+
+      final sucesso = await Navigator.of(context).push<bool>(
+        MaterialPageRoute(
+          builder: (_) => TrocaFerramentaPage(
+            baseUrl: kBaseUrl,
+            re: re,
+            os: os,
+            partnumber: part,
+            operacao: operacao,
+            maquina: maquina,
+          ),
+        ),
+      );
+
+      if (sucesso == true) {
+        await _fimJornada(motivo);
+      }
+      return;
     }
+
+    await _fimJornada(motivo);
   }
 
   Future<void> _encerrarProducao() async {
@@ -634,7 +716,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                       separatorBuilder: (_, __) => const SizedBox(height: 8),
                       itemBuilder: (context, index) {
                         final item = list[index];
-                        return _MeasurementTile(
+                        return MeasurementTile(
                           index: index,
                           item: item,
                           onSelect: (status, medicao) => ref
@@ -684,373 +766,6 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
               ),
             ],
           ),
-        ),
-      ),
-    );
-  }
-}
-
-class _MeasurementTile extends StatelessWidget {
-  final int index;
-  final MedidaItem item;
-  final void Function(StatusMedida status, String? medicao) onSelect;
-
-  const _MeasurementTile({
-    required this.index,
-    required this.item,
-    required this.onSelect,
-  });
-
-  // ---------- helpers ----------
-  String _norm(String? s) => (s ?? '').trim();
-  String _nfd(String s) {
-    // normalização simples (sem pacote intl)
-    const rep = {
-      'á': 'a',
-      'à': 'a',
-      'ã': 'a',
-      'â': 'a',
-      'é': 'e',
-      'ê': 'e',
-      'í': 'i',
-      'ó': 'o',
-      'ô': 'o',
-      'õ': 'o',
-      'ú': 'u',
-      'ç': 'c',
-      'Á': 'A',
-      'À': 'A',
-      'Ã': 'A',
-      'Â': 'A',
-      'É': 'E',
-      'Ê': 'E',
-      'Í': 'I',
-      'Ó': 'O',
-      'Ô': 'O',
-      'Õ': 'O',
-      'Ú': 'U',
-      'Ç': 'C',
-    };
-    var t = s;
-    rep.forEach((k, v) => t = t.replaceAll(k, v));
-    return t;
-  }
-
-  bool _containsAny(String hay, List<String> needles) {
-    final h = _nfd(hay.toLowerCase());
-    return needles.any((n) => h.contains(_nfd(n.toLowerCase())));
-  }
-
-  bool get _isVisualRugParalelismoOrAfins {
-    final t = _norm(item.titulo);
-    final inst = _norm(item.instrumento);
-    return _containsAny(t, [
-          'visual',
-          'rug',
-          'paralelismo',
-          'anel de rosca passa',
-          'cqf',
-          'simetria',
-          'concentricidade',
-        ]) ||
-        _containsAny(inst, [
-          'visual',
-          'rug',
-          'rugosimetro',
-          'paralelismo',
-          'anel de rosca passa',
-          'cqf',
-          'simetria',
-        ]);
-  }
-
-  bool get _isTampao {
-    final t = _norm(item.titulo);
-    final inst = _norm(item.instrumento);
-    return _containsAny(t, ['tamp', 'tampao', 'tampão', 'tampa']) ||
-        _containsAny(inst, ['tamp', 'tampao', 'tampão', 'tampa']);
-  }
-
-  Set<String> _partsFromMedicao(String? medicao) => (medicao ?? '')
-      .split('|')
-      .map((s) => s.trim())
-      .where((s) => s.isNotEmpty)
-      .toSet();
-
-  String _joinParts(Set<String> parts) => parts.join(' | ');
-
-  StatusMedida _statusFromParts(Set<String> parts) {
-    final hasPassa = parts.any((p) => p.startsWith('Lado passa'));
-    final hasNaoPassa = parts.any((p) => p.startsWith('Lado não passa'));
-    if (hasPassa && hasNaoPassa) {
-      final passaReprovado = parts.contains('Lado passa — Reprovado');
-      final naoPassaReprovado = parts.contains('Lado não passa — Reprovado');
-      if (passaReprovado && naoPassaReprovado) {
-        return StatusMedida.reprovadaAcima;
-      }
-      if (passaReprovado) return StatusMedida.reprovadaAbaixo;
-      if (naoPassaReprovado) return StatusMedida.reprovadaAcima;
-      return StatusMedida.ok;
-    }
-    return StatusMedida.pendente;
-  }
-
-  double? _toDoubleNum(dynamic v) {
-    if (v == null) return null;
-    if (v is num) return v.toDouble();
-    return double.tryParse(v.toString().replaceAll(',', '.').trim());
-  }
-
-  Color _fgOn(Color bg) =>
-      ThemeData.estimateBrightnessForColor(bg) == Brightness.dark
-      ? Colors.white
-      : Colors.black87;
-
-  Widget _pill({
-    required String text,
-    required Color bg,
-    required Color border,
-    bool selected = false,
-    Color? fg,
-    VoidCallback? onTap,
-  }) {
-    final fgColor = fg ?? _fgOn(bg);
-    return InkWell(
-      onTap: onTap,
-      borderRadius: BorderRadius.circular(999),
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
-        decoration: BoxDecoration(
-          color: bg,
-          borderRadius: BorderRadius.circular(999),
-          border: Border.all(
-            color: selected ? border.withValues(alpha: 0.9) : border,
-            width: selected ? 2 : 1,
-          ),
-        ),
-        child: Text(
-          text,
-          style: TextStyle(fontWeight: FontWeight.w600, color: fgColor),
-        ),
-      ),
-    );
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final styleLabel = Theme.of(context).textTheme.titleMedium;
-    final styleSpec = Theme.of(context).textTheme.bodyMedium;
-
-    String subtitulo = item.faixaTexto;
-    if (subtitulo.isEmpty && (item.minimo != null || item.maximo != null)) {
-      final minStr = item.minimo?.toStringAsFixed(2) ?? '';
-      final maxStr = item.maximo?.toStringAsFixed(2) ?? '';
-      final uni = (item.unidade ?? '').isNotEmpty ? ' ${item.unidade}' : '';
-      if (minStr.isNotEmpty && maxStr.isNotEmpty) {
-        subtitulo = '$minStr – $maxStr$uni';
-      } else if (minStr.isNotEmpty) {
-        subtitulo = '≥ $minStr$uni';
-      } else if (maxStr.isNotEmpty) {
-        subtitulo = '≤ $maxStr$uni';
-      }
-    }
-
-    // NÃO usar ?? [] se tolerancias for não-nulo (evita dead_null_aware_expression)
-    final tolerancias = item.tolerancias;
-
-    // ------- UI -------
-    return Card(
-      elevation: 0.5,
-      child: Padding(
-        padding: const EdgeInsets.all(12.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              item.titulo.isEmpty ? '(sem título)' : item.titulo,
-              style: styleLabel,
-            ),
-            if (subtitulo.isNotEmpty) ...[
-              const SizedBox(height: 4),
-              Text(subtitulo, style: styleSpec),
-            ],
-            if ((item.periodicidade ?? '').isNotEmpty) ...[
-              const SizedBox(height: 4),
-              Text('Periodicidade: ${item.periodicidade}', style: styleSpec),
-            ],
-            if ((item.instrumento ?? '').isNotEmpty) ...[
-              const SizedBox(height: 2),
-              Text('Instrumento: ${item.instrumento}', style: styleSpec),
-            ],
-            const SizedBox(height: 10),
-
-            // Modo 1: Visual/Rug/Paralelismo/Anel de rosca passa/CQF/Simetria (binário)
-            if (_isVisualRugParalelismoOrAfins) ...[
-              Wrap(
-                spacing: 8,
-                runSpacing: 8,
-                children: [
-                  _pill(
-                    text: 'Aprovado',
-                    bg: Colors.green.shade200,
-                    border: Colors.green.shade600,
-                    fg: Colors.green.shade900,
-                    selected: item.medicao == 'Aprovado',
-                    onTap: () => onSelect(StatusMedida.ok, 'Aprovado'),
-                  ),
-                  _pill(
-                    text: 'Reprovado',
-                    bg: Colors.red.shade100,
-                    border: Colors.red.shade400,
-                    selected: item.medicao == 'Reprovado',
-                    onTap: () =>
-                        onSelect(StatusMedida.reprovadaAcima, 'Reprovado'),
-                  ),
-                ],
-              ),
-            ]
-            // Modo 2: Tampão (4 botões)
-            else if (_isTampao) ...[
-              Builder(
-                builder: (context) {
-                  final parts = _partsFromMedicao(item.medicao);
-                  return Wrap(
-                    spacing: 8,
-                    runSpacing: 8,
-                    children: [
-                      _pill(
-                        text: 'Lado passa — Aprovado',
-                        bg: Colors.green.shade200,
-                        border: Colors.green.shade600,
-                        fg: Colors.green.shade900,
-                        selected: parts.contains('Lado passa — Aprovado'),
-                        onTap: () {
-                          final p = _partsFromMedicao(item.medicao);
-                          p.removeWhere((e) => e.startsWith('Lado passa'));
-                          p.add('Lado passa — Aprovado');
-                          onSelect(_statusFromParts(p), _joinParts(p));
-                        },
-                      ),
-                      _pill(
-                        text: 'Lado passa — Reprovado',
-                        bg: Colors.red.shade100,
-                        border: Colors.red.shade400,
-                        selected: parts.contains('Lado passa — Reprovado'),
-                        onTap: () {
-                          final p = _partsFromMedicao(item.medicao);
-                          p.removeWhere((e) => e.startsWith('Lado passa'));
-                          p.add('Lado passa — Reprovado');
-                          onSelect(_statusFromParts(p), _joinParts(p));
-                        },
-                      ),
-                      _pill(
-                        text: 'Lado não passa — Aprovado',
-                        bg: Colors.green.shade200,
-                        border: Colors.green.shade600,
-                        fg: Colors.green.shade900,
-                        selected: parts.contains('Lado não passa — Aprovado'),
-                        onTap: () {
-                          final p = _partsFromMedicao(item.medicao);
-                          p.removeWhere((e) => e.startsWith('Lado não passa'));
-                          p.add('Lado não passa — Aprovado');
-                          onSelect(_statusFromParts(p), _joinParts(p));
-                        },
-                      ),
-                      _pill(
-                        text: 'Lado não passa — Reprovado',
-                        bg: Colors.red.shade100,
-                        border: Colors.red.shade400,
-                        selected: parts.contains('Lado não passa — Reprovado'),
-                        onTap: () {
-                          final p = _partsFromMedicao(item.medicao);
-                          p.removeWhere((e) => e.startsWith('Lado não passa'));
-                          p.add('Lado não passa — Reprovado');
-                          onSelect(_statusFromParts(p), _joinParts(p));
-                        },
-                      ),
-                    ],
-                  );
-                },
-              ),
-            ]
-            // Modo 3: Pílulas de tolerância + OK
-            else ...[
-              Builder(
-                builder: (context) {
-                  final chips = <Widget>[];
-
-                  // Monta as 4 pílulas coloridas na ordem recebida
-                  for (var i = 0; i < tolerancias.length; i++) {
-                    final raw = tolerancias[i];
-                    final d = _toDoubleNum(raw);
-
-                    // Define cores e status conforme a posição
-                    StatusMedida st;
-                    Color bg;
-                    Color bd;
-                    switch (i) {
-                      case 0:
-                        st = StatusMedida.reprovadaAbaixo;
-                        bg = Colors.red.shade100;
-                        bd = Colors.red.shade400;
-                        break;
-                      case 1:
-                        st = StatusMedida.alertaAbaixo;
-                        bg = Colors.amber.shade100;
-                        bd = Colors.amber.shade400;
-                        break;
-                      case 2:
-                        st = StatusMedida.alertaAcima;
-                        bg = Colors.amber.shade100;
-                        bd = Colors.amber.shade400;
-                        break;
-                      case 3:
-                        st = StatusMedida.reprovadaAcima;
-                        bg = Colors.red.shade100;
-                        bd = Colors.red.shade400;
-                        break;
-                      default:
-                        st = StatusMedida.alertaAbaixo;
-
-                        bg = Colors.amber.shade100;
-                        bd = Colors.amber.shade400;
-                    }
-
-                    final label = d != null
-                        ? d.toStringAsFixed(2)
-                        : raw.toString();
-                    final selected = item.medicao == label;
-
-                    chips.add(
-                      _pill(
-                        text: label,
-                        bg: bg,
-                        border: bd,
-                        selected: selected,
-                        onTap: () => onSelect(st, label),
-                      ),
-                    );
-                  }
-
-                  // Insere OK central
-                  final mid = chips.isEmpty ? 0 : (chips.length ~/ 2);
-                  chips.insert(
-                    mid,
-                    _pill(
-                      text: 'OK',
-                      bg: Colors.green.shade200,
-                      border: Colors.green.shade600,
-                      fg: Colors.green.shade900,
-                      selected: item.medicao == 'OK',
-                      onTap: () => onSelect(StatusMedida.ok, 'OK'),
-                    ),
-                  );
-
-                  return Wrap(spacing: 8, runSpacing: 8, children: chips);
-                },
-              ),
-            ],
-          ],
         ),
       ),
     );

--- a/lib/features/operador/presentation/troca_ferramenta_page.dart
+++ b/lib/features/operador/presentation/troca_ferramenta_page.dart
@@ -1,0 +1,525 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:http/http.dart' as http;
+
+import 'package:admin/features/operador/presentation/widgets/measurement_tile.dart';
+import 'package:admin/features/preparacao/data/models.dart';
+import 'package:admin/utils/string_utils.dart';
+
+class TrocaFerramentaPage extends StatefulWidget {
+  final String baseUrl;
+  final String re;
+  final String os;
+  final String partnumber;
+  final String operacao;
+  final String maquina;
+
+  const TrocaFerramentaPage({
+    super.key,
+    required this.baseUrl,
+    required this.re,
+    required this.os,
+    required this.partnumber,
+    required this.operacao,
+    required this.maquina,
+  });
+
+  @override
+  State<TrocaFerramentaPage> createState() => _TrocaFerramentaPageState();
+}
+
+class _TrocaFerramentaPageState extends State<TrocaFerramentaPage> {
+  late final TextEditingController _reController;
+  bool _loading = true;
+  String? _erro;
+  List<MedidaItem> _todas = [];
+  Set<int> _selecionadas = <int>{};
+  List<MedidaItem> _medidasSelecionadas = [];
+  bool _medindo = false;
+  bool _registrando = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _reController = TextEditingController(text: widget.re);
+    _carregarMedidas();
+  }
+
+  @override
+  void dispose() {
+    _reController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _carregarMedidas() async {
+    setState(() {
+      _loading = true;
+      _erro = null;
+    });
+
+    final uri = Uri.parse('${widget.baseUrl}/preparador/medidas').replace(
+      queryParameters: {
+        'partnumber': normalizeCode(widget.partnumber),
+        'operacao': normalizeCode(widget.operacao),
+      },
+    );
+
+    try {
+      final resp = await http.get(uri).timeout(const Duration(seconds: 20));
+      if (!mounted) return;
+
+      if (resp.statusCode == 200) {
+        final body = resp.body.isEmpty ? '[]' : resp.body;
+        final data = jsonDecode(body);
+        final itens = data is List
+            ? data
+                  .map<MedidaItem>(
+                    (e) =>
+                        MedidaItem.fromMap((e as Map).cast<String, dynamic>()),
+                  )
+                  .toList()
+            : <MedidaItem>[];
+        setState(() {
+          _todas = itens;
+          _selecionadas = <int>{};
+          _medidasSelecionadas = [];
+          _medindo = false;
+          _loading = false;
+        });
+      } else if (resp.statusCode == 404 || resp.statusCode == 204) {
+        setState(() {
+          _todas = [];
+          _selecionadas = <int>{};
+          _medidasSelecionadas = [];
+          _medindo = false;
+          _loading = false;
+        });
+      } else {
+        throw Exception('Falha ao carregar (${resp.statusCode}) ${resp.body}');
+      }
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _erro = e.toString();
+        _loading = false;
+      });
+    }
+  }
+
+  void _toggleSelecao(int index, bool? value) {
+    setState(() {
+      if (value == true) {
+        _selecionadas.add(index);
+      } else {
+        _selecionadas.remove(index);
+      }
+    });
+  }
+
+  void _avancarParaMedicao() {
+    if (_selecionadas.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Selecione ao menos uma medida.')),
+      );
+      return;
+    }
+
+    final ordenadas = _selecionadas.toList()..sort();
+    final selecionadas = ordenadas.map((idx) {
+      final item = _todas[idx];
+      return MedidaItem(
+        titulo: item.titulo,
+        faixaTexto: item.faixaTexto,
+        minimo: item.minimo,
+        maximo: item.maximo,
+        unidade: item.unidade,
+        status: StatusMedida.pendente,
+        medicao: null,
+        observacao: item.observacao,
+        periodicidade: item.periodicidade,
+        instrumento: item.instrumento,
+        tolerancias: item.tolerancias,
+      );
+    }).toList();
+
+    setState(() {
+      _medidasSelecionadas = selecionadas;
+      _medindo = true;
+    });
+  }
+
+  void _atualizarMedicao(int index, StatusMedida status, String? medicao) {
+    final itens = [..._medidasSelecionadas];
+    if (index < 0 || index >= itens.length) return;
+    final antigo = itens[index];
+    itens[index] = MedidaItem(
+      titulo: antigo.titulo,
+      faixaTexto: antigo.faixaTexto,
+      minimo: antigo.minimo,
+      maximo: antigo.maximo,
+      unidade: antigo.unidade,
+      status: status,
+      medicao: medicao,
+      observacao: antigo.observacao,
+      periodicidade: antigo.periodicidade,
+      instrumento: antigo.instrumento,
+      tolerancias: antigo.tolerancias,
+    );
+    setState(() {
+      _medidasSelecionadas = itens;
+    });
+  }
+
+  String _subtitleFor(MedidaItem item) {
+    if (item.faixaTexto.isNotEmpty) return item.faixaTexto;
+    final min = item.minimo;
+    final max = item.maximo;
+    final uni = (item.unidade ?? '').isNotEmpty ? ' ${item.unidade}' : '';
+    if (min != null && max != null) {
+      return '${min.toStringAsFixed(2)} – ${max.toStringAsFixed(2)}$uni';
+    }
+    if (min != null) {
+      return '≥ ${min.toStringAsFixed(2)}$uni';
+    }
+    if (max != null) {
+      return '≤ ${max.toStringAsFixed(2)}$uni';
+    }
+    return '';
+  }
+
+  String _observacaoComContexto(String? original) {
+    const marcador = 'Troca de ferramenta';
+    final atual = (original ?? '').trim();
+    if (atual.isEmpty) return marcador;
+    final lowerAtual = atual.toLowerCase();
+    if (lowerAtual.contains(marcador.toLowerCase())) return atual;
+    return '$marcador | $atual';
+  }
+
+  Future<void> _registrarMedicoes() async {
+    if (_registrando) return;
+    if (_medidasSelecionadas.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Nenhuma medida selecionada.')),
+      );
+      return;
+    }
+
+    final reAtual = _reController.text.trim();
+    if (reAtual.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Informe o R.E. de quem está medindo.')),
+      );
+      return;
+    }
+    if (int.tryParse(reAtual) == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('O R.E. deve conter apenas números.')),
+      );
+      return;
+    }
+
+    final pendentes = _medidasSelecionadas.where(
+      (m) =>
+          m.status == StatusMedida.pendente ||
+          (m.medicao == null || m.medicao!.trim().isEmpty),
+    );
+    if (pendentes.isNotEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Preencha todas as medições selecionadas.'),
+        ),
+      );
+      return;
+    }
+
+    final naoAprovadas = _medidasSelecionadas.where(
+      (m) => m.status != StatusMedida.ok,
+    );
+    if (naoAprovadas.isNotEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Todas as medições devem estar aprovadas.'),
+        ),
+      );
+      return;
+    }
+
+    final itens = <Map<String, dynamic>>[];
+    for (var i = 0; i < _medidasSelecionadas.length; i++) {
+      final m = _medidasSelecionadas[i];
+      itens.add({
+        'indice': i,
+        'titulo': m.titulo,
+        'faixaTexto': m.faixaTexto,
+        'min': m.minimo,
+        'max': m.maximo,
+        'unidade': m.unidade,
+        'medicao': m.medicao ?? '',
+        'status': statusToString(m.status),
+        'observacao': _observacaoComContexto(m.observacao),
+        'periodicidade': m.periodicidade ?? '',
+        'instrumento': m.instrumento ?? '',
+        'tolerancias': m.tolerancias,
+      });
+    }
+
+    final uri = Uri.parse('${widget.baseUrl}/preparador/resultado');
+    final body = jsonEncode({
+      're': reAtual,
+      'os': widget.os,
+      'partnumber': normalizeCode(widget.partnumber),
+      'operacao': normalizeCode(widget.operacao),
+      'maquina': widget.maquina,
+      'contexto': 'troca_ferramenta',
+      'itens': itens,
+    });
+
+    setState(() => _registrando = true);
+    try {
+      final resp = await http
+          .post(uri, headers: {'Content-Type': 'application/json'}, body: body)
+          .timeout(const Duration(seconds: 25));
+
+      if (!mounted) return;
+
+      if (resp.statusCode == 200) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Medições registradas com sucesso.')),
+        );
+        Navigator.of(context).pop(true);
+      } else if (resp.statusCode == 409) {
+        final data = jsonDecode(resp.body);
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              data['error']?.toString() ?? 'Conflito ao registrar medições.',
+            ),
+          ),
+        );
+      } else {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              'Falha ao registrar: ${resp.statusCode} ${resp.body}',
+            ),
+          ),
+        );
+      }
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('Erro ao registrar: $e')));
+    } finally {
+      if (mounted) {
+        setState(() => _registrando = false);
+      }
+    }
+  }
+
+  void _onBack() {
+    if (_medindo) {
+      setState(() {
+        _medindo = false;
+        _medidasSelecionadas = [];
+      });
+    } else {
+      Navigator.of(context).pop(false);
+    }
+  }
+
+  Widget _buildEditableReChip() {
+    final theme = Theme.of(context);
+    return SizedBox(
+      width: 160,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('R.E.', style: theme.textTheme.labelSmall),
+          const SizedBox(height: 4),
+          TextField(
+            controller: _reController,
+            keyboardType: TextInputType.number,
+            inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+            decoration: const InputDecoration(
+              hintText: 'Informe o R.E.',
+              border: OutlineInputBorder(),
+              isDense: true,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildInfoChip(String label, String value) {
+    final theme = Theme.of(context);
+    return SizedBox(
+      width: 160,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(label, style: theme.textTheme.labelSmall),
+          const SizedBox(height: 4),
+          Text(value.isEmpty ? '-' : value, style: theme.textTheme.titleMedium),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return WillPopScope(
+      onWillPop: () async {
+        if (_medindo) {
+          _onBack();
+          return false;
+        }
+        return true;
+      },
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Troca de ferramenta'),
+          leading: IconButton(
+            icon: const Icon(Icons.arrow_back),
+            onPressed: _onBack,
+          ),
+        ),
+        body: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: _loading
+              ? const Center(child: CircularProgressIndicator())
+              : _erro != null
+              ? Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Text(
+                      'Erro ao carregar medidas:\n${_erro!}',
+                      textAlign: TextAlign.center,
+                    ),
+                    const SizedBox(height: 12),
+                    FilledButton.icon(
+                      onPressed: _carregarMedidas,
+                      icon: const Icon(Icons.refresh),
+                      label: const Text('Tentar novamente'),
+                    ),
+                  ],
+                )
+              : Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Card(
+                      margin: EdgeInsets.zero,
+                      child: Padding(
+                        padding: const EdgeInsets.all(16.0),
+                        child: Wrap(
+                          spacing: 24,
+                          runSpacing: 12,
+                          children: [
+                            _buildEditableReChip(),
+                            _buildInfoChip('O.S.', widget.os),
+                            _buildInfoChip('Peça', widget.partnumber),
+                            _buildInfoChip('Operação', widget.operacao),
+                            _buildInfoChip('Máquina', widget.maquina),
+                          ],
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+                    if (!_medindo) ...[
+                      Text(
+                        'Selecione as medidas impactadas pela troca da ferramenta.',
+                        style: Theme.of(context).textTheme.titleMedium,
+                      ),
+                      const SizedBox(height: 12),
+                      Expanded(
+                        child: _todas.isEmpty
+                            ? const Center(
+                                child: Text('Nenhuma medida disponível.'),
+                              )
+                            : ListView.separated(
+                                itemCount: _todas.length,
+                                separatorBuilder: (_, __) =>
+                                    const Divider(height: 1),
+                                itemBuilder: (context, index) {
+                                  final item = _todas[index];
+                                  final selecionado = _selecionadas.contains(
+                                    index,
+                                  );
+                                  final subtitulo = _subtitleFor(item);
+                                  return CheckboxListTile(
+                                    value: selecionado,
+                                    onChanged: (value) =>
+                                        _toggleSelecao(index, value),
+                                    title: Text(
+                                      item.titulo.isEmpty
+                                          ? '(sem título)'
+                                          : item.titulo,
+                                    ),
+                                    subtitle: subtitulo.isEmpty
+                                        ? null
+                                        : Text(subtitulo),
+                                  );
+                                },
+                              ),
+                      ),
+                      const SizedBox(height: 12),
+                      Align(
+                        alignment: Alignment.centerRight,
+                        child: FilledButton.icon(
+                          onPressed: _selecionadas.isEmpty
+                              ? null
+                              : _avancarParaMedicao,
+                          icon: const Icon(Icons.playlist_add_check),
+                          label: const Text('Prosseguir para medição (FOR07)'),
+                        ),
+                      ),
+                    ] else ...[
+                      Text(
+                        'Realize as medições selecionadas (FOR07).',
+                        style: Theme.of(context).textTheme.titleMedium,
+                      ),
+                      const SizedBox(height: 12),
+                      Expanded(
+                        child: ListView.builder(
+                          itemCount: _medidasSelecionadas.length,
+                          itemBuilder: (context, index) {
+                            final item = _medidasSelecionadas[index];
+                            return MeasurementTile(
+                              index: index,
+                              item: item,
+                              manualEntry: true,
+                              onSelect: (status, medicao) =>
+                                  _atualizarMedicao(index, status, medicao),
+                            );
+                          },
+                        ),
+                      ),
+                      const SizedBox(height: 12),
+                      Align(
+                        alignment: Alignment.centerRight,
+                        child: FilledButton.icon(
+                          onPressed: _registrando ? null : _registrarMedicoes,
+                          icon: _registrando
+                              ? const SizedBox(
+                                  width: 18,
+                                  height: 18,
+                                  child: CircularProgressIndicator(
+                                    strokeWidth: 2,
+                                  ),
+                                )
+                              : const Icon(Icons.save_outlined),
+                          label: const Text('Registrar medições'),
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/operador/presentation/widgets/measurement_tile.dart
+++ b/lib/features/operador/presentation/widgets/measurement_tile.dart
@@ -1,0 +1,537 @@
+import 'package:flutter/material.dart';
+
+import 'package:admin/features/preparacao/data/models.dart';
+
+class MeasurementTile extends StatefulWidget {
+  final int index;
+  final MedidaItem item;
+  final void Function(StatusMedida status, String? medicao) onSelect;
+  final bool manualEntry;
+
+  const MeasurementTile({
+    super.key,
+    required this.index,
+    required this.item,
+    required this.onSelect,
+    this.manualEntry = false,
+  });
+
+  @override
+  State<MeasurementTile> createState() => _MeasurementTileState();
+}
+
+class _MeasurementTileState extends State<MeasurementTile> {
+  TextEditingController? _manualCtrl;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.manualEntry) {
+      _manualCtrl = TextEditingController(text: widget.item.medicao ?? '');
+    }
+  }
+
+  @override
+  void didUpdateWidget(covariant MeasurementTile oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.manualEntry) {
+      _manualCtrl ??= TextEditingController();
+      final newText = widget.item.medicao ?? '';
+      if (oldWidget.item.medicao != widget.item.medicao &&
+          _manualCtrl!.text != newText) {
+        _manualCtrl!.value = TextEditingValue(
+          text: newText,
+          selection: TextSelection.collapsed(offset: newText.length),
+          composing: TextRange.empty,
+        );
+      }
+    } else if (_manualCtrl != null) {
+      _manualCtrl!.dispose();
+      _manualCtrl = null;
+    }
+  }
+
+  @override
+  void dispose() {
+    _manualCtrl?.dispose();
+    super.dispose();
+  }
+
+  String _norm(String? s) => (s ?? '').trim();
+
+  String _nfd(String s) {
+    const rep = {
+      'á': 'a',
+      'à': 'a',
+      'ã': 'a',
+      'â': 'a',
+      'é': 'e',
+      'ê': 'e',
+      'í': 'i',
+      'ó': 'o',
+      'ô': 'o',
+      'õ': 'o',
+      'ú': 'u',
+      'ç': 'c',
+      'Á': 'A',
+      'À': 'A',
+      'Ã': 'A',
+      'Â': 'A',
+      'É': 'E',
+      'Ê': 'E',
+      'Í': 'I',
+      'Ó': 'O',
+      'Ô': 'O',
+      'Õ': 'O',
+      'Ú': 'U',
+      'Ç': 'C',
+    };
+    var t = s;
+    rep.forEach((k, v) => t = t.replaceAll(k, v));
+    return t;
+  }
+
+  bool _containsAny(String hay, List<String> needles) {
+    final h = _nfd(hay.toLowerCase());
+    return needles.any((n) => h.contains(_nfd(n.toLowerCase())));
+  }
+
+  bool _isVisualRugParalelismoOrAfins(MedidaItem item) {
+    final t = _norm(item.titulo);
+    final inst = _norm(item.instrumento);
+    return _containsAny(t, [
+          'visual',
+          'rug',
+          'paralelismo',
+          'anel de rosca passa',
+          'cqf',
+          'simetria',
+          'concentricidade',
+        ]) ||
+        _containsAny(inst, [
+          'visual',
+          'rug',
+          'rugosimetro',
+          'paralelismo',
+          'anel de rosca passa',
+          'cqf',
+          'simetria',
+        ]);
+  }
+
+  bool _isTampao(MedidaItem item) {
+    final t = _norm(item.titulo);
+    final inst = _norm(item.instrumento);
+    return _containsAny(t, ['tamp', 'tampao', 'tampão', 'tampa']) ||
+        _containsAny(inst, ['tamp', 'tampao', 'tampão', 'tampa']);
+  }
+
+  Set<String> _partsFromMedicao(String? medicao) => (medicao ?? '')
+      .split('|')
+      .map((s) => s.trim())
+      .where((s) => s.isNotEmpty)
+      .toSet();
+
+  String _joinParts(Set<String> parts) => parts.join(' | ');
+
+  StatusMedida _statusFromParts(Set<String> parts) {
+    final hasPassa = parts.any((p) => p.startsWith('Lado passa'));
+    final hasNaoPassa = parts.any((p) => p.startsWith('Lado não passa'));
+    if (hasPassa && hasNaoPassa) {
+      final passaReprovado = parts.contains('Lado passa — Reprovado');
+      final naoPassaReprovado = parts.contains('Lado não passa — Reprovado');
+      if (passaReprovado && naoPassaReprovado) {
+        return StatusMedida.reprovadaAcima;
+      }
+      if (passaReprovado) return StatusMedida.reprovadaAbaixo;
+      if (naoPassaReprovado) return StatusMedida.reprovadaAcima;
+      return StatusMedida.ok;
+    }
+    return StatusMedida.pendente;
+  }
+
+  double? _toDoubleNum(dynamic v) {
+    if (v == null) return null;
+    if (v is num) return v.toDouble();
+    return double.tryParse(v.toString().replaceAll(',', '.').trim());
+  }
+
+  Color _fgOn(Color bg) =>
+      ThemeData.estimateBrightnessForColor(bg) == Brightness.dark
+      ? Colors.white
+      : Colors.black87;
+
+  Widget _pill({
+    required String text,
+    required Color bg,
+    required Color border,
+    bool selected = false,
+    Color? fg,
+    VoidCallback? onTap,
+  }) {
+    final fgColor = fg ?? _fgOn(bg);
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(999),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+        decoration: BoxDecoration(
+          color: bg,
+          borderRadius: BorderRadius.circular(999),
+          border: Border.all(
+            color: selected ? border.withValues(alpha: 0.9) : border,
+            width: selected ? 2 : 1,
+          ),
+        ),
+        child: Text(
+          text,
+          style: TextStyle(fontWeight: FontWeight.w600, color: fgColor),
+        ),
+      ),
+    );
+  }
+
+  String _subtitleFor(MedidaItem item) {
+    if (item.faixaTexto.isNotEmpty) return item.faixaTexto;
+    final min = item.minimo;
+    final max = item.maximo;
+    final uni = (item.unidade ?? '').isNotEmpty ? ' ${item.unidade}' : '';
+    if (min != null && max != null) {
+      return '${min.toStringAsFixed(2)} – ${max.toStringAsFixed(2)}$uni';
+    }
+    if (min != null) {
+      return '≥ ${min.toStringAsFixed(2)}$uni';
+    }
+    if (max != null) {
+      return '≤ ${max.toStringAsFixed(2)}$uni';
+    }
+    return '';
+  }
+
+  double? _parseManualValue(String txt) {
+    final normalized = txt.replaceAll(',', '.').trim();
+    if (normalized.isEmpty) return null;
+    return double.tryParse(normalized);
+  }
+
+  Color _statusColor(StatusMedida st) {
+    switch (st) {
+      case StatusMedida.ok:
+        return Colors.green.shade600;
+      case StatusMedida.reprovadaAbaixo:
+      case StatusMedida.reprovadaAcima:
+        return Colors.red.shade400;
+      case StatusMedida.alertaAbaixo:
+      case StatusMedida.alertaAcima:
+        return Colors.amber.shade700;
+      case StatusMedida.pendente:
+        return Colors.grey;
+    }
+  }
+
+  String _statusHelper(StatusMedida st) {
+    switch (st) {
+      case StatusMedida.ok:
+        return 'Dentro da tolerância';
+      case StatusMedida.reprovadaAbaixo:
+        return 'Abaixo do mínimo';
+      case StatusMedida.reprovadaAcima:
+        return 'Acima do máximo';
+      case StatusMedida.alertaAbaixo:
+      case StatusMedida.alertaAcima:
+        return 'Fora da faixa ideal';
+      case StatusMedida.pendente:
+        return 'Preencha o valor para classificar';
+    }
+  }
+
+  Widget _buildManualEntry(BuildContext context) {
+    final item = widget.item;
+    final ctrl = _manualCtrl ??= TextEditingController(
+      text: item.medicao ?? '',
+    );
+    final valor = _parseManualValue(ctrl.text);
+    final status = item.avaliarStatus(valor);
+    final theme = Theme.of(context);
+    final subtitulo = _subtitleFor(item);
+    final unidadeLabel = (item.unidade ?? '').isNotEmpty
+        ? ' (${item.unidade})'
+        : '';
+    final helper = _statusHelper(status);
+    final helperColor = _statusColor(status);
+
+    return Card(
+      elevation: 0.5,
+      child: Padding(
+        padding: const EdgeInsets.all(12.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Container(
+                  width: 10,
+                  height: 10,
+                  decoration: BoxDecoration(
+                    color: helperColor,
+                    shape: BoxShape.circle,
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    item.titulo.isEmpty ? '(sem título)' : item.titulo,
+                    style: theme.textTheme.titleMedium,
+                  ),
+                ),
+              ],
+            ),
+            if (subtitulo.isNotEmpty) ...[
+              const SizedBox(height: 4),
+              Text(subtitulo, style: theme.textTheme.bodyMedium),
+            ],
+            if ((item.periodicidade ?? '').isNotEmpty) ...[
+              const SizedBox(height: 4),
+              Text(
+                'Periodicidade: ${item.periodicidade}',
+                style: theme.textTheme.bodyMedium,
+              ),
+            ],
+            if ((item.instrumento ?? '').isNotEmpty) ...[
+              const SizedBox(height: 2),
+              Text(
+                'Instrumento: ${item.instrumento}',
+                style: theme.textTheme.bodyMedium,
+              ),
+            ],
+            const SizedBox(height: 10),
+            TextField(
+              controller: ctrl,
+              keyboardType: const TextInputType.numberWithOptions(
+                decimal: true,
+                signed: false,
+              ),
+              decoration: InputDecoration(
+                labelText: 'Medição$unidadeLabel',
+                border: const OutlineInputBorder(),
+                helperText: helper,
+                helperStyle: TextStyle(color: helperColor),
+              ),
+              onChanged: (txt) {
+                final v = _parseManualValue(txt);
+                final novoStatus = item.avaliarStatus(v);
+                widget.onSelect(novoStatus, txt);
+                setState(() {});
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildAutomaticEntry(BuildContext context) {
+    final item = widget.item;
+    final styleLabel = Theme.of(context).textTheme.titleMedium;
+    final styleSpec = Theme.of(context).textTheme.bodyMedium;
+
+    final subtitulo = _subtitleFor(item);
+    final tolerancias = item.tolerancias;
+
+    return Card(
+      elevation: 0.5,
+      child: Padding(
+        padding: const EdgeInsets.all(12.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              item.titulo.isEmpty ? '(sem título)' : item.titulo,
+              style: styleLabel,
+            ),
+            if (subtitulo.isNotEmpty) ...[
+              const SizedBox(height: 4),
+              Text(subtitulo, style: styleSpec),
+            ],
+            if ((item.periodicidade ?? '').isNotEmpty) ...[
+              const SizedBox(height: 4),
+              Text('Periodicidade: ${item.periodicidade}', style: styleSpec),
+            ],
+            if ((item.instrumento ?? '').isNotEmpty) ...[
+              const SizedBox(height: 2),
+              Text('Instrumento: ${item.instrumento}', style: styleSpec),
+            ],
+            const SizedBox(height: 10),
+            if (_isVisualRugParalelismoOrAfins(item)) ...[
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: [
+                  _pill(
+                    text: 'Aprovado',
+                    bg: Colors.green.shade200,
+                    border: Colors.green.shade600,
+                    fg: Colors.green.shade900,
+                    selected: item.medicao == 'Aprovado',
+                    onTap: () => widget.onSelect(StatusMedida.ok, 'Aprovado'),
+                  ),
+                  _pill(
+                    text: 'Reprovado',
+                    bg: Colors.red.shade100,
+                    border: Colors.red.shade400,
+                    selected: item.medicao == 'Reprovado',
+                    onTap: () => widget.onSelect(
+                      StatusMedida.reprovadaAcima,
+                      'Reprovado',
+                    ),
+                  ),
+                ],
+              ),
+            ] else if (_isTampao(item)) ...[
+              Builder(
+                builder: (context) {
+                  final parts = _partsFromMedicao(item.medicao);
+                  return Wrap(
+                    spacing: 8,
+                    runSpacing: 8,
+                    children: [
+                      _pill(
+                        text: 'Lado passa — Aprovado',
+                        bg: Colors.green.shade200,
+                        border: Colors.green.shade600,
+                        fg: Colors.green.shade900,
+                        selected: parts.contains('Lado passa — Aprovado'),
+                        onTap: () {
+                          final p = _partsFromMedicao(item.medicao);
+                          p.removeWhere((e) => e.startsWith('Lado passa'));
+                          p.add('Lado passa — Aprovado');
+                          widget.onSelect(_statusFromParts(p), _joinParts(p));
+                        },
+                      ),
+                      _pill(
+                        text: 'Lado passa — Reprovado',
+                        bg: Colors.red.shade100,
+                        border: Colors.red.shade400,
+                        selected: parts.contains('Lado passa — Reprovado'),
+                        onTap: () {
+                          final p = _partsFromMedicao(item.medicao);
+                          p.removeWhere((e) => e.startsWith('Lado passa'));
+                          p.add('Lado passa — Reprovado');
+                          widget.onSelect(_statusFromParts(p), _joinParts(p));
+                        },
+                      ),
+                      _pill(
+                        text: 'Lado não passa — Aprovado',
+                        bg: Colors.green.shade200,
+                        border: Colors.green.shade600,
+                        fg: Colors.green.shade900,
+                        selected: parts.contains('Lado não passa — Aprovado'),
+                        onTap: () {
+                          final p = _partsFromMedicao(item.medicao);
+                          p.removeWhere((e) => e.startsWith('Lado não passa'));
+                          p.add('Lado não passa — Aprovado');
+                          widget.onSelect(_statusFromParts(p), _joinParts(p));
+                        },
+                      ),
+                      _pill(
+                        text: 'Lado não passa — Reprovado',
+                        bg: Colors.red.shade100,
+                        border: Colors.red.shade400,
+                        selected: parts.contains('Lado não passa — Reprovado'),
+                        onTap: () {
+                          final p = _partsFromMedicao(item.medicao);
+                          p.removeWhere((e) => e.startsWith('Lado não passa'));
+                          p.add('Lado não passa — Reprovado');
+                          widget.onSelect(_statusFromParts(p), _joinParts(p));
+                        },
+                      ),
+                    ],
+                  );
+                },
+              ),
+            ] else ...[
+              Builder(
+                builder: (context) {
+                  final chips = <Widget>[];
+
+                  for (var i = 0; i < tolerancias.length; i++) {
+                    final raw = tolerancias[i];
+                    final d = _toDoubleNum(raw);
+
+                    StatusMedida st;
+                    Color bg;
+                    Color bd;
+                    switch (i) {
+                      case 0:
+                        st = StatusMedida.reprovadaAbaixo;
+                        bg = Colors.red.shade100;
+                        bd = Colors.red.shade400;
+                        break;
+                      case 1:
+                        st = StatusMedida.alertaAbaixo;
+                        bg = Colors.amber.shade100;
+                        bd = Colors.amber.shade400;
+                        break;
+                      case 2:
+                        st = StatusMedida.alertaAcima;
+                        bg = Colors.amber.shade100;
+                        bd = Colors.amber.shade400;
+                        break;
+                      case 3:
+                        st = StatusMedida.reprovadaAcima;
+                        bg = Colors.red.shade100;
+                        bd = Colors.red.shade400;
+                        break;
+                      default:
+                        st = StatusMedida.alertaAbaixo;
+                        bg = Colors.amber.shade100;
+                        bd = Colors.amber.shade400;
+                    }
+
+                    final label = d != null
+                        ? d.toStringAsFixed(2)
+                        : raw.toString();
+                    final selected = item.medicao == label;
+
+                    chips.add(
+                      _pill(
+                        text: label,
+                        bg: bg,
+                        border: bd,
+                        selected: selected,
+                        onTap: () => widget.onSelect(st, label),
+                      ),
+                    );
+                  }
+
+                  final mid = chips.isEmpty ? 0 : (chips.length ~/ 2);
+                  chips.insert(
+                    mid,
+                    _pill(
+                      text: 'OK',
+                      bg: Colors.green.shade200,
+                      border: Colors.green.shade600,
+                      fg: Colors.green.shade900,
+                      selected: item.medicao == 'OK',
+                      onTap: () => widget.onSelect(StatusMedida.ok, 'OK'),
+                    ),
+                  );
+
+                  return Wrap(spacing: 8, runSpacing: 8, children: chips);
+                },
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.manualEntry) {
+      return _buildManualEntry(context);
+    }
+    return _buildAutomaticEntry(context);
+  }
+}


### PR DESCRIPTION
## Summary
- allow editing the R.E. on the tool change screen, require numeric validation, and capture the selected measures with manual entry just like the preparer flow
- flag tool change submissions with contextual observations and send the necessary metadata so the backend can register both FOR07 and FOR09 records
- update the backend to block concurrent OS on the same machine, permit repeated registrations for the same OS when marked as tool changes, and mirror the measurements into operador_amostragem

## Testing
- flutter test

------
https://chatgpt.com/codex/tasks/task_e_68cd7271f65483319e6273128655a2a9