### PR TITLE
Persist search criteria across workflow pages and improve selection highlight

### DIFF
--- a/lib/features/finalizar_os/presentation/finalizar_os_page.dart
+++ b/lib/features/finalizar_os/presentation/finalizar_os_page.dart
@@ -14,6 +14,7 @@ import 'package:admin/widgets/window_bar.dart';
 import 'package:admin/utils/string_utils.dart';
 import 'package:admin/services/machine_service.dart';
 import 'package:admin/models/machine.dart';
+import 'package:admin/features/shared/providers/search_flow_form_provider.dart';
 
 /// Mesmo base URL usado no Operador
 const String kBaseUrl = 'http://192.168.0.241:5005';
@@ -132,6 +133,10 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
   bool _registrando = false;
   bool _osFinalizada = false;
 
+  late final VoidCallback _osSyncListener;
+  late final VoidCallback _partSyncListener;
+  late final VoidCallback _opSyncListener;
+
   void _resetFinalizada() {
     if (_osFinalizada) setState(() => _osFinalizada = false);
   }
@@ -139,9 +144,29 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
   @override
   void initState() {
     super.initState();
+    final shared = ref.read(sharedSearchFormProvider);
+    _osCtrl.text = shared.os;
+    _partCtrl.text = shared.partNumber;
+    _opCtrl.text = shared.operacao;
+    _categoriaSel = shared.categoria;
+    _maquinaSel = shared.maquina;
+
+    _osSyncListener = () {
+      ref.read(sharedSearchFormProvider.notifier).setOs(_osCtrl.text);
+    };
+    _partSyncListener = () {
+      ref.read(sharedSearchFormProvider.notifier).setPartNumber(_partCtrl.text);
+    };
+    _opSyncListener = () {
+      ref.read(sharedSearchFormProvider.notifier).setOperacao(_opCtrl.text);
+    };
+
     _osCtrl.addListener(_resetFinalizada);
     _partCtrl.addListener(_resetFinalizada);
     _opCtrl.addListener(_resetFinalizada);
+    _osCtrl.addListener(_osSyncListener);
+    _partCtrl.addListener(_partSyncListener);
+    _opCtrl.addListener(_opSyncListener);
     _carregarMaquinas();
   }
 
@@ -150,10 +175,33 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
       final list = await MachineService().fetchMaquinas();
       if (mounted) {
         setState(() {
-          _maquinas.addAll(list);
-          _categorias.addAll(
-            _maquinas.map((e) => e.categoria).toSet().toList()..sort(),
-          );
+          _maquinas
+            ..clear()
+            ..addAll(list);
+          _categorias
+            ..clear()
+            ..addAll(
+              _maquinas.map((e) => e.categoria).toSet().toList()..sort(),
+            );
+          final notifier = ref.read(sharedSearchFormProvider.notifier);
+          final categoriaAtual = _categoriaSel;
+          if (categoriaAtual != null && !_categorias.contains(categoriaAtual)) {
+            _categoriaSel = null;
+            notifier.setCategoria(null);
+          }
+
+          if (_categoriaSel != null) {
+            final possuiMaquina = _maquinas.any(
+              (m) => m.categoria == _categoriaSel && m.codigo == _maquinaSel,
+            );
+            if (!possuiMaquina && _maquinaSel != null) {
+              _maquinaSel = null;
+              notifier.setMaquina(null);
+            }
+          } else if (_maquinaSel != null) {
+            _maquinaSel = null;
+            notifier.setMaquina(null);
+          }
         });
       }
     } catch (e) {
@@ -165,11 +213,23 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
     }
   }
 
+  bool _maquinaSelecionadaValida() {
+    final categoria = _categoriaSel;
+    final maquina = _maquinaSel;
+    if (categoria == null || maquina == null) return false;
+    return _maquinas.any(
+      (m) => m.categoria == categoria && m.codigo == maquina,
+    );
+  }
+
   @override
   void dispose() {
     _osCtrl.removeListener(_resetFinalizada);
     _partCtrl.removeListener(_resetFinalizada);
     _opCtrl.removeListener(_resetFinalizada);
+    _osCtrl.removeListener(_osSyncListener);
+    _partCtrl.removeListener(_partSyncListener);
+    _opCtrl.removeListener(_opSyncListener);
     _reCtrl.dispose();
     _osCtrl.dispose();
     _partCtrl.dispose();
@@ -200,7 +260,7 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
     // Valida RE / OS / Máquina
     if (_reCtrl.text.trim().isEmpty ||
         _osCtrl.text.trim().isEmpty ||
-        (_maquinaSel ?? '').isEmpty) {
+        !_maquinaSelecionadaValida()) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(
@@ -330,7 +390,19 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
     // Pode registrar quando: RE e OS preenchidos + todas as medições preenchidas
     final reOk = _reCtrl.text.trim().isNotEmpty;
     final osOk = _osCtrl.text.trim().isNotEmpty;
-    final maquinaOk = (_maquinaSel ?? '').isNotEmpty;
+    final categoriaValue =
+        (_categoriaSel != null && _categorias.contains(_categoriaSel))
+        ? _categoriaSel
+        : null;
+    final maquinasDisponiveis = _maquinas
+        .where((m) => m.categoria == categoriaValue)
+        .toList();
+    final maquinaValue =
+        (_maquinaSel != null &&
+            maquinasDisponiveis.any((m) => m.codigo == _maquinaSel))
+        ? _maquinaSel
+        : null;
+    final maquinaOk = (maquinaValue ?? '').isNotEmpty;
     final todasOk =
         medidas.isNotEmpty &&
         medidas.every(
@@ -425,7 +497,7 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
                       children: [
                         Expanded(
                           child: DropdownButtonFormField<String>(
-                            value: _categoriaSel,
+                            value: categoriaValue,
                             decoration: const InputDecoration(
                               labelText: 'Categoria',
                               border: OutlineInputBorder(),
@@ -438,10 +510,15 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
                                   ),
                                 )
                                 .toList(),
-                            onChanged: (v) => setState(() {
-                              _categoriaSel = v;
-                              _maquinaSel = null;
-                            }),
+                            onChanged: (v) {
+                              ref
+                                  .read(sharedSearchFormProvider.notifier)
+                                  .setCategoria(v);
+                              setState(() {
+                                _categoriaSel = v;
+                                _maquinaSel = null;
+                              });
+                            },
                             validator: (v) =>
                                 (v == null || v.isEmpty) ? 'Obrigatório' : null,
                           ),
@@ -449,13 +526,12 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
                         const SizedBox(width: 12),
                         Expanded(
                           child: DropdownButtonFormField<String>(
-                            value: _maquinaSel,
+                            value: maquinaValue,
                             decoration: const InputDecoration(
                               labelText: 'Código da máquina',
                               border: OutlineInputBorder(),
                             ),
-                            items: _maquinas
-                                .where((m) => m.categoria == _categoriaSel)
+                            items: maquinasDisponiveis
                                 .map(
                                   (m) => DropdownMenuItem(
                                     value: m.codigo,
@@ -463,7 +539,12 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
                                   ),
                                 )
                                 .toList(),
-                            onChanged: (v) => setState(() => _maquinaSel = v),
+                            onChanged: (v) {
+                              ref
+                                  .read(sharedSearchFormProvider.notifier)
+                                  .setMaquina(v);
+                              setState(() => _maquinaSel = v);
+                            },
                             validator: (v) =>
                                 (v == null || v.isEmpty) ? 'Obrigatório' : null,
                           ),

--- a/lib/features/operador/presentation/operador_page.dart
+++ b/lib/features/operador/presentation/operador_page.dart
@@ -16,6 +16,7 @@ import 'package:admin/widgets/window_bar.dart';
 import 'package:admin/utils/string_utils.dart';
 import 'package:admin/services/machine_service.dart';
 import 'package:admin/models/machine.dart';
+import 'package:admin/features/shared/providers/search_flow_form_provider.dart';
 
 /// >>>>> Ajuste para o endereço/porta do seu Flask <<<<<
 const String kBaseUrl = 'http://192.168.0.241:5005';
@@ -115,9 +116,33 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
 
   bool _registrando = false;
 
+  late final VoidCallback _osSyncListener;
+  late final VoidCallback _partSyncListener;
+  late final VoidCallback _opSyncListener;
+
   @override
   void initState() {
     super.initState();
+    final shared = ref.read(sharedSearchFormProvider);
+    _osCtrl.text = shared.os;
+    _partCtrl.text = shared.partNumber;
+    _opCtrl.text = shared.operacao;
+    _categoriaSel = shared.categoria;
+    _maquinaSel = shared.maquina;
+
+    _osSyncListener = () {
+      ref.read(sharedSearchFormProvider.notifier).setOs(_osCtrl.text);
+    };
+    _partSyncListener = () {
+      ref.read(sharedSearchFormProvider.notifier).setPartNumber(_partCtrl.text);
+    };
+    _opSyncListener = () {
+      ref.read(sharedSearchFormProvider.notifier).setOperacao(_opCtrl.text);
+    };
+
+    _osCtrl.addListener(_osSyncListener);
+    _partCtrl.addListener(_partSyncListener);
+    _opCtrl.addListener(_opSyncListener);
     _carregarMaquinas();
   }
 
@@ -126,10 +151,33 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
       final list = await MachineService().fetchMaquinas();
       if (mounted) {
         setState(() {
-          _maquinas.addAll(list);
-          _categorias.addAll(
-            _maquinas.map((e) => e.categoria).toSet().toList()..sort(),
-          );
+          _maquinas
+            ..clear()
+            ..addAll(list);
+          _categorias
+            ..clear()
+            ..addAll(
+              _maquinas.map((e) => e.categoria).toSet().toList()..sort(),
+            );
+          final notifier = ref.read(sharedSearchFormProvider.notifier);
+          final categoriaAtual = _categoriaSel;
+          if (categoriaAtual != null && !_categorias.contains(categoriaAtual)) {
+            _categoriaSel = null;
+            notifier.setCategoria(null);
+          }
+
+          if (_categoriaSel != null) {
+            final possuiMaquina = _maquinas.any(
+              (m) => m.categoria == _categoriaSel && m.codigo == _maquinaSel,
+            );
+            if (!possuiMaquina && _maquinaSel != null) {
+              _maquinaSel = null;
+              notifier.setMaquina(null);
+            }
+          } else if (_maquinaSel != null) {
+            _maquinaSel = null;
+            notifier.setMaquina(null);
+          }
         });
       }
     } catch (e) {
@@ -141,8 +189,20 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
     }
   }
 
+  bool _maquinaSelecionadaValida() {
+    final categoria = _categoriaSel;
+    final maquina = _maquinaSel;
+    if (categoria == null || maquina == null) return false;
+    return _maquinas.any(
+      (m) => m.categoria == categoria && m.codigo == maquina,
+    );
+  }
+
   @override
   void dispose() {
+    _osCtrl.removeListener(_osSyncListener);
+    _partCtrl.removeListener(_partSyncListener);
+    _opCtrl.removeListener(_opSyncListener);
     _reCtrl.dispose();
     _osCtrl.dispose();
     _partCtrl.dispose();
@@ -156,7 +216,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
     // Valida RE/OS/Máquina
     if (_reCtrl.text.trim().isEmpty ||
         _osCtrl.text.trim().isEmpty ||
-        (_maquinaSel ?? '').isEmpty) {
+        !_maquinaSelecionadaValida()) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(
@@ -387,13 +447,14 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
       final os = _osCtrl.text.trim();
       final part = _partCtrl.text.trim();
       final operacao = _opCtrl.text.trim();
-      final maquina = (_maquinaSel ?? '').trim();
+      final maquinaValida = _maquinaSelecionadaValida();
+      final maquina = maquinaValida ? (_maquinaSel ?? '').trim() : '';
 
       if (re.isEmpty ||
           os.isEmpty ||
           part.isEmpty ||
           operacao.isEmpty ||
-          maquina.isEmpty) {
+          !maquinaValida) {
         if (!mounted) return;
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(
@@ -489,7 +550,19 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
     final medidas = medidasAsync.value ?? [];
     final reOk = _reCtrl.text.trim().isNotEmpty;
     final osOk = _osCtrl.text.trim().isNotEmpty;
-    final maquinaOk = (_maquinaSel ?? '').isNotEmpty;
+    final categoriaValue =
+        (_categoriaSel != null && _categorias.contains(_categoriaSel))
+        ? _categoriaSel
+        : null;
+    final maquinasDisponiveis = _maquinas
+        .where((m) => m.categoria == categoriaValue)
+        .toList();
+    final maquinaValue =
+        (_maquinaSel != null &&
+            maquinasDisponiveis.any((m) => m.codigo == _maquinaSel))
+        ? _maquinaSel
+        : null;
+    final maquinaOk = (maquinaValue ?? '').isNotEmpty;
 
     // todas respondidas?
     final todasRespondidas =
@@ -587,7 +660,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                       children: [
                         Expanded(
                           child: DropdownButtonFormField<String>(
-                            value: _categoriaSel,
+                            value: categoriaValue,
                             decoration: const InputDecoration(
                               labelText: 'Categoria',
                               border: OutlineInputBorder(),
@@ -600,10 +673,15 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                                   ),
                                 )
                                 .toList(),
-                            onChanged: (v) => setState(() {
-                              _categoriaSel = v;
-                              _maquinaSel = null;
-                            }),
+                            onChanged: (v) {
+                              ref
+                                  .read(sharedSearchFormProvider.notifier)
+                                  .setCategoria(v);
+                              setState(() {
+                                _categoriaSel = v;
+                                _maquinaSel = null;
+                              });
+                            },
                             validator: (v) =>
                                 (v == null || v.isEmpty) ? 'Obrigatório' : null,
                           ),
@@ -611,13 +689,12 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                         const SizedBox(width: 12),
                         Expanded(
                           child: DropdownButtonFormField<String>(
-                            value: _maquinaSel,
+                            value: maquinaValue,
                             decoration: const InputDecoration(
                               labelText: 'Código da máquina',
                               border: OutlineInputBorder(),
                             ),
-                            items: _maquinas
-                                .where((m) => m.categoria == _categoriaSel)
+                            items: maquinasDisponiveis
                                 .map(
                                   (m) => DropdownMenuItem(
                                     value: m.codigo,
@@ -625,7 +702,12 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                                   ),
                                 )
                                 .toList(),
-                            onChanged: (v) => setState(() => _maquinaSel = v),
+                            onChanged: (v) {
+                              ref
+                                  .read(sharedSearchFormProvider.notifier)
+                                  .setMaquina(v);
+                              setState(() => _maquinaSel = v);
+                            },
                             validator: (v) =>
                                 (v == null || v.isEmpty) ? 'Obrigatório' : null,
                           ),

--- a/lib/features/operador/presentation/widgets/measurement_tile.dart
+++ b/lib/features/operador/presentation/widgets/measurement_tile.dart
@@ -169,23 +169,37 @@ class _MeasurementTileState extends State<MeasurementTile> {
     Color? fg,
     VoidCallback? onTap,
   }) {
-    final fgColor = fg ?? _fgOn(bg);
+    final baseFg = fg ?? _fgOn(bg);
+    final effectiveBg = selected ? border : bg;
+    final effectiveBorder = selected ? border : border.withValues(alpha: 0.7);
+    final effectiveFg = selected
+        ? (fg != null ? Colors.white : _fgOn(effectiveBg))
+        : baseFg;
     return InkWell(
       onTap: onTap,
       borderRadius: BorderRadius.circular(999),
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
         decoration: BoxDecoration(
-          color: bg,
+          color: effectiveBg,
           borderRadius: BorderRadius.circular(999),
-          border: Border.all(
-            color: selected ? border.withValues(alpha: 0.9) : border,
-            width: selected ? 2 : 1,
-          ),
+          border: Border.all(color: effectiveBorder, width: selected ? 2 : 1),
+          boxShadow: selected
+              ? [
+                  BoxShadow(
+                    color: border.withValues(alpha: 0.35),
+                    blurRadius: 10,
+                    offset: const Offset(0, 4),
+                  ),
+                ]
+              : null,
         ),
         child: Text(
           text,
-          style: TextStyle(fontWeight: FontWeight.w600, color: fgColor),
+          style: TextStyle(
+            fontWeight: selected ? FontWeight.w700 : FontWeight.w600,
+            color: effectiveFg,
+          ),
         ),
       ),
     );

--- a/lib/features/preparacao/presentation/preparacao_page.dart
+++ b/lib/features/preparacao/presentation/preparacao_page.dart
@@ -9,6 +9,7 @@ import 'package:http/http.dart' as http;
 
 import 'package:admin/features/preparacao/data/models.dart';
 import 'package:admin/features/operador/data/repository_provider.dart';
+import 'package:admin/features/shared/providers/search_flow_form_provider.dart';
 import 'package:admin/screens/main/components/side_menu.dart';
 import 'package:admin/widgets/window_bar.dart';
 import 'package:admin/utils/string_utils.dart';
@@ -132,6 +133,10 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
   bool _registrando = false;
   bool _osLiberada = false;
 
+  late final VoidCallback _osSyncListener;
+  late final VoidCallback _partSyncListener;
+  late final VoidCallback _opSyncListener;
+
   void _resetLiberada() {
     if (_osLiberada) setState(() => _osLiberada = false);
   }
@@ -139,9 +144,30 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
   @override
   void initState() {
     super.initState();
+    final shared = ref.read(sharedSearchFormProvider);
+    _osCtrl.text = shared.os;
+    _partCtrl.text = shared.partNumber;
+    _opCtrl.text = shared.operacao;
+    _categoriaSel = shared.categoria;
+    _maquinaSel = shared.maquina;
+
+    _osSyncListener = () {
+      ref.read(sharedSearchFormProvider.notifier).setOs(_osCtrl.text);
+    };
+    _partSyncListener = () {
+      ref.read(sharedSearchFormProvider.notifier).setPartNumber(_partCtrl.text);
+    };
+    _opSyncListener = () {
+      ref.read(sharedSearchFormProvider.notifier).setOperacao(_opCtrl.text);
+    };
+
     _osCtrl.addListener(_resetLiberada);
     _partCtrl.addListener(_resetLiberada);
     _opCtrl.addListener(_resetLiberada);
+
+    _osCtrl.addListener(_osSyncListener);
+    _partCtrl.addListener(_partSyncListener);
+    _opCtrl.addListener(_opSyncListener);
     _carregarMaquinas();
   }
 
@@ -150,10 +176,33 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
       final list = await MachineService().fetchMaquinas();
       if (mounted) {
         setState(() {
-          _maquinas.addAll(list);
-          _categorias.addAll(
-            _maquinas.map((e) => e.categoria).toSet().toList()..sort(),
-          );
+          _maquinas
+            ..clear()
+            ..addAll(list);
+          _categorias
+            ..clear()
+            ..addAll(
+              _maquinas.map((e) => e.categoria).toSet().toList()..sort(),
+            );
+          final notifier = ref.read(sharedSearchFormProvider.notifier);
+          final categoriaAtual = _categoriaSel;
+          if (categoriaAtual != null && !_categorias.contains(categoriaAtual)) {
+            _categoriaSel = null;
+            notifier.setCategoria(null);
+          }
+
+          if (_categoriaSel != null) {
+            final possuiMaquina = _maquinas.any(
+              (m) => m.categoria == _categoriaSel && m.codigo == _maquinaSel,
+            );
+            if (!possuiMaquina && _maquinaSel != null) {
+              _maquinaSel = null;
+              notifier.setMaquina(null);
+            }
+          } else if (_maquinaSel != null) {
+            _maquinaSel = null;
+            notifier.setMaquina(null);
+          }
         });
       }
     } catch (e) {
@@ -170,6 +219,9 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
     _osCtrl.removeListener(_resetLiberada);
     _partCtrl.removeListener(_resetLiberada);
     _opCtrl.removeListener(_resetLiberada);
+    _osCtrl.removeListener(_osSyncListener);
+    _partCtrl.removeListener(_partSyncListener);
+    _opCtrl.removeListener(_opSyncListener);
     _reCtrl.dispose();
     _osCtrl.dispose();
     _partCtrl.dispose();
@@ -340,7 +392,19 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
     // Pode registrar quando: RE e OS preenchidos + todas as medições preenchidas
     final reOk = _reCtrl.text.trim().isNotEmpty;
     final osOk = _osCtrl.text.trim().isNotEmpty;
-    final maquinaOk = (_maquinaSel ?? '').isNotEmpty;
+    final categoriaValue =
+        (_categoriaSel != null && _categorias.contains(_categoriaSel))
+        ? _categoriaSel
+        : null;
+    final maquinasDisponiveis = _maquinas
+        .where((m) => m.categoria == categoriaValue)
+        .toList();
+    final maquinaValue =
+        (_maquinaSel != null &&
+            maquinasDisponiveis.any((m) => m.codigo == _maquinaSel))
+        ? _maquinaSel
+        : null;
+    final maquinaOk = (maquinaValue ?? '').isNotEmpty;
     final todasOk =
         medidas.isNotEmpty &&
         medidas.every(
@@ -435,7 +499,7 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
                       children: [
                         Expanded(
                           child: DropdownButtonFormField<String>(
-                            value: _categoriaSel,
+                            value: categoriaValue,
                             decoration: const InputDecoration(
                               labelText: 'Categoria',
                               border: OutlineInputBorder(),
@@ -448,10 +512,15 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
                                   ),
                                 )
                                 .toList(),
-                            onChanged: (v) => setState(() {
-                              _categoriaSel = v;
-                              _maquinaSel = null;
-                            }),
+                            onChanged: (v) {
+                              ref
+                                  .read(sharedSearchFormProvider.notifier)
+                                  .setCategoria(v);
+                              setState(() {
+                                _categoriaSel = v;
+                                _maquinaSel = null;
+                              });
+                            },
                             validator: (v) =>
                                 (v == null || v.isEmpty) ? 'Obrigatório' : null,
                           ),
@@ -459,13 +528,12 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
                         const SizedBox(width: 12),
                         Expanded(
                           child: DropdownButtonFormField<String>(
-                            value: _maquinaSel,
+                            value: maquinaValue,
                             decoration: const InputDecoration(
                               labelText: 'Código da máquina',
                               border: OutlineInputBorder(),
                             ),
-                            items: _maquinas
-                                .where((m) => m.categoria == _categoriaSel)
+                            items: maquinasDisponiveis
                                 .map(
                                   (m) => DropdownMenuItem(
                                     value: m.codigo,
@@ -473,7 +541,12 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
                                   ),
                                 )
                                 .toList(),
-                            onChanged: (v) => setState(() => _maquinaSel = v),
+                            onChanged: (v) {
+                              ref
+                                  .read(sharedSearchFormProvider.notifier)
+                                  .setMaquina(v);
+                              setState(() => _maquinaSel = v);
+                            },
                             validator: (v) =>
                                 (v == null || v.isEmpty) ? 'Obrigatório' : null,
                           ),

--- a/lib/features/shared/providers/search_flow_form_provider.dart
+++ b/lib/features/shared/providers/search_flow_form_provider.dart
@@ -1,0 +1,79 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class SharedSearchFormState {
+  const SharedSearchFormState({
+    this.os = '',
+    this.partNumber = '',
+    this.operacao = '',
+    this.categoria,
+    this.maquina,
+  });
+
+  final String os;
+  final String partNumber;
+  final String operacao;
+  final String? categoria;
+  final String? maquina;
+
+  static const _sentinel = Object();
+
+  SharedSearchFormState copyWith({
+    String? os,
+    String? partNumber,
+    String? operacao,
+    Object? categoria = _sentinel,
+    Object? maquina = _sentinel,
+  }) {
+    return SharedSearchFormState(
+      os: os ?? this.os,
+      partNumber: partNumber ?? this.partNumber,
+      operacao: operacao ?? this.operacao,
+      categoria: categoria == _sentinel ? this.categoria : categoria as String?,
+      maquina: maquina == _sentinel ? this.maquina : maquina as String?,
+    );
+  }
+}
+
+class SharedSearchFormController extends StateNotifier<SharedSearchFormState> {
+  SharedSearchFormController() : super(const SharedSearchFormState());
+
+  void setOs(String value) {
+    final trimmed = value.trim();
+    if (trimmed == state.os) return;
+    state = state.copyWith(os: trimmed);
+  }
+
+  void setPartNumber(String value) {
+    final trimmed = value.trim();
+    if (trimmed == state.partNumber) return;
+    state = state.copyWith(partNumber: trimmed);
+  }
+
+  void setOperacao(String value) {
+    final trimmed = value.trim();
+    if (trimmed == state.operacao) return;
+    state = state.copyWith(operacao: trimmed);
+  }
+
+  void setCategoria(String? categoria) {
+    if (categoria == state.categoria) return;
+    state = state.copyWith(
+      categoria: categoria,
+      maquina: categoria == state.categoria ? state.maquina : null,
+    );
+  }
+
+  void setMaquina(String? maquina) {
+    if (maquina == state.maquina) return;
+    state = state.copyWith(maquina: maquina);
+  }
+
+  void clear() {
+    state = const SharedSearchFormState();
+  }
+}
+
+final sharedSearchFormProvider =
+    StateNotifierProvider<SharedSearchFormController, SharedSearchFormState>(
+      (ref) => SharedSearchFormController(),
+    );


### PR DESCRIPTION
## Summary
- persist OS/part/operation/machine selections across Preparação, Operador and Finalização via a shared Riverpod controller
- preload the shared values on each page while validating machine/category choices against the fetched lists
- intensify the highlight for selected measurement pills to improve visual feedback

## Testing
- flutter analyze *(emits existing Flutter deprecation warnings about DropdownButtonFormField.value and older widgets)*

------
https://chatgpt.com/codex/tasks/task_e_68cd88921f788331bc434384662fa734