### PR TITLE
Restore automatic flow navigation with scoped form sharing

### DIFF
--- a/lib/features/finalizar_os/presentation/finalizar_os_page.dart
+++ b/lib/features/finalizar_os/presentation/finalizar_os_page.dart
@@ -14,6 +14,7 @@ import 'package:admin/widgets/window_bar.dart';
 import 'package:admin/utils/string_utils.dart';
 import 'package:admin/services/machine_service.dart';
 import 'package:admin/models/machine.dart';
+import 'package:admin/features/shared/providers/search_flow_form_provider.dart';
 
 /// Mesmo base URL usado no Operador
 const String kBaseUrl = 'http://192.168.0.241:5005';
@@ -132,6 +133,10 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
   bool _registrando = false;
   bool _osFinalizada = false;
 
+  late final VoidCallback _osSyncListener;
+  late final VoidCallback _partSyncListener;
+  late final VoidCallback _opSyncListener;
+
   void _resetFinalizada() {
     if (_osFinalizada) setState(() => _osFinalizada = false);
   }
@@ -139,9 +144,31 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
   @override
   void initState() {
     super.initState();
+    final shared = ref.read(sharedSearchFormProvider);
+    if (shared.isActive) {
+      _osCtrl.text = shared.os;
+      _partCtrl.text = shared.partNumber;
+      _opCtrl.text = shared.operacao;
+      _categoriaSel = shared.categoria;
+      _maquinaSel = shared.maquina;
+    }
+
+    _osSyncListener = () {
+      ref.read(sharedSearchFormProvider.notifier).setOs(_osCtrl.text);
+    };
+    _partSyncListener = () {
+      ref.read(sharedSearchFormProvider.notifier).setPartNumber(_partCtrl.text);
+    };
+    _opSyncListener = () {
+      ref.read(sharedSearchFormProvider.notifier).setOperacao(_opCtrl.text);
+    };
+
     _osCtrl.addListener(_resetFinalizada);
     _partCtrl.addListener(_resetFinalizada);
     _opCtrl.addListener(_resetFinalizada);
+    _osCtrl.addListener(_osSyncListener);
+    _partCtrl.addListener(_partSyncListener);
+    _opCtrl.addListener(_opSyncListener);
     _carregarMaquinas();
   }
 
@@ -150,10 +177,33 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
       final list = await MachineService().fetchMaquinas();
       if (mounted) {
         setState(() {
-          _maquinas.addAll(list);
-          _categorias.addAll(
-            _maquinas.map((e) => e.categoria).toSet().toList()..sort(),
-          );
+          _maquinas
+            ..clear()
+            ..addAll(list);
+          _categorias
+            ..clear()
+            ..addAll(
+              _maquinas.map((e) => e.categoria).toSet().toList()..sort(),
+            );
+          final notifier = ref.read(sharedSearchFormProvider.notifier);
+          final categoriaAtual = _categoriaSel;
+          if (categoriaAtual != null && !_categorias.contains(categoriaAtual)) {
+            _categoriaSel = null;
+            notifier.setCategoria(null);
+          }
+
+          if (_categoriaSel != null) {
+            final possuiMaquina = _maquinas.any(
+              (m) => m.categoria == _categoriaSel && m.codigo == _maquinaSel,
+            );
+            if (!possuiMaquina && _maquinaSel != null) {
+              _maquinaSel = null;
+              notifier.setMaquina(null);
+            }
+          } else if (_maquinaSel != null) {
+            _maquinaSel = null;
+            notifier.setMaquina(null);
+          }
         });
       }
     } catch (e) {
@@ -165,11 +215,23 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
     }
   }
 
+  bool _maquinaSelecionadaValida() {
+    final categoria = _categoriaSel;
+    final maquina = _maquinaSel;
+    if (categoria == null || maquina == null) return false;
+    return _maquinas.any(
+      (m) => m.categoria == categoria && m.codigo == maquina,
+    );
+  }
+
   @override
   void dispose() {
     _osCtrl.removeListener(_resetFinalizada);
     _partCtrl.removeListener(_resetFinalizada);
     _opCtrl.removeListener(_resetFinalizada);
+    _osCtrl.removeListener(_osSyncListener);
+    _partCtrl.removeListener(_partSyncListener);
+    _opCtrl.removeListener(_opSyncListener);
     _reCtrl.dispose();
     _osCtrl.dispose();
     _partCtrl.dispose();
@@ -200,7 +262,7 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
     // Valida RE / OS / Máquina
     if (_reCtrl.text.trim().isEmpty ||
         _osCtrl.text.trim().isEmpty ||
-        (_maquinaSel ?? '').isEmpty) {
+        !_maquinaSelecionadaValida()) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(
@@ -293,10 +355,12 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
           const SnackBar(content: Text('OS finalizada com sucesso!')),
         );
         ref.read(medidasFinalizadorControllerProvider.notifier).resetSelecoes();
+        ref.read(sharedSearchFormProvider.notifier).clear();
       } else if (resp.statusCode == 409) {
         final data = jsonDecode(resp.body);
         if ((data['code'] ?? '') == 'ja_finalizada') {
           setState(() => _osFinalizada = true);
+          ref.read(sharedSearchFormProvider.notifier).clear();
         }
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
@@ -330,7 +394,19 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
     // Pode registrar quando: RE e OS preenchidos + todas as medições preenchidas
     final reOk = _reCtrl.text.trim().isNotEmpty;
     final osOk = _osCtrl.text.trim().isNotEmpty;
-    final maquinaOk = (_maquinaSel ?? '').isNotEmpty;
+    final categoriaValue =
+        (_categoriaSel != null && _categorias.contains(_categoriaSel))
+        ? _categoriaSel
+        : null;
+    final maquinasDisponiveis = _maquinas
+        .where((m) => m.categoria == categoriaValue)
+        .toList();
+    final maquinaValue =
+        (_maquinaSel != null &&
+            maquinasDisponiveis.any((m) => m.codigo == _maquinaSel))
+        ? _maquinaSel
+        : null;
+    final maquinaOk = (maquinaValue ?? '').isNotEmpty;
     final todasOk =
         medidas.isNotEmpty &&
         medidas.every(
@@ -425,7 +501,7 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
                       children: [
                         Expanded(
                           child: DropdownButtonFormField<String>(
-                            value: _categoriaSel,
+                            value: categoriaValue,
                             decoration: const InputDecoration(
                               labelText: 'Categoria',
                               border: OutlineInputBorder(),
@@ -438,10 +514,15 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
                                   ),
                                 )
                                 .toList(),
-                            onChanged: (v) => setState(() {
-                              _categoriaSel = v;
-                              _maquinaSel = null;
-                            }),
+                            onChanged: (v) {
+                              ref
+                                  .read(sharedSearchFormProvider.notifier)
+                                  .setCategoria(v);
+                              setState(() {
+                                _categoriaSel = v;
+                                _maquinaSel = null;
+                              });
+                            },
                             validator: (v) =>
                                 (v == null || v.isEmpty) ? 'Obrigatório' : null,
                           ),
@@ -449,13 +530,12 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
                         const SizedBox(width: 12),
                         Expanded(
                           child: DropdownButtonFormField<String>(
-                            value: _maquinaSel,
+                            value: maquinaValue,
                             decoration: const InputDecoration(
                               labelText: 'Código da máquina',
                               border: OutlineInputBorder(),
                             ),
-                            items: _maquinas
-                                .where((m) => m.categoria == _categoriaSel)
+                            items: maquinasDisponiveis
                                 .map(
                                   (m) => DropdownMenuItem(
                                     value: m.codigo,
@@ -463,7 +543,12 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
                                   ),
                                 )
                                 .toList(),
-                            onChanged: (v) => setState(() => _maquinaSel = v),
+                            onChanged: (v) {
+                              ref
+                                  .read(sharedSearchFormProvider.notifier)
+                                  .setMaquina(v);
+                              setState(() => _maquinaSel = v);
+                            },
                             validator: (v) =>
                                 (v == null || v.isEmpty) ? 'Obrigatório' : null,
                           ),

--- a/lib/features/main_menu/main_menu_page.dart
+++ b/lib/features/main_menu/main_menu_page.dart
@@ -12,7 +12,7 @@ import '../operador/presentation/operador_page.dart';
 import '../login/login_page.dart';
 import '../../services/auth_service.dart';
 import '../finalizar_os/presentation/finalizar_os_page.dart';
-
+import '../shared/providers/search_flow_form_provider.dart';
 
 class MainMenuPage extends ConsumerStatefulWidget {
   const MainMenuPage({super.key});
@@ -34,7 +34,11 @@ class _MainMenuPageState extends ConsumerState<MainMenuPage> {
   Timer? _timer;
   static const _logos = [
     _LogoConfig(asset: 'assets/images/Relictt.png', width: 250, height: 110),
-    _LogoConfig(asset: 'assets/images/logotuptech1.png', width: 250 , height: 110),
+    _LogoConfig(
+      asset: 'assets/images/logotuptech1.png',
+      width: 250,
+      height: 110,
+    ),
   ];
 
   @override
@@ -54,6 +58,7 @@ class _MainMenuPageState extends ConsumerState<MainMenuPage> {
   @override
   Widget build(BuildContext context) {
     void open(BuildContext context, Widget page) {
+      ref.read(sharedSearchFormProvider.notifier).clear();
       Navigator.of(context).push(MaterialPageRoute(builder: (_) => page));
     }
 
@@ -98,7 +103,8 @@ class _MainMenuPageState extends ConsumerState<MainMenuPage> {
                       children: [
                         _MenuButton(
                           image: 'assets/icons/FOR007.svg',
-                          onPressed: () => open(context, const PreparacaoPage()),
+                          onPressed: () =>
+                              open(context, const PreparacaoPage()),
                         ),
                         _MenuButton(
                           image: 'assets/icons/Amostragem.svg',
@@ -106,7 +112,8 @@ class _MainMenuPageState extends ConsumerState<MainMenuPage> {
                         ),
                         _MenuButton(
                           image: 'assets/icons/FOR008.svg',
-                          onPressed: () => open(context, const FinalizarOsPage()),
+                          onPressed: () =>
+                              open(context, const FinalizarOsPage()),
                         ),
                         _MenuButton(
                           image: 'assets/icons/Dashboard.svg',

--- a/lib/features/operador/presentation/operador_page.dart
+++ b/lib/features/operador/presentation/operador_page.dart
@@ -9,6 +9,7 @@ import 'package:http/http.dart' as http;
 
 import '../../preparacao/data/models.dart';
 import '../data/repository_provider.dart';
+import 'package:admin/features/finalizar_os/presentation/finalizar_os_page.dart';
 import 'package:admin/features/operador/presentation/troca_ferramenta_page.dart';
 import 'package:admin/features/operador/presentation/widgets/measurement_tile.dart';
 import 'package:admin/screens/main/components/side_menu.dart';
@@ -16,6 +17,7 @@ import 'package:admin/widgets/window_bar.dart';
 import 'package:admin/utils/string_utils.dart';
 import 'package:admin/services/machine_service.dart';
 import 'package:admin/models/machine.dart';
+import 'package:admin/features/shared/providers/search_flow_form_provider.dart';
 
 /// >>>>> Ajuste para o endereço/porta do seu Flask <<<<<
 const String kBaseUrl = 'http://192.168.0.241:5005';
@@ -115,9 +117,35 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
 
   bool _registrando = false;
 
+  late final VoidCallback _osSyncListener;
+  late final VoidCallback _partSyncListener;
+  late final VoidCallback _opSyncListener;
+
   @override
   void initState() {
     super.initState();
+    final shared = ref.read(sharedSearchFormProvider);
+    if (shared.isActive) {
+      _osCtrl.text = shared.os;
+      _partCtrl.text = shared.partNumber;
+      _opCtrl.text = shared.operacao;
+      _categoriaSel = shared.categoria;
+      _maquinaSel = shared.maquina;
+    }
+
+    _osSyncListener = () {
+      ref.read(sharedSearchFormProvider.notifier).setOs(_osCtrl.text);
+    };
+    _partSyncListener = () {
+      ref.read(sharedSearchFormProvider.notifier).setPartNumber(_partCtrl.text);
+    };
+    _opSyncListener = () {
+      ref.read(sharedSearchFormProvider.notifier).setOperacao(_opCtrl.text);
+    };
+
+    _osCtrl.addListener(_osSyncListener);
+    _partCtrl.addListener(_partSyncListener);
+    _opCtrl.addListener(_opSyncListener);
     _carregarMaquinas();
   }
 
@@ -126,10 +154,33 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
       final list = await MachineService().fetchMaquinas();
       if (mounted) {
         setState(() {
-          _maquinas.addAll(list);
-          _categorias.addAll(
-            _maquinas.map((e) => e.categoria).toSet().toList()..sort(),
-          );
+          _maquinas
+            ..clear()
+            ..addAll(list);
+          _categorias
+            ..clear()
+            ..addAll(
+              _maquinas.map((e) => e.categoria).toSet().toList()..sort(),
+            );
+          final notifier = ref.read(sharedSearchFormProvider.notifier);
+          final categoriaAtual = _categoriaSel;
+          if (categoriaAtual != null && !_categorias.contains(categoriaAtual)) {
+            _categoriaSel = null;
+            notifier.setCategoria(null);
+          }
+
+          if (_categoriaSel != null) {
+            final possuiMaquina = _maquinas.any(
+              (m) => m.categoria == _categoriaSel && m.codigo == _maquinaSel,
+            );
+            if (!possuiMaquina && _maquinaSel != null) {
+              _maquinaSel = null;
+              notifier.setMaquina(null);
+            }
+          } else if (_maquinaSel != null) {
+            _maquinaSel = null;
+            notifier.setMaquina(null);
+          }
         });
       }
     } catch (e) {
@@ -141,8 +192,20 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
     }
   }
 
+  bool _maquinaSelecionadaValida() {
+    final categoria = _categoriaSel;
+    final maquina = _maquinaSel;
+    if (categoria == null || maquina == null) return false;
+    return _maquinas.any(
+      (m) => m.categoria == categoria && m.codigo == maquina,
+    );
+  }
+
   @override
   void dispose() {
+    _osCtrl.removeListener(_osSyncListener);
+    _partCtrl.removeListener(_partSyncListener);
+    _opCtrl.removeListener(_opSyncListener);
     _reCtrl.dispose();
     _osCtrl.dispose();
     _partCtrl.dispose();
@@ -156,7 +219,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
     // Valida RE/OS/Máquina
     if (_reCtrl.text.trim().isEmpty ||
         _osCtrl.text.trim().isEmpty ||
-        (_maquinaSel ?? '').isEmpty) {
+        !_maquinaSelecionadaValida()) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(
@@ -387,13 +450,14 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
       final os = _osCtrl.text.trim();
       final part = _partCtrl.text.trim();
       final operacao = _opCtrl.text.trim();
-      final maquina = (_maquinaSel ?? '').trim();
+      final maquinaValida = _maquinaSelecionadaValida();
+      final maquina = maquinaValida ? (_maquinaSel ?? '').trim() : '';
 
       if (re.isEmpty ||
           os.isEmpty ||
           part.isEmpty ||
           operacao.isEmpty ||
-          maquina.isEmpty) {
+          !maquinaValida) {
         if (!mounted) return;
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(
@@ -447,6 +511,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
         ScaffoldMessenger.of(
           context,
         ).showSnackBar(const SnackBar(content: Text('Produção encerrada.')));
+        await _abrirPaginaFinalizacaoOs();
       } else {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text('Falha: ${resp.statusCode} ${resp.body}')),
@@ -483,13 +548,47 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
     }
   }
 
+  Future<void> _abrirPaginaFinalizacaoOs() async {
+    final notifier = ref.read(sharedSearchFormProvider.notifier);
+    notifier.beginFlow(
+      os: _osCtrl.text,
+      partNumber: _partCtrl.text,
+      operacao: _opCtrl.text,
+      categoria: _categoriaSel,
+      maquina: _maquinaSel,
+    );
+
+    if (mounted) {
+      FocusScope.of(context).unfocus();
+    }
+
+    await Future.delayed(const Duration(milliseconds: 600));
+    if (!mounted) return;
+    Navigator.of(
+      context,
+      rootNavigator: true,
+    ).push(MaterialPageRoute(builder: (_) => const FinalizarOsPage()));
+  }
+
   @override
   Widget build(BuildContext context) {
     final medidasAsync = ref.watch(medidasOperadorControllerProvider);
     final medidas = medidasAsync.value ?? [];
     final reOk = _reCtrl.text.trim().isNotEmpty;
     final osOk = _osCtrl.text.trim().isNotEmpty;
-    final maquinaOk = (_maquinaSel ?? '').isNotEmpty;
+    final categoriaValue =
+        (_categoriaSel != null && _categorias.contains(_categoriaSel))
+        ? _categoriaSel
+        : null;
+    final maquinasDisponiveis = _maquinas
+        .where((m) => m.categoria == categoriaValue)
+        .toList();
+    final maquinaValue =
+        (_maquinaSel != null &&
+            maquinasDisponiveis.any((m) => m.codigo == _maquinaSel))
+        ? _maquinaSel
+        : null;
+    final maquinaOk = (maquinaValue ?? '').isNotEmpty;
 
     // todas respondidas?
     final todasRespondidas =
@@ -587,7 +686,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                       children: [
                         Expanded(
                           child: DropdownButtonFormField<String>(
-                            value: _categoriaSel,
+                            value: categoriaValue,
                             decoration: const InputDecoration(
                               labelText: 'Categoria',
                               border: OutlineInputBorder(),
@@ -600,10 +699,15 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                                   ),
                                 )
                                 .toList(),
-                            onChanged: (v) => setState(() {
-                              _categoriaSel = v;
-                              _maquinaSel = null;
-                            }),
+                            onChanged: (v) {
+                              ref
+                                  .read(sharedSearchFormProvider.notifier)
+                                  .setCategoria(v);
+                              setState(() {
+                                _categoriaSel = v;
+                                _maquinaSel = null;
+                              });
+                            },
                             validator: (v) =>
                                 (v == null || v.isEmpty) ? 'Obrigatório' : null,
                           ),
@@ -611,13 +715,12 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                         const SizedBox(width: 12),
                         Expanded(
                           child: DropdownButtonFormField<String>(
-                            value: _maquinaSel,
+                            value: maquinaValue,
                             decoration: const InputDecoration(
                               labelText: 'Código da máquina',
                               border: OutlineInputBorder(),
                             ),
-                            items: _maquinas
-                                .where((m) => m.categoria == _categoriaSel)
+                            items: maquinasDisponiveis
                                 .map(
                                   (m) => DropdownMenuItem(
                                     value: m.codigo,
@@ -625,7 +728,12 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                                   ),
                                 )
                                 .toList(),
-                            onChanged: (v) => setState(() => _maquinaSel = v),
+                            onChanged: (v) {
+                              ref
+                                  .read(sharedSearchFormProvider.notifier)
+                                  .setMaquina(v);
+                              setState(() => _maquinaSel = v);
+                            },
                             validator: (v) =>
                                 (v == null || v.isEmpty) ? 'Obrigatório' : null,
                           ),

--- a/lib/features/operador/presentation/widgets/measurement_tile.dart
+++ b/lib/features/operador/presentation/widgets/measurement_tile.dart
@@ -169,23 +169,37 @@ class _MeasurementTileState extends State<MeasurementTile> {
     Color? fg,
     VoidCallback? onTap,
   }) {
-    final fgColor = fg ?? _fgOn(bg);
+    final baseFg = fg ?? _fgOn(bg);
+    final effectiveBg = selected ? border : bg;
+    final effectiveBorder = selected ? border : border.withValues(alpha: 0.7);
+    final effectiveFg = selected
+        ? (fg != null ? Colors.white : _fgOn(effectiveBg))
+        : baseFg;
     return InkWell(
       onTap: onTap,
       borderRadius: BorderRadius.circular(999),
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
         decoration: BoxDecoration(
-          color: bg,
+          color: effectiveBg,
           borderRadius: BorderRadius.circular(999),
-          border: Border.all(
-            color: selected ? border.withValues(alpha: 0.9) : border,
-            width: selected ? 2 : 1,
-          ),
+          border: Border.all(color: effectiveBorder, width: selected ? 2 : 1),
+          boxShadow: selected
+              ? [
+                  BoxShadow(
+                    color: border.withValues(alpha: 0.35),
+                    blurRadius: 10,
+                    offset: const Offset(0, 4),
+                  ),
+                ]
+              : null,
         ),
         child: Text(
           text,
-          style: TextStyle(fontWeight: FontWeight.w600, color: fgColor),
+          style: TextStyle(
+            fontWeight: selected ? FontWeight.w700 : FontWeight.w600,
+            color: effectiveFg,
+          ),
         ),
       ),
     );

--- a/lib/features/preparacao/presentation/preparacao_page.dart
+++ b/lib/features/preparacao/presentation/preparacao_page.dart
@@ -9,6 +9,8 @@ import 'package:http/http.dart' as http;
 
 import 'package:admin/features/preparacao/data/models.dart';
 import 'package:admin/features/operador/data/repository_provider.dart';
+import 'package:admin/features/operador/presentation/operador_page.dart';
+import 'package:admin/features/shared/providers/search_flow_form_provider.dart';
 import 'package:admin/screens/main/components/side_menu.dart';
 import 'package:admin/widgets/window_bar.dart';
 import 'package:admin/utils/string_utils.dart';
@@ -132,6 +134,10 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
   bool _registrando = false;
   bool _osLiberada = false;
 
+  late final VoidCallback _osSyncListener;
+  late final VoidCallback _partSyncListener;
+  late final VoidCallback _opSyncListener;
+
   void _resetLiberada() {
     if (_osLiberada) setState(() => _osLiberada = false);
   }
@@ -139,9 +145,32 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
   @override
   void initState() {
     super.initState();
+    final shared = ref.read(sharedSearchFormProvider);
+    if (shared.isActive) {
+      _osCtrl.text = shared.os;
+      _partCtrl.text = shared.partNumber;
+      _opCtrl.text = shared.operacao;
+      _categoriaSel = shared.categoria;
+      _maquinaSel = shared.maquina;
+    }
+
+    _osSyncListener = () {
+      ref.read(sharedSearchFormProvider.notifier).setOs(_osCtrl.text);
+    };
+    _partSyncListener = () {
+      ref.read(sharedSearchFormProvider.notifier).setPartNumber(_partCtrl.text);
+    };
+    _opSyncListener = () {
+      ref.read(sharedSearchFormProvider.notifier).setOperacao(_opCtrl.text);
+    };
+
     _osCtrl.addListener(_resetLiberada);
     _partCtrl.addListener(_resetLiberada);
     _opCtrl.addListener(_resetLiberada);
+
+    _osCtrl.addListener(_osSyncListener);
+    _partCtrl.addListener(_partSyncListener);
+    _opCtrl.addListener(_opSyncListener);
     _carregarMaquinas();
   }
 
@@ -150,10 +179,33 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
       final list = await MachineService().fetchMaquinas();
       if (mounted) {
         setState(() {
-          _maquinas.addAll(list);
-          _categorias.addAll(
-            _maquinas.map((e) => e.categoria).toSet().toList()..sort(),
-          );
+          _maquinas
+            ..clear()
+            ..addAll(list);
+          _categorias
+            ..clear()
+            ..addAll(
+              _maquinas.map((e) => e.categoria).toSet().toList()..sort(),
+            );
+          final notifier = ref.read(sharedSearchFormProvider.notifier);
+          final categoriaAtual = _categoriaSel;
+          if (categoriaAtual != null && !_categorias.contains(categoriaAtual)) {
+            _categoriaSel = null;
+            notifier.setCategoria(null);
+          }
+
+          if (_categoriaSel != null) {
+            final possuiMaquina = _maquinas.any(
+              (m) => m.categoria == _categoriaSel && m.codigo == _maquinaSel,
+            );
+            if (!possuiMaquina && _maquinaSel != null) {
+              _maquinaSel = null;
+              notifier.setMaquina(null);
+            }
+          } else if (_maquinaSel != null) {
+            _maquinaSel = null;
+            notifier.setMaquina(null);
+          }
         });
       }
     } catch (e) {
@@ -165,11 +217,36 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
     }
   }
 
+  Future<void> _abrirPaginaOperador() async {
+    final notifier = ref.read(sharedSearchFormProvider.notifier);
+    notifier.beginFlow(
+      os: _osCtrl.text,
+      partNumber: _partCtrl.text,
+      operacao: _opCtrl.text,
+      categoria: _categoriaSel,
+      maquina: _maquinaSel,
+    );
+
+    if (mounted) {
+      FocusScope.of(context).unfocus();
+    }
+
+    await Future.delayed(const Duration(milliseconds: 600));
+    if (!mounted) return;
+    Navigator.of(
+      context,
+      rootNavigator: true,
+    ).push(MaterialPageRoute(builder: (_) => const OperadorPage()));
+  }
+
   @override
   void dispose() {
     _osCtrl.removeListener(_resetLiberada);
     _partCtrl.removeListener(_resetLiberada);
     _opCtrl.removeListener(_resetLiberada);
+    _osCtrl.removeListener(_osSyncListener);
+    _partCtrl.removeListener(_partSyncListener);
+    _opCtrl.removeListener(_opSyncListener);
     _reCtrl.dispose();
     _osCtrl.dispose();
     _partCtrl.dispose();
@@ -295,23 +372,19 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
         );
         ref.read(medidasPreparadorControllerProvider.notifier).resetSelecoes();
         if (liberada) {
-          await Future.delayed(const Duration(seconds: 1));
-          if (mounted) Navigator.of(context).pop();
+          await _abrirPaginaOperador();
         }
       } else if (resp.statusCode == 409) {
         final data = jsonDecode(resp.body);
         final liberada = (data['code'] ?? '') == 'ja_liberada';
-        if (liberada) {
-          setState(() => _osLiberada = true);
-        }
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: Text('Falha ao registrar: ${data['error'] ?? resp.body}'),
           ),
         );
         if (liberada) {
-          await Future.delayed(const Duration(seconds: 1));
-          if (mounted) Navigator.of(context).pop();
+          setState(() => _osLiberada = true);
+          await _abrirPaginaOperador();
         }
       } else {
         ScaffoldMessenger.of(context).showSnackBar(
@@ -340,7 +413,19 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
     // Pode registrar quando: RE e OS preenchidos + todas as medições preenchidas
     final reOk = _reCtrl.text.trim().isNotEmpty;
     final osOk = _osCtrl.text.trim().isNotEmpty;
-    final maquinaOk = (_maquinaSel ?? '').isNotEmpty;
+    final categoriaValue =
+        (_categoriaSel != null && _categorias.contains(_categoriaSel))
+        ? _categoriaSel
+        : null;
+    final maquinasDisponiveis = _maquinas
+        .where((m) => m.categoria == categoriaValue)
+        .toList();
+    final maquinaValue =
+        (_maquinaSel != null &&
+            maquinasDisponiveis.any((m) => m.codigo == _maquinaSel))
+        ? _maquinaSel
+        : null;
+    final maquinaOk = (maquinaValue ?? '').isNotEmpty;
     final todasOk =
         medidas.isNotEmpty &&
         medidas.every(
@@ -435,7 +520,7 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
                       children: [
                         Expanded(
                           child: DropdownButtonFormField<String>(
-                            value: _categoriaSel,
+                            value: categoriaValue,
                             decoration: const InputDecoration(
                               labelText: 'Categoria',
                               border: OutlineInputBorder(),
@@ -448,10 +533,15 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
                                   ),
                                 )
                                 .toList(),
-                            onChanged: (v) => setState(() {
-                              _categoriaSel = v;
-                              _maquinaSel = null;
-                            }),
+                            onChanged: (v) {
+                              ref
+                                  .read(sharedSearchFormProvider.notifier)
+                                  .setCategoria(v);
+                              setState(() {
+                                _categoriaSel = v;
+                                _maquinaSel = null;
+                              });
+                            },
                             validator: (v) =>
                                 (v == null || v.isEmpty) ? 'Obrigatório' : null,
                           ),
@@ -459,13 +549,12 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
                         const SizedBox(width: 12),
                         Expanded(
                           child: DropdownButtonFormField<String>(
-                            value: _maquinaSel,
+                            value: maquinaValue,
                             decoration: const InputDecoration(
                               labelText: 'Código da máquina',
                               border: OutlineInputBorder(),
                             ),
-                            items: _maquinas
-                                .where((m) => m.categoria == _categoriaSel)
+                            items: maquinasDisponiveis
                                 .map(
                                   (m) => DropdownMenuItem(
                                     value: m.codigo,
@@ -473,7 +562,12 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
                                   ),
                                 )
                                 .toList(),
-                            onChanged: (v) => setState(() => _maquinaSel = v),
+                            onChanged: (v) {
+                              ref
+                                  .read(sharedSearchFormProvider.notifier)
+                                  .setMaquina(v);
+                              setState(() => _maquinaSel = v);
+                            },
                             validator: (v) =>
                                 (v == null || v.isEmpty) ? 'Obrigatório' : null,
                           ),

--- a/lib/features/shared/providers/search_flow_form_provider.dart
+++ b/lib/features/shared/providers/search_flow_form_provider.dart
@@ -1,0 +1,113 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class SharedSearchFormState {
+  const SharedSearchFormState({
+    this.isActive = false,
+    this.os = '',
+    this.partNumber = '',
+    this.operacao = '',
+    this.categoria,
+    this.maquina,
+  });
+
+  final bool isActive;
+  final String os;
+  final String partNumber;
+  final String operacao;
+  final String? categoria;
+  final String? maquina;
+
+  static const _sentinel = Object();
+
+  SharedSearchFormState copyWith({
+    bool? isActive,
+    String? os,
+    String? partNumber,
+    String? operacao,
+    Object? categoria = _sentinel,
+    Object? maquina = _sentinel,
+  }) {
+    return SharedSearchFormState(
+      isActive: isActive ?? this.isActive,
+      os: os ?? this.os,
+      partNumber: partNumber ?? this.partNumber,
+      operacao: operacao ?? this.operacao,
+      categoria: categoria == _sentinel ? this.categoria : categoria as String?,
+      maquina: maquina == _sentinel ? this.maquina : maquina as String?,
+    );
+  }
+}
+
+class SharedSearchFormController extends StateNotifier<SharedSearchFormState> {
+  SharedSearchFormController() : super(const SharedSearchFormState());
+
+  bool get _isActive => state.isActive;
+
+  void beginFlow({
+    required String os,
+    required String partNumber,
+    required String operacao,
+    String? categoria,
+    String? maquina,
+  }) {
+    String? normalizeOptional(String? value) {
+      final trimmed = value?.trim();
+      if (trimmed == null || trimmed.isEmpty) return null;
+      return trimmed;
+    }
+
+    state = SharedSearchFormState(
+      isActive: true,
+      os: os.trim(),
+      partNumber: partNumber.trim(),
+      operacao: operacao.trim(),
+      categoria: normalizeOptional(categoria),
+      maquina: normalizeOptional(maquina),
+    );
+  }
+
+  void setOs(String value) {
+    if (_isActive == false) return;
+    final trimmed = value.trim();
+    if (trimmed == state.os) return;
+    state = state.copyWith(os: trimmed);
+  }
+
+  void setPartNumber(String value) {
+    if (_isActive == false) return;
+    final trimmed = value.trim();
+    if (trimmed == state.partNumber) return;
+    state = state.copyWith(partNumber: trimmed);
+  }
+
+  void setOperacao(String value) {
+    if (_isActive == false) return;
+    final trimmed = value.trim();
+    if (trimmed == state.operacao) return;
+    state = state.copyWith(operacao: trimmed);
+  }
+
+  void setCategoria(String? categoria) {
+    if (_isActive == false) return;
+    if (categoria == state.categoria) return;
+    state = state.copyWith(
+      categoria: categoria,
+      maquina: categoria == state.categoria ? state.maquina : null,
+    );
+  }
+
+  void setMaquina(String? maquina) {
+    if (_isActive == false) return;
+    if (maquina == state.maquina) return;
+    state = state.copyWith(maquina: maquina);
+  }
+
+  void clear() {
+    state = const SharedSearchFormState();
+  }
+}
+
+final sharedSearchFormProvider =
+    StateNotifierProvider<SharedSearchFormController, SharedSearchFormState>(
+      (ref) => SharedSearchFormController(),
+    );

--- a/lib/screens/main/components/side_menu.dart
+++ b/lib/screens/main/components/side_menu.dart
@@ -16,6 +16,7 @@ import 'package:admin/features/login/login_page.dart';
 import 'package:admin/features/users/users_page.dart';
 import 'package:admin/services/auth_service.dart';
 import 'package:admin/screens/main/main_screen.dart';
+import 'package:admin/features/shared/providers/search_flow_form_provider.dart';
 
 enum SideMenuSection { mainMenu, dashboard, preparador, operador, finalizar }
 
@@ -24,18 +25,20 @@ class SideMenu extends ConsumerWidget {
 
   final SideMenuSection current;
 
-  void _navigate(BuildContext context, Widget page) {
+  void _navigate(BuildContext context, WidgetRef ref, Widget page) {
     final navigator = Navigator.of(context, rootNavigator: true);
     navigator.pop();
     WidgetsBinding.instance.addPostFrameCallback((_) {
+      ref.read(sharedSearchFormProvider.notifier).clear();
       navigator.push(MaterialPageRoute(builder: (_) => page));
     });
   }
 
-  void _goHome(BuildContext context) {
+  void _goHome(BuildContext context, WidgetRef ref) {
     final navigator = Navigator.of(context, rootNavigator: true);
     navigator.pop();
     WidgetsBinding.instance.addPostFrameCallback((_) {
+      ref.read(sharedSearchFormProvider.notifier).clear();
       navigator.popUntil((route) => route.isFirst);
     });
   }
@@ -46,7 +49,7 @@ class SideMenu extends ConsumerWidget {
       DrawerListTile(
         title: 'Menu Principal',
         svgSrc: 'assets/icons/menu_dashboard.svg',
-        press: () => _goHome(context),
+        press: () => _goHome(context, ref),
       ),
     ];
 
@@ -55,17 +58,18 @@ class SideMenu extends ConsumerWidget {
         DrawerListTile(
           title: 'Exportar relatórios',
           svgSrc: 'assets/icons/menu_doc.svg',
-          press: () => _navigate(context, const ExportRelatoriosPage()),
+          press: () => _navigate(context, ref, const ExportRelatoriosPage()),
         ),
         DrawerListTile(
           title: 'Visualizar relatórios',
           svgSrc: 'assets/icons/menu_doc.svg',
-          press: () => _navigate(context, const VisualizarRelatoriosPage()),
+          press: () =>
+              _navigate(context, ref, const VisualizarRelatoriosPage()),
         ),
         DrawerListTile(
           title: 'Tempo por OS',
           svgSrc: 'assets/icons/menu_doc.svg',
-          press: () => _navigate(context, const TempoOsPage()),
+          press: () => _navigate(context, ref, const TempoOsPage()),
         ),
       ]);
     }
@@ -76,22 +80,23 @@ class SideMenu extends ConsumerWidget {
           DrawerListTile(
             title: 'Cadastro/Edição de itens',
             svgSrc: 'assets/icons/menu_store.svg',
-            press: () => _navigate(context, const CadastroItensPage()),
+            press: () => _navigate(context, ref, const CadastroItensPage()),
           ),
           DrawerListTile(
             title: 'Cadastro de Preparadores',
             svgSrc: 'assets/icons/menu_profile.svg',
-            press: () => _navigate(context, const CadastroPreparadoresPage()),
+            press: () =>
+                _navigate(context, ref, const CadastroPreparadoresPage()),
           ),
           DrawerListTile(
             title: 'Cadastro de Máquinas',
             svgSrc: 'assets/icons/menu_setting.svg',
-            press: () => _navigate(context, CadastroMaquinasPage()),
+            press: () => _navigate(context, ref, CadastroMaquinasPage()),
           ),
           DrawerListTile(
             title: 'Gerenciar Acessos',
             svgSrc: 'assets/icons/menu_profile.svg',
-            press: () => _navigate(context, const UsersPage()),
+            press: () => _navigate(context, ref, const UsersPage()),
           ),
         ]);
         break;
@@ -100,12 +105,12 @@ class SideMenu extends ConsumerWidget {
           DrawerListTile(
             title: 'Operador',
             svgSrc: 'assets/icons/menu_profile.svg',
-            press: () => _navigate(context, const OperadorPage()),
+            press: () => _navigate(context, ref, const OperadorPage()),
           ),
           DrawerListTile(
             title: 'Finalizar OS',
             svgSrc: 'assets/icons/menu_doc.svg',
-            press: () => _navigate(context, const FinalizarOsPage()),
+            press: () => _navigate(context, ref, const FinalizarOsPage()),
           ),
         ]);
         break;
@@ -114,12 +119,12 @@ class SideMenu extends ConsumerWidget {
           DrawerListTile(
             title: 'Preparador',
             svgSrc: 'assets/icons/menu_setting.svg',
-            press: () => _navigate(context, const PreparacaoPage()),
+            press: () => _navigate(context, ref, const PreparacaoPage()),
           ),
           DrawerListTile(
             title: 'Finalizar OS',
             svgSrc: 'assets/icons/menu_doc.svg',
-            press: () => _navigate(context, const FinalizarOsPage()),
+            press: () => _navigate(context, ref, const FinalizarOsPage()),
           ),
         ]);
         break;
@@ -128,12 +133,12 @@ class SideMenu extends ConsumerWidget {
           DrawerListTile(
             title: 'Preparador',
             svgSrc: 'assets/icons/menu_setting.svg',
-            press: () => _navigate(context, const PreparacaoPage()),
+            press: () => _navigate(context, ref, const PreparacaoPage()),
           ),
           DrawerListTile(
             title: 'Operador',
             svgSrc: 'assets/icons/menu_profile.svg',
-            press: () => _navigate(context, const OperadorPage()),
+            press: () => _navigate(context, ref, const OperadorPage()),
           ),
         ]);
         break;
@@ -142,17 +147,17 @@ class SideMenu extends ConsumerWidget {
           DrawerListTile(
             title: 'Preparador',
             svgSrc: 'assets/icons/menu_setting.svg',
-            press: () => _navigate(context, const PreparacaoPage()),
+            press: () => _navigate(context, ref, const PreparacaoPage()),
           ),
           DrawerListTile(
             title: 'Operador',
             svgSrc: 'assets/icons/menu_profile.svg',
-            press: () => _navigate(context, const OperadorPage()),
+            press: () => _navigate(context, ref, const OperadorPage()),
           ),
           DrawerListTile(
             title: 'Finalizar OS',
             svgSrc: 'assets/icons/menu_doc.svg',
-            press: () => _navigate(context, const FinalizarOsPage()),
+            press: () => _navigate(context, ref, const FinalizarOsPage()),
           ),
           DrawerListTile(
             title: 'Supervisão',
@@ -174,7 +179,7 @@ class SideMenu extends ConsumerWidget {
                 );
                 return;
               }
-              _navigate(context, MainScreen());
+              _navigate(context, ref, MainScreen());
             },
           ),
         ]);
@@ -187,8 +192,7 @@ class SideMenu extends ConsumerWidget {
             padding: const EdgeInsets.symmetric(vertical: 10),
             alignment: Alignment.center,
             child: SizedBox(
-              width: 150
-              ,
+              width: 150,
               height: 75,
               child: SvgPicture.asset(
                 'assets/icons/Reliclimpo.svg',


### PR DESCRIPTION
## Summary
- add an active flag and `beginFlow` helper to the shared search form controller so we only persist data when the guided flow is running
- preload Preparação, Operador and Finalizar OS fields only when a flow is active, automatically pushing the next page on successful submissions and carrying the search data forward
- clear the shared state when the flow ends or when pages are opened manually via the main menu or side menu to keep manual forms empty

## Testing
- flutter analyze *(emits existing Flutter deprecation warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68cd88921f788331bc434384662fa734