### PR TITLE
Show rosca status chips and instrument info on FOR07 screens

### DIFF
--- a/lib/features/finalizar_os/presentation/finalizar_os_page.dart
+++ b/lib/features/finalizar_os/presentation/finalizar_os_page.dart
@@ -15,6 +15,7 @@ import 'package:admin/utils/string_utils.dart';
 import 'package:admin/services/machine_service.dart';
 import 'package:admin/models/machine.dart';
 import 'package:admin/features/shared/providers/search_flow_form_provider.dart';
+import 'package:admin/features/operador/presentation/widgets/measurement_tile.dart';
 
 /// Mesmo base URL usado no Operador
 const String kBaseUrl = 'http://192.168.0.241:5005';
@@ -639,14 +640,15 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
                       separatorBuilder: (_, __) => const SizedBox(height: 8),
                       itemBuilder: (context, index) {
                         final item = list[index];
-                        return _MeasurementTilePrep(
+                        return MeasurementTile(
                           index: index,
                           item: item,
-                          onChanged: (status, valor) => ref
+                          manualEntry: true,
+                          onSelect: (status, medicao) => ref
                               .read(
                                 medidasFinalizadorControllerProvider.notifier,
                               )
-                              .setStatusAndMedicao(index, status, valor),
+                              .setStatusAndMedicao(index, status, medicao),
                         );
                       },
                     );
@@ -674,169 +676,6 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
               ),
             ],
           ),
-        ),
-      ),
-    );
-  }
-}
-
-class _MeasurementTilePrep extends StatefulWidget {
-  final int index;
-  final MedidaItem item;
-  final void Function(StatusMedida status, String valor) onChanged;
-
-  const _MeasurementTilePrep({
-    required this.index,
-    required this.item,
-    required this.onChanged,
-  });
-
-  @override
-  State<_MeasurementTilePrep> createState() => _MeasurementTilePrepState();
-}
-
-class _MeasurementTilePrepState extends State<_MeasurementTilePrep> {
-  final _ctrl = TextEditingController();
-
-  @override
-  void initState() {
-    super.initState();
-    _setTextFromParent(widget.item.medicao);
-  }
-
-  @override
-  void didUpdateWidget(covariant _MeasurementTilePrep oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    // só atualiza o controller quando o valor vindo do pai REALMENTE mudou
-    if (oldWidget.item.medicao != widget.item.medicao) {
-      _setTextFromParent(widget.item.medicao);
-    }
-  }
-
-  void _setTextFromParent(String? txt) {
-    final newText = (txt ?? '');
-    if (newText == _ctrl.text)
-      return; // evita sobrescrever e mexer no cursor à toa
-    _ctrl.value = TextEditingValue(
-      text: newText,
-      // cursor no final do texto (sem selecionar tudo)
-      selection: TextSelection.collapsed(offset: newText.length),
-      composing: TextRange.empty,
-    );
-  }
-
-  @override
-  void dispose() {
-    _ctrl.dispose();
-    super.dispose();
-  }
-
-  double? _toDouble(String? s) {
-    if (s == null || s.trim().isEmpty) return null;
-    return double.tryParse(s.replaceAll(',', '.'));
-  }
-
-  StatusMedida _classifica(double? v, double? min, double? max) {
-    if (v == null) return StatusMedida.pendente;
-    if (min != null && v < min) return StatusMedida.reprovadaAbaixo;
-    if (max != null && v > max) return StatusMedida.reprovadaAcima;
-    return StatusMedida.ok;
-  }
-
-  Color _statusColor(StatusMedida st) {
-    switch (st) {
-      case StatusMedida.ok:
-        return Colors.green.shade600;
-      case StatusMedida.reprovadaAbaixo:
-        return Colors.red.shade400;
-      case StatusMedida.reprovadaAcima:
-        return Colors.red.shade400;
-      case StatusMedida.alertaAbaixo:
-      case StatusMedida.alertaAcima:
-        return Colors.amber.shade700;
-      case StatusMedida.pendente:
-        return Colors.grey;
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final m = widget.item;
-
-    String subtitulo = m.faixaTexto;
-    if (subtitulo.isEmpty && (m.minimo != null || m.maximo != null)) {
-      final minStr = m.minimo?.toStringAsFixed(2) ?? '';
-      final maxStr = m.maximo?.toStringAsFixed(2) ?? '';
-      final uni = (m.unidade ?? '').isNotEmpty ? ' ${m.unidade}' : '';
-      if (minStr.isNotEmpty && maxStr.isNotEmpty) {
-        subtitulo = '$minStr – $maxStr$uni';
-      } else if (minStr.isNotEmpty) {
-        subtitulo = '≥ $minStr$uni';
-      } else if (maxStr.isNotEmpty) {
-        subtitulo = '≤ $maxStr$uni';
-      }
-    }
-
-    final vNum = _toDouble(_ctrl.text);
-    final st = _classifica(vNum, m.minimo, m.maximo);
-
-    return Card(
-      elevation: 0.5,
-      child: Padding(
-        padding: const EdgeInsets.all(12.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              children: [
-                Container(
-                  width: 10,
-                  height: 10,
-                  decoration: BoxDecoration(
-                    color: _statusColor(st),
-                    shape: BoxShape.circle,
-                  ),
-                ),
-                const SizedBox(width: 8),
-                Expanded(
-                  child: Text(
-                    m.titulo.isEmpty ? '(sem título)' : m.titulo,
-                    style: Theme.of(context).textTheme.titleMedium,
-                  ),
-                ),
-              ],
-            ),
-            if (subtitulo.isNotEmpty) ...[
-              const SizedBox(height: 4),
-              Text(subtitulo, style: Theme.of(context).textTheme.bodyMedium),
-            ],
-            const SizedBox(height: 10),
-            TextField(
-              controller: _ctrl,
-              keyboardType: const TextInputType.numberWithOptions(
-                decimal: true,
-                signed: false,
-              ),
-              decoration: InputDecoration(
-                labelText: 'Medição (${m.unidade ?? ''})',
-                border: const OutlineInputBorder(),
-                helperText: st == StatusMedida.ok
-                    ? 'Dentro da tolerância'
-                    : st == StatusMedida.pendente
-                    ? 'Preencha o valor para classificar'
-                    : (st == StatusMedida.reprovadaAbaixo
-                          ? 'Abaixo do mínimo'
-                          : 'Acima do máximo'),
-                helperStyle: TextStyle(color: _statusColor(st)),
-              ),
-              onChanged: (txt) {
-                final v = _toDouble(txt);
-                final novoStatus = _classifica(v, m.minimo, m.maximo);
-                widget.onChanged(novoStatus, txt);
-                setState(() {});
-              },
-            ),
-          ],
         ),
       ),
     );

--- a/lib/features/operador/presentation/widgets/measurement_tile.dart
+++ b/lib/features/operador/presentation/widgets/measurement_tile.dart
@@ -22,10 +22,12 @@ class MeasurementTile extends StatefulWidget {
 
 class _MeasurementTileState extends State<MeasurementTile> {
   TextEditingController? _manualCtrl;
+  String? _roscaSelection;
 
   @override
   void initState() {
     super.initState();
+    _roscaSelection = widget.item.medicao;
     if (widget.manualEntry) {
       _manualCtrl = TextEditingController(text: widget.item.medicao ?? '');
     }
@@ -48,6 +50,10 @@ class _MeasurementTileState extends State<MeasurementTile> {
     } else if (_manualCtrl != null) {
       _manualCtrl!.dispose();
       _manualCtrl = null;
+    }
+
+    if (oldWidget.item.medicao != widget.item.medicao) {
+      _roscaSelection = widget.item.medicao;
     }
   }
 
@@ -124,6 +130,21 @@ class _MeasurementTileState extends State<MeasurementTile> {
     final inst = _norm(item.instrumento);
     return _containsAny(t, ['tamp', 'tampao', 'tampão', 'tampa']) ||
         _containsAny(inst, ['tamp', 'tampao', 'tampão', 'tampa']);
+  }
+
+  bool _stringHasRoscaPattern(String? value) {
+    if (value == null || value.trim().isEmpty) return false;
+    final normalized = _nfd(value).toLowerCase();
+    if (normalized.contains('rosca')) return true;
+    final upper = value.toUpperCase();
+    return RegExp(r'\bM\s*\d').hasMatch(upper);
+  }
+
+  bool _isRosca(MedidaItem item) {
+    return _stringHasRoscaPattern(item.titulo) ||
+        _stringHasRoscaPattern(item.instrumento) ||
+        _stringHasRoscaPattern(item.observacao) ||
+        _stringHasRoscaPattern(item.faixaTexto);
   }
 
   Set<String> _partsFromMedicao(String? medicao) => (medicao ?? '')
@@ -259,19 +280,44 @@ class _MeasurementTileState extends State<MeasurementTile> {
     }
   }
 
+  String _roscaHelper(StatusMedida st) {
+    switch (st) {
+      case StatusMedida.ok:
+        return 'Resultado aprovado';
+      case StatusMedida.reprovadaAbaixo:
+      case StatusMedida.reprovadaAcima:
+        return 'Resultado reprovado';
+      case StatusMedida.alertaAbaixo:
+      case StatusMedida.alertaAcima:
+        return 'Resultado fora da tolerância';
+      case StatusMedida.pendente:
+        return 'Selecione o resultado';
+    }
+  }
+
   Widget _buildManualEntry(BuildContext context) {
     final item = widget.item;
+    final isRosca = _isRosca(item);
     final ctrl = _manualCtrl ??= TextEditingController(
       text: item.medicao ?? '',
     );
-    final valor = _parseManualValue(ctrl.text);
-    final status = item.avaliarStatus(valor);
+    final roscaSelection = (_roscaSelection ?? item.medicao ?? '')
+        .trim()
+        .toLowerCase();
+    final valor = isRosca ? null : _parseManualValue(ctrl.text);
+    final status = isRosca
+        ? (roscaSelection == 'aprovado'
+              ? StatusMedida.ok
+              : roscaSelection == 'reprovado'
+              ? StatusMedida.reprovadaAcima
+              : StatusMedida.pendente)
+        : item.avaliarStatus(valor);
     final theme = Theme.of(context);
     final subtitulo = _subtitleFor(item);
     final unidadeLabel = (item.unidade ?? '').isNotEmpty
         ? ' (${item.unidade})'
         : '';
-    final helper = _statusHelper(status);
+    final helper = isRosca ? _roscaHelper(status) : _statusHelper(status);
     final helperColor = _statusColor(status);
 
     return Card(
@@ -319,25 +365,63 @@ class _MeasurementTileState extends State<MeasurementTile> {
               ),
             ],
             const SizedBox(height: 10),
-            TextField(
-              controller: ctrl,
-              keyboardType: const TextInputType.numberWithOptions(
-                decimal: true,
-                signed: false,
+            if (isRosca) ...[
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: [
+                  _pill(
+                    text: 'Aprovado',
+                    bg: Colors.green.shade200,
+                    border: Colors.green.shade600,
+                    fg: Colors.green.shade900,
+                    selected: roscaSelection == 'aprovado',
+                    onTap: () {
+                      FocusScope.of(context).unfocus();
+                      setState(() {
+                        _roscaSelection = 'Aprovado';
+                      });
+                      widget.onSelect(StatusMedida.ok, 'Aprovado');
+                    },
+                  ),
+                  _pill(
+                    text: 'Reprovado',
+                    bg: Colors.red.shade100,
+                    border: Colors.red.shade400,
+                    selected: roscaSelection == 'reprovado',
+                    onTap: () {
+                      FocusScope.of(context).unfocus();
+                      setState(() {
+                        _roscaSelection = 'Reprovado';
+                      });
+                      widget.onSelect(StatusMedida.reprovadaAcima, 'Reprovado');
+                    },
+                  ),
+                ],
               ),
-              decoration: InputDecoration(
-                labelText: 'Medição$unidadeLabel',
-                border: const OutlineInputBorder(),
-                helperText: helper,
-                helperStyle: TextStyle(color: helperColor),
+              const SizedBox(height: 6),
+              Text(helper, style: TextStyle(color: helperColor)),
+            ] else ...[
+              TextField(
+                controller: ctrl,
+                keyboardType: const TextInputType.numberWithOptions(
+                  decimal: true,
+                  signed: false,
+                ),
+                decoration: InputDecoration(
+                  labelText: 'Medição$unidadeLabel',
+                  border: const OutlineInputBorder(),
+                  helperText: helper,
+                  helperStyle: TextStyle(color: helperColor),
+                ),
+                onChanged: (txt) {
+                  final v = _parseManualValue(txt);
+                  final novoStatus = item.avaliarStatus(v);
+                  widget.onSelect(novoStatus, txt);
+                  setState(() {});
+                },
               ),
-              onChanged: (txt) {
-                final v = _parseManualValue(txt);
-                final novoStatus = item.avaliarStatus(v);
-                widget.onSelect(novoStatus, txt);
-                setState(() {});
-              },
-            ),
+            ],
           ],
         ),
       ),

--- a/lib/features/preparacao/presentation/preparacao_page.dart
+++ b/lib/features/preparacao/presentation/preparacao_page.dart
@@ -10,6 +10,7 @@ import 'package:http/http.dart' as http;
 import 'package:admin/features/preparacao/data/models.dart';
 import 'package:admin/features/operador/data/repository_provider.dart';
 import 'package:admin/features/operador/presentation/operador_page.dart';
+import 'package:admin/features/operador/presentation/widgets/measurement_tile.dart';
 import 'package:admin/features/shared/providers/search_flow_form_provider.dart';
 import 'package:admin/screens/main/components/side_menu.dart';
 import 'package:admin/widgets/window_bar.dart';
@@ -658,14 +659,15 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
                       separatorBuilder: (_, __) => const SizedBox(height: 8),
                       itemBuilder: (context, index) {
                         final item = list[index];
-                        return _MeasurementTilePrep(
+                        return MeasurementTile(
                           index: index,
                           item: item,
-                          onChanged: (status, valor) => ref
+                          manualEntry: true,
+                          onSelect: (status, medicao) => ref
                               .read(
                                 medidasPreparadorControllerProvider.notifier,
                               )
-                              .setStatusAndMedicao(index, status, valor),
+                              .setStatusAndMedicao(index, status, medicao),
                         );
                       },
                     );
@@ -693,169 +695,6 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
               ),
             ],
           ),
-        ),
-      ),
-    );
-  }
-}
-
-class _MeasurementTilePrep extends StatefulWidget {
-  final int index;
-  final MedidaItem item;
-  final void Function(StatusMedida status, String valor) onChanged;
-
-  const _MeasurementTilePrep({
-    required this.index,
-    required this.item,
-    required this.onChanged,
-  });
-
-  @override
-  State<_MeasurementTilePrep> createState() => _MeasurementTilePrepState();
-}
-
-class _MeasurementTilePrepState extends State<_MeasurementTilePrep> {
-  final _ctrl = TextEditingController();
-
-  @override
-  void initState() {
-    super.initState();
-    _setTextFromParent(widget.item.medicao);
-  }
-
-  @override
-  void didUpdateWidget(covariant _MeasurementTilePrep oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    // só atualiza o controller quando o valor vindo do pai REALMENTE mudou
-    if (oldWidget.item.medicao != widget.item.medicao) {
-      _setTextFromParent(widget.item.medicao);
-    }
-  }
-
-  void _setTextFromParent(String? txt) {
-    final newText = (txt ?? '');
-    if (newText == _ctrl.text)
-      return; // evita sobrescrever e mexer no cursor à toa
-    _ctrl.value = TextEditingValue(
-      text: newText,
-      // cursor no final do texto (sem selecionar tudo)
-      selection: TextSelection.collapsed(offset: newText.length),
-      composing: TextRange.empty,
-    );
-  }
-
-  @override
-  void dispose() {
-    _ctrl.dispose();
-    super.dispose();
-  }
-
-  double? _toDouble(String? s) {
-    if (s == null || s.trim().isEmpty) return null;
-    return double.tryParse(s.replaceAll(',', '.'));
-  }
-
-  StatusMedida _classifica(double? v, double? min, double? max) {
-    if (v == null) return StatusMedida.pendente;
-    if (min != null && v < min) return StatusMedida.reprovadaAbaixo;
-    if (max != null && v > max) return StatusMedida.reprovadaAcima;
-    return StatusMedida.ok;
-  }
-
-  Color _statusColor(StatusMedida st) {
-    switch (st) {
-      case StatusMedida.ok:
-        return Colors.green.shade600;
-      case StatusMedida.reprovadaAbaixo:
-        return Colors.red.shade400;
-      case StatusMedida.reprovadaAcima:
-        return Colors.red.shade400;
-      case StatusMedida.alertaAbaixo:
-      case StatusMedida.alertaAcima:
-        return Colors.amber.shade700;
-      case StatusMedida.pendente:
-        return Colors.grey;
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final m = widget.item;
-
-    String subtitulo = m.faixaTexto;
-    if (subtitulo.isEmpty && (m.minimo != null || m.maximo != null)) {
-      final minStr = m.minimo?.toStringAsFixed(2) ?? '';
-      final maxStr = m.maximo?.toStringAsFixed(2) ?? '';
-      final uni = (m.unidade ?? '').isNotEmpty ? ' ${m.unidade}' : '';
-      if (minStr.isNotEmpty && maxStr.isNotEmpty) {
-        subtitulo = '$minStr – $maxStr$uni';
-      } else if (minStr.isNotEmpty) {
-        subtitulo = '≥ $minStr$uni';
-      } else if (maxStr.isNotEmpty) {
-        subtitulo = '≤ $maxStr$uni';
-      }
-    }
-
-    final vNum = _toDouble(_ctrl.text);
-    final st = _classifica(vNum, m.minimo, m.maximo);
-
-    return Card(
-      elevation: 0.5,
-      child: Padding(
-        padding: const EdgeInsets.all(12.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              children: [
-                Container(
-                  width: 10,
-                  height: 10,
-                  decoration: BoxDecoration(
-                    color: _statusColor(st),
-                    shape: BoxShape.circle,
-                  ),
-                ),
-                const SizedBox(width: 8),
-                Expanded(
-                  child: Text(
-                    m.titulo.isEmpty ? '(sem título)' : m.titulo,
-                    style: Theme.of(context).textTheme.titleMedium,
-                  ),
-                ),
-              ],
-            ),
-            if (subtitulo.isNotEmpty) ...[
-              const SizedBox(height: 4),
-              Text(subtitulo, style: Theme.of(context).textTheme.bodyMedium),
-            ],
-            const SizedBox(height: 10),
-            TextField(
-              controller: _ctrl,
-              keyboardType: const TextInputType.numberWithOptions(
-                decimal: true,
-                signed: false,
-              ),
-              decoration: InputDecoration(
-                labelText: 'Medição (${m.unidade ?? ''})',
-                border: const OutlineInputBorder(),
-                helperText: st == StatusMedida.ok
-                    ? 'Dentro da tolerância'
-                    : st == StatusMedida.pendente
-                    ? 'Preencha o valor para classificar'
-                    : (st == StatusMedida.reprovadaAbaixo
-                          ? 'Abaixo do mínimo'
-                          : 'Acima do máximo'),
-                helperStyle: TextStyle(color: _statusColor(st)),
-              ),
-              onChanged: (txt) {
-                final v = _toDouble(txt);
-                final novoStatus = _classifica(v, m.minimo, m.maximo);
-                widget.onChanged(novoStatus, txt);
-                setState(() {});
-              },
-            ),
-          ],
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- reuse the shared MeasurementTile widget on the FOR07 preparation and finalization lists so that periodicity and instrument metadata remain visible
- extend the manual-entry MeasurementTile to detect rosca measurements and replace the numeric field with Aprovado/Reprovado chips
- track the rosca selection locally so the status indicator updates immediately and keep delegating persistence through the existing callbacks

## Testing
- flutter analyze

------
https://chatgpt.com/codex/tasks/task_e_68cd9d2ffb2483319180ae0a73388b6d