### PR TITLE
Ajusta detecção de rosca com instrumento Anel de Rosca

### DIFF
--- a/lib/features/operador/presentation/widgets/measurement_tile.dart
+++ b/lib/features/operador/presentation/widgets/measurement_tile.dart
@@ -109,6 +109,8 @@ class _MeasurementTileState extends State<MeasurementTile> {
           'visual',
           'rug',
           'paralelismo',
+          'anel de rosca',
+          'anel rosca',
           'anel de rosca passa',
           'cqf',
           'simetria',
@@ -119,6 +121,8 @@ class _MeasurementTileState extends State<MeasurementTile> {
           'rug',
           'rugosimetro',
           'paralelismo',
+          'anel de rosca',
+          'anel rosca',
           'anel de rosca passa',
           'cqf',
           'simetria',
@@ -141,7 +145,8 @@ class _MeasurementTileState extends State<MeasurementTile> {
   }
 
   bool _isRosca(MedidaItem item) {
-    return _stringHasRoscaPattern(item.titulo);
+    return _stringHasRoscaPattern(item.titulo) ||
+        _stringHasRoscaPattern(item.instrumento);
   }
 
   Set<String> _partsFromMedicao(String? medicao) => (medicao ?? '')


### PR DESCRIPTION
## Resumo
- amplia a detecção de medições de rosca ao considerar o instrumento informado
- trata instrumentos "anel de rosca" como medições de aprovação/reprovação na listagem do operador

## Testes
- flutter analyze

------
https://chatgpt.com/codex/tasks/task_e_68d133b6a35483318ffca34570a0d835