### PR TITLE
feat: show sampling option counters

### DIFF
--- a/app_db.py
+++ b/app_db.py
@@ -3,6 +3,7 @@ from flask import Flask, request, jsonify, send_file
 from flask_cors import CORS
 from pathlib import Path
 from typing import Optional, Tuple
+from collections import defaultdict
 import os
 import re
 import json
@@ -695,6 +696,7 @@ def _medidas_operador_db(part: str, op: str):
     part = _norm_part(part)
     op = _norm_op(op)
     rows = []
+    contagens_rows = []
     with _conn_db(DB_NAME) as c:
         with c.cursor() as cur:
             cur.execute(
@@ -711,8 +713,38 @@ def _medidas_operador_db(part: str, op: str):
                 (part, op),
             )
             rows = cur.fetchall()
+        with c.cursor() as cur:
+            cur.execute(
+                """
+                SELECT i.idx_medida,
+                       i.escolha,
+                       COUNT(*) AS qtd
+                  FROM operador_amostragem_item i
+                  JOIN operador_amostragem a ON a.id = i.amostragem_id
+                 WHERE TRIM(LEADING '0' FROM TRIM(a.partnumber))=%s
+                   AND TRIM(LEADING '0' FROM TRIM(a.operacao))=%s
+                 GROUP BY i.idx_medida, i.escolha
+                """,
+                (part, op),
+            )
+            contagens_rows = cur.fetchall()
+
+    contagens_por_indice = defaultdict(lambda: defaultdict(int))
+    for cnt in contagens_rows:
+        idx = cnt.get("idx_medida")
+        escolha = (cnt.get("escolha") or "").strip()
+        qtd = int(cnt.get("qtd") or 0)
+        if idx is None or not escolha or qtd <= 0:
+            continue
+        partes = [p.strip() for p in escolha.split("|") if p.strip()]
+        if not partes:
+            partes = [escolha]
+        for parte in partes:
+            contagens_por_indice[idx][parte] += qtd
+
     medidas = []
     for row in rows:
+        idx = row.get("idx_medida")
         titulo = row.get("titulo") or ""
         faixa = row.get("faixa_texto") or ""
         mn = row.get("minimo")
@@ -739,6 +771,7 @@ def _medidas_operador_db(part: str, op: str):
             row.get("reprovada_acima"),
         ]
         tolerancias = [t for t in tolerancias if t is not None]
+        raw_counts = contagens_por_indice.get(idx) or {}
         medidas.append(
             {
                 "titulo": titulo,
@@ -749,6 +782,7 @@ def _medidas_operador_db(part: str, op: str):
                 "periodicidade": row.get("periodicidade") or "",
                 "instrumento": row.get("instrumento") or "",
                 "tolerancias": tolerancias,
+                "contagens": {k: int(v) for k, v in raw_counts.items()},
             }
         )
     return medidas

--- a/lib/features/finalizar_os/presentation/finalizar_os_page.dart
+++ b/lib/features/finalizar_os/presentation/finalizar_os_page.dart
@@ -67,6 +67,7 @@ class MedidasFinalizadorController
               periodicidade: m.periodicidade,
               instrumento: m.instrumento,
               tolerancias: m.tolerancias,
+              contagens: m.contagens,
             ),
           )
           .toList();
@@ -93,6 +94,7 @@ class MedidasFinalizadorController
       periodicidade: old.periodicidade,
       instrumento: old.instrumento,
       tolerancias: old.tolerancias,
+      contagens: old.contagens,
     );
     state = AsyncValue.data(current);
   }
@@ -113,6 +115,7 @@ class MedidasFinalizadorController
         periodicidade: old.periodicidade,
         instrumento: old.instrumento,
         tolerancias: old.tolerancias,
+        contagens: old.contagens,
       );
     }
     state = AsyncValue.data(current);

--- a/lib/features/operador/data/models.dart
+++ b/lib/features/operador/data/models.dart
@@ -87,6 +87,7 @@ class MedidaItem {
 
   /// Rótulos de tolerância (até 4) vindos do backend do Operador (AE/AF/AG/AH...).
   final List<String> tolerancias;
+  final Map<String, int> contagens;
 
   MedidaItem({
     required this.titulo,
@@ -100,7 +101,8 @@ class MedidaItem {
     this.periodicidade,
     this.instrumento,
     this.tolerancias = const [],
-  });
+    Map<String, int>? contagens,
+  }) : contagens = Map.unmodifiable(contagens ?? const {});
 
   /// Avalia um valor numérico contra os limites.
   /// - Se só houver `minimo`, reprova **abaixo** do mínimo.
@@ -286,6 +288,26 @@ class MedidaItem {
         ? (map['tolerancias'] as List).map((e) => e.toString()).toList()
         : const <String>[];
 
+    final rawCounts = map['contagens'];
+    final counts = <String, int>{};
+    if (rawCounts is Map) {
+      rawCounts.forEach((key, value) {
+        if (key == null) return;
+        final label = key.toString();
+        if (label.isEmpty) return;
+        int? parsed;
+        final v = value;
+        if (v is num) {
+          parsed = v.toInt();
+        } else {
+          parsed = int.tryParse(v.toString());
+        }
+        if (parsed != null && parsed >= 0) {
+          counts[label] = parsed;
+        }
+      });
+    }
+
     return MedidaItem(
       titulo: titulo,
       faixaTexto: faixaOut,
@@ -298,6 +320,7 @@ class MedidaItem {
       periodicidade: map['periodicidade']?.toString(),
       instrumento: map['instrumento']?.toString(),
       tolerancias: tol,
+      contagens: counts,
     );
   }
 
@@ -313,6 +336,7 @@ class MedidaItem {
     'periodicidade': periodicidade,
     'instrumento': instrumento,
     'tolerancias': tolerancias,
+    'contagens': contagens,
   };
 }
 

--- a/lib/features/operador/presentation/operador_page.dart
+++ b/lib/features/operador/presentation/operador_page.dart
@@ -69,6 +69,7 @@ class MedidasOperadorController
       periodicidade: old.periodicidade,
       instrumento: old.instrumento,
       tolerancias: old.tolerancias,
+      contagens: old.contagens,
     );
     state = AsyncValue.data(current);
   }
@@ -90,6 +91,50 @@ class MedidasOperadorController
         periodicidade: old.periodicidade,
         instrumento: old.instrumento,
         tolerancias: old.tolerancias,
+        contagens: old.contagens,
+      );
+    }
+    state = AsyncValue.data(current);
+  }
+
+  /// Após um registro bem-sucedido, incrementa as contagens com base nas
+  /// medições selecionadas e reseta os campos para nova entrada.
+  void aplicarSelecoesComoHistorico() {
+    final current = [...(state.value ?? const <MedidaItem>[])];
+    for (var i = 0; i < current.length; i++) {
+      final old = current[i];
+      final counts = Map<String, int>.from(old.contagens);
+      final raw = old.medicao ?? '';
+      final partes = raw
+          .split('|')
+          .map((p) => p.trim())
+          .where((p) => p.isNotEmpty)
+          .toList();
+      if (partes.isEmpty) {
+        // Para medições numéricas simples, `medicao` já é o valor escolhido.
+        final label = raw.trim();
+        if (label.isNotEmpty) {
+          counts[label] = (counts[label] ?? 0) + 1;
+        }
+      } else {
+        for (final parte in partes) {
+          counts[parte] = (counts[parte] ?? 0) + 1;
+        }
+      }
+
+      current[i] = MedidaItem(
+        titulo: old.titulo,
+        faixaTexto: old.faixaTexto,
+        minimo: old.minimo,
+        maximo: old.maximo,
+        unidade: old.unidade,
+        status: StatusMedida.pendente,
+        medicao: null,
+        observacao: old.observacao,
+        periodicidade: old.periodicidade,
+        instrumento: old.instrumento,
+        tolerancias: old.tolerancias,
+        contagens: counts,
       );
     }
     state = AsyncValue.data(current);
@@ -311,7 +356,9 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
           const SnackBar(content: Text('Amostragem registrada com sucesso!')),
         );
         // Limpa seleções, mantém lista
-        ref.read(medidasOperadorControllerProvider.notifier).resetSelecoes();
+        ref
+            .read(medidasOperadorControllerProvider.notifier)
+            .aplicarSelecoesComoHistorico();
       } else {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(

--- a/lib/features/operador/presentation/troca_ferramenta_page.dart
+++ b/lib/features/operador/presentation/troca_ferramenta_page.dart
@@ -142,6 +142,7 @@ class _TrocaFerramentaPageState extends State<TrocaFerramentaPage> {
         periodicidade: item.periodicidade,
         instrumento: item.instrumento,
         tolerancias: item.tolerancias,
+        contagens: item.contagens,
       );
     }).toList();
 
@@ -167,6 +168,7 @@ class _TrocaFerramentaPageState extends State<TrocaFerramentaPage> {
       periodicidade: antigo.periodicidade,
       instrumento: antigo.instrumento,
       tolerancias: antigo.tolerancias,
+      contagens: antigo.contagens,
     );
     setState(() {
       _medidasSelecionadas = itens;

--- a/lib/features/operador/presentation/widgets/measurement_tile.dart
+++ b/lib/features/operador/presentation/widgets/measurement_tile.dart
@@ -143,8 +143,9 @@ class _MeasurementTileState extends State<MeasurementTile> {
     if (RegExp(r'\bmicro[\s-]*metros?\b').hasMatch(normalized)) return false;
     if (RegExp(r'\banel\s*de\s*rosca\b').hasMatch(normalized)) return true;
 
-    return RegExp(r'\b(anel|cal|calib\w*|calibre\w*|galg\w*)\b')
-        .hasMatch(normalized);
+    return RegExp(
+      r'\b(anel|cal|calib\w*|calibre\w*|galg\w*)\b',
+    ).hasMatch(normalized);
   }
 
   bool _isRosca(MedidaItem item) {
@@ -195,6 +196,7 @@ class _MeasurementTileState extends State<MeasurementTile> {
     bool selected = false,
     Color? fg,
     VoidCallback? onTap,
+    int? count,
   }) {
     final baseFg = fg ?? _fgOn(bg);
     final effectiveBg = selected ? border : bg;
@@ -202,6 +204,7 @@ class _MeasurementTileState extends State<MeasurementTile> {
     final effectiveFg = selected
         ? (fg != null ? Colors.white : _fgOn(effectiveBg))
         : baseFg;
+    final displayCount = count;
     return InkWell(
       onTap: onTap,
       borderRadius: BorderRadius.circular(999),
@@ -221,8 +224,20 @@ class _MeasurementTileState extends State<MeasurementTile> {
                 ]
               : null,
         ),
-        child: Text(
-          text,
+        child: Text.rich(
+          TextSpan(
+            children: [
+              TextSpan(text: text),
+              if (displayCount != null)
+                TextSpan(
+                  text: ' ($displayCount)',
+                  style: TextStyle(
+                    fontWeight: selected ? FontWeight.w600 : FontWeight.w500,
+                    color: effectiveFg.withOpacity(0.85),
+                  ),
+                ),
+            ],
+          ),
           style: TextStyle(
             fontWeight: selected ? FontWeight.w700 : FontWeight.w600,
             color: effectiveFg,
@@ -230,6 +245,18 @@ class _MeasurementTileState extends State<MeasurementTile> {
         ),
       ),
     );
+  }
+
+  int _countFor(String label) {
+    final counts = widget.item.contagens;
+    final direct = counts[label];
+    if (direct != null) return direct;
+    final trimmed = label.trim();
+    if (trimmed != label) {
+      final trimmedCount = counts[trimmed];
+      if (trimmedCount != null) return trimmedCount;
+    }
+    return 0;
   }
 
   String _subtitleFor(MedidaItem item) {
@@ -382,6 +409,7 @@ class _MeasurementTileState extends State<MeasurementTile> {
                     border: Colors.green.shade600,
                     fg: Colors.green.shade900,
                     selected: roscaSelection == 'aprovado',
+                    count: _countFor('Aprovado'),
                     onTap: () {
                       FocusScope.of(context).unfocus();
                       setState(() {
@@ -395,6 +423,7 @@ class _MeasurementTileState extends State<MeasurementTile> {
                     bg: Colors.red.shade100,
                     border: Colors.red.shade400,
                     selected: roscaSelection == 'reprovado',
+                    count: _countFor('Reprovado'),
                     onTap: () {
                       FocusScope.of(context).unfocus();
                       setState(() {
@@ -477,6 +506,7 @@ class _MeasurementTileState extends State<MeasurementTile> {
                     border: Colors.green.shade600,
                     fg: Colors.green.shade900,
                     selected: item.medicao == 'Aprovado',
+                    count: _countFor('Aprovado'),
                     onTap: () => widget.onSelect(StatusMedida.ok, 'Aprovado'),
                   ),
                   _pill(
@@ -484,6 +514,7 @@ class _MeasurementTileState extends State<MeasurementTile> {
                     bg: Colors.red.shade100,
                     border: Colors.red.shade400,
                     selected: item.medicao == 'Reprovado',
+                    count: _countFor('Reprovado'),
                     onTap: () => widget.onSelect(
                       StatusMedida.reprovadaAcima,
                       'Reprovado',
@@ -505,6 +536,7 @@ class _MeasurementTileState extends State<MeasurementTile> {
                         border: Colors.green.shade600,
                         fg: Colors.green.shade900,
                         selected: parts.contains('Lado passa — Aprovado'),
+                        count: _countFor('Lado passa — Aprovado'),
                         onTap: () {
                           final p = _partsFromMedicao(item.medicao);
                           p.removeWhere((e) => e.startsWith('Lado passa'));
@@ -517,6 +549,7 @@ class _MeasurementTileState extends State<MeasurementTile> {
                         bg: Colors.red.shade100,
                         border: Colors.red.shade400,
                         selected: parts.contains('Lado passa — Reprovado'),
+                        count: _countFor('Lado passa — Reprovado'),
                         onTap: () {
                           final p = _partsFromMedicao(item.medicao);
                           p.removeWhere((e) => e.startsWith('Lado passa'));
@@ -530,6 +563,7 @@ class _MeasurementTileState extends State<MeasurementTile> {
                         border: Colors.green.shade600,
                         fg: Colors.green.shade900,
                         selected: parts.contains('Lado não passa — Aprovado'),
+                        count: _countFor('Lado não passa — Aprovado'),
                         onTap: () {
                           final p = _partsFromMedicao(item.medicao);
                           p.removeWhere((e) => e.startsWith('Lado não passa'));
@@ -542,6 +576,7 @@ class _MeasurementTileState extends State<MeasurementTile> {
                         bg: Colors.red.shade100,
                         border: Colors.red.shade400,
                         selected: parts.contains('Lado não passa — Reprovado'),
+                        count: _countFor('Lado não passa — Reprovado'),
                         onTap: () {
                           final p = _partsFromMedicao(item.medicao);
                           p.removeWhere((e) => e.startsWith('Lado não passa'));
@@ -601,6 +636,7 @@ class _MeasurementTileState extends State<MeasurementTile> {
                         bg: bg,
                         border: bd,
                         selected: selected,
+                        count: _countFor(label),
                         onTap: () => widget.onSelect(st, label),
                       ),
                     );
@@ -614,6 +650,7 @@ class _MeasurementTileState extends State<MeasurementTile> {
                       border: Colors.green.shade600,
                       fg: Colors.green.shade900,
                       selected: item.medicao == 'OK',
+                      count: _countFor('OK'),
                       onTap: () => widget.onSelect(StatusMedida.ok, 'OK'),
                     ),
                   );

--- a/lib/features/preparacao/data/models.dart
+++ b/lib/features/preparacao/data/models.dart
@@ -85,6 +85,7 @@ class MedidaItem {
 
   /// Rótulos de tolerância (até 4) vindos do backend do Operador (AE/AF/AG/AH...).
   final List<String> tolerancias;
+  final Map<String, int> contagens;
 
   MedidaItem({
     required this.titulo,
@@ -98,7 +99,8 @@ class MedidaItem {
     this.periodicidade,
     this.instrumento,
     this.tolerancias = const [],
-  });
+    Map<String, int>? contagens,
+  }) : contagens = Map.unmodifiable(contagens ?? const {});
 
   /// Avalia um valor numérico contra os limites.
   /// - Se só houver `minimo`, reprova **abaixo** do mínimo.
@@ -284,6 +286,26 @@ class MedidaItem {
         ? (map['tolerancias'] as List).map((e) => e.toString()).toList()
         : const <String>[];
 
+    final rawCounts = map['contagens'];
+    final counts = <String, int>{};
+    if (rawCounts is Map) {
+      rawCounts.forEach((key, value) {
+        if (key == null) return;
+        final label = key.toString();
+        if (label.isEmpty) return;
+        int? parsed;
+        final v = value;
+        if (v is num) {
+          parsed = v.toInt();
+        } else {
+          parsed = int.tryParse(v.toString());
+        }
+        if (parsed != null && parsed >= 0) {
+          counts[label] = parsed;
+        }
+      });
+    }
+
     return MedidaItem(
       titulo: titulo,
       faixaTexto: faixaOut,
@@ -296,6 +318,7 @@ class MedidaItem {
       periodicidade: map['periodicidade']?.toString(),
       instrumento: map['instrumento']?.toString(),
       tolerancias: tol,
+      contagens: counts,
     );
   }
 
@@ -311,6 +334,7 @@ class MedidaItem {
     'periodicidade': periodicidade,
     'instrumento': instrumento,
     'tolerancias': tolerancias,
+    'contagens': contagens,
   };
 }
 

--- a/lib/features/preparacao/presentation/preparacao_page.dart
+++ b/lib/features/preparacao/presentation/preparacao_page.dart
@@ -68,6 +68,7 @@ class MedidasPreparadorController
               periodicidade: m.periodicidade,
               instrumento: m.instrumento,
               tolerancias: m.tolerancias,
+              contagens: m.contagens,
             ),
           )
           .toList();
@@ -94,6 +95,7 @@ class MedidasPreparadorController
       periodicidade: old.periodicidade,
       instrumento: old.instrumento,
       tolerancias: old.tolerancias,
+      contagens: old.contagens,
     );
     state = AsyncValue.data(current);
   }
@@ -114,6 +116,7 @@ class MedidasPreparadorController
         periodicidade: old.periodicidade,
         instrumento: old.instrumento,
         tolerancias: old.tolerancias,
+        contagens: old.contagens,
       );
     }
     state = AsyncValue.data(current);


### PR DESCRIPTION
## Summary
- return historical selection counts with each medida and track them when registering samples
- display the per-option counters on sampling pills for numeric, OK, rosca and tampão measurements
- keep the new counters available across operator, preparador and finalização flows

## Testing
- flutter analyze
- python -m py_compile app_db.py

------
https://chatgpt.com/codex/tasks/task_e_68d13b10cbb083319ed2929b5def0e53