### PR TITLE
Add summary card after loading search results

### DIFF
--- a/lib/features/finalizar_os/presentation/finalizar_os_page.dart
+++ b/lib/features/finalizar_os/presentation/finalizar_os_page.dart
@@ -10,6 +10,7 @@ import 'package:http/http.dart' as http;
 import 'package:admin/features/preparacao/data/models.dart';
 import 'package:admin/features/preparacao/data/repository_provider.dart';
 import 'package:admin/screens/main/components/side_menu.dart';
+import 'package:admin/widgets/search_summary_card.dart';
 import 'package:admin/widgets/window_bar.dart';
 import 'package:admin/utils/string_utils.dart';
 import 'package:admin/services/machine_service.dart';
@@ -136,6 +137,7 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
 
   bool _registrando = false;
   bool _osFinalizada = false;
+  bool _mostrarResumo = false;
 
   late final VoidCallback _osSyncListener;
   late final VoidCallback _partSyncListener;
@@ -445,188 +447,223 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
           padding: const EdgeInsets.all(16.0),
           child: Column(
             children: [
-              Form(
-                key: _formKey,
-                child: Column(
-                  children: [
-                    Row(
-                      children: [
-                        Expanded(
-                          child: TextFormField(
-                            controller: _reCtrl,
-                            textInputAction: TextInputAction.next,
-                            keyboardType: TextInputType.number,
-                            inputFormatters: [
-                              FilteringTextInputFormatter.digitsOnly,
-                            ],
-                            decoration: const InputDecoration(
-                              labelText:
-                                  'R.E. do Preparador', // ajuste o texto se for Operador
-                              border: OutlineInputBorder(),
-                            ),
-                            validator: (v) {
-                              final s = (v ?? '').trim();
-                              if (s.isEmpty) return 'Obrigatório';
-                              if (!RegExp(r'^\d+$').hasMatch(s))
-                                return 'Apenas números';
-                              return null;
-                            },
-                          ),
-                        ),
-                        const SizedBox(width: 12),
-                        SizedBox(
-                          width: 140, // igual ao campo Operação
-                          child: TextFormField(
-                            controller: _osCtrl,
-                            textInputAction: TextInputAction.next,
-                            keyboardType: TextInputType.number,
-                            inputFormatters: [
-                              FilteringTextInputFormatter.digitsOnly,
-                            ],
-                            decoration: const InputDecoration(
-                              labelText: 'O.S.',
-                              border: OutlineInputBorder(),
-                            ),
-                            validator: (v) {
-                              final s = (v ?? '').trim();
-                              if (s.isEmpty) return 'Obrigatório';
-                              if (!RegExp(r'^\d+$').hasMatch(s))
-                                return 'Apenas números';
-                              return null;
-                            },
-                          ),
-                        ),
-                      ],
-                    ),
-
-                    const SizedBox(height: 12),
-
-                    Row(
-                      children: [
-                        Expanded(
-                          child: DropdownButtonFormField<String>(
-                            value: categoriaValue,
-                            decoration: const InputDecoration(
-                              labelText: 'Categoria',
-                              border: OutlineInputBorder(),
-                            ),
-                            items: _categorias
-                                .map(
-                                  (c) => DropdownMenuItem(
-                                    value: c,
-                                    child: Text(c),
-                                  ),
-                                )
-                                .toList(),
-                            onChanged: (v) {
-                              ref
-                                  .read(sharedSearchFormProvider.notifier)
-                                  .setCategoria(v);
-                              setState(() {
-                                _categoriaSel = v;
-                                _maquinaSel = null;
-                              });
-                            },
-                            validator: (v) =>
-                                (v == null || v.isEmpty) ? 'Obrigatório' : null,
-                          ),
-                        ),
-                        const SizedBox(width: 12),
-                        Expanded(
-                          child: DropdownButtonFormField<String>(
-                            value: maquinaValue,
-                            decoration: const InputDecoration(
-                              labelText: 'Código da máquina',
-                              border: OutlineInputBorder(),
-                            ),
-                            items: maquinasDisponiveis
-                                .map(
-                                  (m) => DropdownMenuItem(
-                                    value: m.codigo,
-                                    child: Text(m.codigo),
-                                  ),
-                                )
-                                .toList(),
-                            onChanged: (v) {
-                              ref
-                                  .read(sharedSearchFormProvider.notifier)
-                                  .setMaquina(v);
-                              setState(() => _maquinaSel = v);
-                            },
-                            validator: (v) =>
-                                (v == null || v.isEmpty) ? 'Obrigatório' : null,
-                          ),
-                        ),
-                      ],
-                    ),
-
-                    const SizedBox(height: 12),
-
-                    // ---------- PartNumber + Operação (Operação só números) ----------
-                    Row(
-                      children: [
-                        Expanded(
-                          child: TextFormField(
-                            controller: _partCtrl,
-                            textInputAction: TextInputAction.next,
-                            decoration: const InputDecoration(
-                              labelText: 'Código da peça (PartNumber)',
-                              border: OutlineInputBorder(),
-                            ),
-                            validator: (v) => (v == null || v.trim().isEmpty)
-                                ? 'Obrigatório'
-                                : null,
-                          ),
-                        ),
-                        const SizedBox(width: 12),
-                        SizedBox(
-                          width: 140,
-                          child: TextFormField(
-                            controller: _opCtrl,
-                            keyboardType: TextInputType.number,
-                            inputFormatters: [
-                              FilteringTextInputFormatter.digitsOnly,
-                            ],
-                            decoration: const InputDecoration(
-                              labelText: 'Operação',
-                              border: OutlineInputBorder(),
-                            ),
-                            validator: (v) {
-                              final s = (v ?? '').trim();
-                              if (s.isEmpty) return 'Obrigatório';
-                              if (!RegExp(r'^\d+$').hasMatch(s))
-                                return 'Apenas números';
-                              return null;
-                            },
-                          ),
-                        ),
-                      ],
-                    ),
-
-                    const SizedBox(height: 12),
-                    SizedBox(
-                      width: double.infinity,
-                      child: FilledButton.icon(
-                        onPressed: () async {
-                          if (_formKey.currentState!.validate()) {
-                            FocusScope.of(context).unfocus();
-                            await ref
-                                .read(
-                                  medidasFinalizadorControllerProvider.notifier,
-                                )
-                                .carregar(
-                                  partnumber: normalizeCode(_partCtrl.text),
-                                  operacao: normalizeCode(_opCtrl.text),
-                                );
-                          }
-                        },
-                        icon: const Icon(Icons.search),
-                        label: const Text('Carregar medidas'),
-                      ),
-                    ),
+              if (_mostrarResumo) ...[
+                SearchSummaryCard(
+                  reController: _reCtrl,
+                  reLabel: 'R.E. do Preparador',
+                  reHint: 'Informe o R.E.',
+                  items: [
+                    SummaryInfo(label: 'O.S.', value: _osCtrl.text),
+                    SummaryInfo(label: 'Peça', value: _partCtrl.text),
+                    SummaryInfo(label: 'Operação', value: _opCtrl.text),
+                    if ((maquinaValue ?? '').isNotEmpty)
+                      SummaryInfo(label: 'Máquina', value: maquinaValue!),
+                    if ((categoriaValue ?? '').isNotEmpty)
+                      SummaryInfo(label: 'Categoria', value: categoriaValue!),
                   ],
                 ),
-              ),
+                const SizedBox(height: 8),
+                Align(
+                  alignment: Alignment.centerRight,
+                  child: TextButton.icon(
+                    onPressed: () {
+                      FocusScope.of(context).unfocus();
+                      setState(() => _mostrarResumo = false);
+                    },
+                    icon: const Icon(Icons.edit_outlined),
+                    label: const Text('Alterar dados da busca'),
+                  ),
+                ),
+              ] else ...[
+                Form(
+                  key: _formKey,
+                  child: Column(
+                    children: [
+                      Row(
+                        children: [
+                          Expanded(
+                            child: TextFormField(
+                              controller: _reCtrl,
+                              textInputAction: TextInputAction.next,
+                              keyboardType: TextInputType.number,
+                              inputFormatters: [
+                                FilteringTextInputFormatter.digitsOnly,
+                              ],
+                              decoration: const InputDecoration(
+                                labelText:
+                                    'R.E. do Preparador', // ajuste o texto se for Operador
+                                border: OutlineInputBorder(),
+                              ),
+                              validator: (v) {
+                                final s = (v ?? '').trim();
+                                if (s.isEmpty) return 'Obrigatório';
+                                if (!RegExp(r'^\d+$').hasMatch(s))
+                                  return 'Apenas números';
+                                return null;
+                              },
+                            ),
+                          ),
+                          const SizedBox(width: 12),
+                          SizedBox(
+                            width: 140, // igual ao campo Operação
+                            child: TextFormField(
+                              controller: _osCtrl,
+                              textInputAction: TextInputAction.next,
+                              keyboardType: TextInputType.number,
+                              inputFormatters: [
+                                FilteringTextInputFormatter.digitsOnly,
+                              ],
+                              decoration: const InputDecoration(
+                                labelText: 'O.S.',
+                                border: OutlineInputBorder(),
+                              ),
+                              validator: (v) {
+                                final s = (v ?? '').trim();
+                                if (s.isEmpty) return 'Obrigatório';
+                                if (!RegExp(r'^\d+$').hasMatch(s))
+                                  return 'Apenas números';
+                                return null;
+                              },
+                            ),
+                          ),
+                        ],
+                      ),
+
+                      const SizedBox(height: 12),
+
+                      Row(
+                        children: [
+                          Expanded(
+                            child: DropdownButtonFormField<String>(
+                              value: categoriaValue,
+                              decoration: const InputDecoration(
+                                labelText: 'Categoria',
+                                border: OutlineInputBorder(),
+                              ),
+                              items: _categorias
+                                  .map(
+                                    (c) => DropdownMenuItem(
+                                      value: c,
+                                      child: Text(c),
+                                    ),
+                                  )
+                                  .toList(),
+                              onChanged: (v) {
+                                ref
+                                    .read(sharedSearchFormProvider.notifier)
+                                    .setCategoria(v);
+                                setState(() {
+                                  _categoriaSel = v;
+                                  _maquinaSel = null;
+                                });
+                              },
+                              validator: (v) => (v == null || v.isEmpty)
+                                  ? 'Obrigatório'
+                                  : null,
+                            ),
+                          ),
+                          const SizedBox(width: 12),
+                          Expanded(
+                            child: DropdownButtonFormField<String>(
+                              value: maquinaValue,
+                              decoration: const InputDecoration(
+                                labelText: 'Código da máquina',
+                                border: OutlineInputBorder(),
+                              ),
+                              items: maquinasDisponiveis
+                                  .map(
+                                    (m) => DropdownMenuItem(
+                                      value: m.codigo,
+                                      child: Text(m.codigo),
+                                    ),
+                                  )
+                                  .toList(),
+                              onChanged: (v) {
+                                ref
+                                    .read(sharedSearchFormProvider.notifier)
+                                    .setMaquina(v);
+                                setState(() => _maquinaSel = v);
+                              },
+                              validator: (v) => (v == null || v.isEmpty)
+                                  ? 'Obrigatório'
+                                  : null,
+                            ),
+                          ),
+                        ],
+                      ),
+
+                      const SizedBox(height: 12),
+
+                      // ---------- PartNumber + Operação (Operação só números) ----------
+                      Row(
+                        children: [
+                          Expanded(
+                            child: TextFormField(
+                              controller: _partCtrl,
+                              textInputAction: TextInputAction.next,
+                              decoration: const InputDecoration(
+                                labelText: 'Código da peça (PartNumber)',
+                                border: OutlineInputBorder(),
+                              ),
+                              validator: (v) => (v == null || v.trim().isEmpty)
+                                  ? 'Obrigatório'
+                                  : null,
+                            ),
+                          ),
+                          const SizedBox(width: 12),
+                          SizedBox(
+                            width: 140,
+                            child: TextFormField(
+                              controller: _opCtrl,
+                              keyboardType: TextInputType.number,
+                              inputFormatters: [
+                                FilteringTextInputFormatter.digitsOnly,
+                              ],
+                              decoration: const InputDecoration(
+                                labelText: 'Operação',
+                                border: OutlineInputBorder(),
+                              ),
+                              validator: (v) {
+                                final s = (v ?? '').trim();
+                                if (s.isEmpty) return 'Obrigatório';
+                                if (!RegExp(r'^\d+$').hasMatch(s))
+                                  return 'Apenas números';
+                                return null;
+                              },
+                            ),
+                          ),
+                        ],
+                      ),
+
+                      const SizedBox(height: 12),
+                      SizedBox(
+                        width: double.infinity,
+                        child: FilledButton.icon(
+                          onPressed: () async {
+                            if (_formKey.currentState!.validate()) {
+                              FocusScope.of(context).unfocus();
+                              await ref
+                                  .read(
+                                    medidasFinalizadorControllerProvider
+                                        .notifier,
+                                  )
+                                  .carregar(
+                                    partnumber: normalizeCode(_partCtrl.text),
+                                    operacao: normalizeCode(_opCtrl.text),
+                                  );
+                              if (mounted) {
+                                setState(() => _mostrarResumo = true);
+                              }
+                            }
+                          },
+                          icon: const Icon(Icons.search),
+                          label: const Text('Carregar medidas'),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
               const SizedBox(height: 16),
               Expanded(
                 child: medidasAsync.when(

--- a/lib/features/operador/presentation/operador_page.dart
+++ b/lib/features/operador/presentation/operador_page.dart
@@ -13,6 +13,7 @@ import 'package:admin/features/finalizar_os/presentation/finalizar_os_page.dart'
 import 'package:admin/features/operador/presentation/troca_ferramenta_page.dart';
 import 'package:admin/features/operador/presentation/widgets/measurement_tile.dart';
 import 'package:admin/screens/main/components/side_menu.dart';
+import 'package:admin/widgets/search_summary_card.dart';
 import 'package:admin/widgets/window_bar.dart';
 import 'package:admin/utils/string_utils.dart';
 import 'package:admin/services/machine_service.dart';
@@ -161,6 +162,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
   String? _maquinaSel;
 
   bool _registrando = false;
+  bool _mostrarResumo = false;
 
   late final VoidCallback _osSyncListener;
   late final VoidCallback _partSyncListener;
@@ -673,188 +675,222 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
           padding: const EdgeInsets.all(16.0),
           child: Column(
             children: [
-              Form(
-                key: _formKey,
-                child: Column(
-                  children: [
-                    Row(
-                      children: [
-                        Expanded(
-                          child: TextFormField(
-                            controller: _reCtrl,
-                            textInputAction: TextInputAction.next,
-                            keyboardType: TextInputType.number,
-                            inputFormatters: [
-                              FilteringTextInputFormatter.digitsOnly,
-                            ],
-                            decoration: const InputDecoration(
-                              labelText:
-                                  'R.E. do Preparador', // ajuste o texto se for Operador
-                              border: OutlineInputBorder(),
-                            ),
-                            validator: (v) {
-                              final s = (v ?? '').trim();
-                              if (s.isEmpty) return 'Obrigatório';
-                              if (!RegExp(r'^\d+$').hasMatch(s))
-                                return 'Apenas números';
-                              return null;
-                            },
-                          ),
-                        ),
-                        const SizedBox(width: 12),
-                        SizedBox(
-                          width: 140, // igual ao campo Operação
-                          child: TextFormField(
-                            controller: _osCtrl,
-                            textInputAction: TextInputAction.next,
-                            keyboardType: TextInputType.number,
-                            inputFormatters: [
-                              FilteringTextInputFormatter.digitsOnly,
-                            ],
-                            decoration: const InputDecoration(
-                              labelText: 'O.S.',
-                              border: OutlineInputBorder(),
-                            ),
-                            validator: (v) {
-                              final s = (v ?? '').trim();
-                              if (s.isEmpty) return 'Obrigatório';
-                              if (!RegExp(r'^\d+$').hasMatch(s))
-                                return 'Apenas números';
-                              return null;
-                            },
-                          ),
-                        ),
-                      ],
-                    ),
-
-                    const SizedBox(height: 12),
-
-                    Row(
-                      children: [
-                        Expanded(
-                          child: DropdownButtonFormField<String>(
-                            value: categoriaValue,
-                            decoration: const InputDecoration(
-                              labelText: 'Categoria',
-                              border: OutlineInputBorder(),
-                            ),
-                            items: _categorias
-                                .map(
-                                  (c) => DropdownMenuItem(
-                                    value: c,
-                                    child: Text(c),
-                                  ),
-                                )
-                                .toList(),
-                            onChanged: (v) {
-                              ref
-                                  .read(sharedSearchFormProvider.notifier)
-                                  .setCategoria(v);
-                              setState(() {
-                                _categoriaSel = v;
-                                _maquinaSel = null;
-                              });
-                            },
-                            validator: (v) =>
-                                (v == null || v.isEmpty) ? 'Obrigatório' : null,
-                          ),
-                        ),
-                        const SizedBox(width: 12),
-                        Expanded(
-                          child: DropdownButtonFormField<String>(
-                            value: maquinaValue,
-                            decoration: const InputDecoration(
-                              labelText: 'Código da máquina',
-                              border: OutlineInputBorder(),
-                            ),
-                            items: maquinasDisponiveis
-                                .map(
-                                  (m) => DropdownMenuItem(
-                                    value: m.codigo,
-                                    child: Text(m.codigo),
-                                  ),
-                                )
-                                .toList(),
-                            onChanged: (v) {
-                              ref
-                                  .read(sharedSearchFormProvider.notifier)
-                                  .setMaquina(v);
-                              setState(() => _maquinaSel = v);
-                            },
-                            validator: (v) =>
-                                (v == null || v.isEmpty) ? 'Obrigatório' : null,
-                          ),
-                        ),
-                      ],
-                    ),
-
-                    const SizedBox(height: 12),
-
-                    // ---------- PartNumber + Operação (Operação só números) ----------
-                    Row(
-                      children: [
-                        Expanded(
-                          child: TextFormField(
-                            controller: _partCtrl,
-                            textInputAction: TextInputAction.next,
-                            decoration: const InputDecoration(
-                              labelText: 'Código da peça (PartNumber)',
-                              border: OutlineInputBorder(),
-                            ),
-                            validator: (v) => (v == null || v.trim().isEmpty)
-                                ? 'Obrigatório'
-                                : null,
-                          ),
-                        ),
-                        const SizedBox(width: 12),
-                        SizedBox(
-                          width: 140,
-                          child: TextFormField(
-                            controller: _opCtrl,
-                            keyboardType: TextInputType.number,
-                            inputFormatters: [
-                              FilteringTextInputFormatter.digitsOnly,
-                            ],
-                            decoration: const InputDecoration(
-                              labelText: 'Operação',
-                              border: OutlineInputBorder(),
-                            ),
-                            validator: (v) {
-                              final s = (v ?? '').trim();
-                              if (s.isEmpty) return 'Obrigatório';
-                              if (!RegExp(r'^\d+$').hasMatch(s))
-                                return 'Apenas números';
-                              return null;
-                            },
-                          ),
-                        ),
-                      ],
-                    ),
-
-                    const SizedBox(height: 12),
-                    SizedBox(
-                      width: double.infinity,
-                      child: FilledButton.icon(
-                        onPressed: () async {
-                          if (_formKey.currentState!.validate()) {
-                            FocusScope.of(context).unfocus();
-                            await ref
-                                .read(
-                                  medidasOperadorControllerProvider.notifier,
-                                )
-                                .carregar(
-                                  partnumber: normalizeCode(_partCtrl.text),
-                                  operacao: normalizeCode(_opCtrl.text),
-                                );
-                          }
-                        },
-                        icon: const Icon(Icons.search),
-                        label: const Text('Carregar medidas'),
-                      ),
-                    ),
+              if (_mostrarResumo) ...[
+                SearchSummaryCard(
+                  reController: _reCtrl,
+                  reLabel: 'R.E. do Preparador',
+                  reHint: 'Informe o R.E.',
+                  items: [
+                    SummaryInfo(label: 'O.S.', value: _osCtrl.text),
+                    SummaryInfo(label: 'Peça', value: _partCtrl.text),
+                    SummaryInfo(label: 'Operação', value: _opCtrl.text),
+                    if ((maquinaValue ?? '').isNotEmpty)
+                      SummaryInfo(label: 'Máquina', value: maquinaValue!),
+                    if ((categoriaValue ?? '').isNotEmpty)
+                      SummaryInfo(label: 'Categoria', value: categoriaValue!),
                   ],
                 ),
-              ),
+                const SizedBox(height: 8),
+                Align(
+                  alignment: Alignment.centerRight,
+                  child: TextButton.icon(
+                    onPressed: () {
+                      FocusScope.of(context).unfocus();
+                      setState(() => _mostrarResumo = false);
+                    },
+                    icon: const Icon(Icons.edit_outlined),
+                    label: const Text('Alterar dados da busca'),
+                  ),
+                ),
+              ] else ...[
+                Form(
+                  key: _formKey,
+                  child: Column(
+                    children: [
+                      Row(
+                        children: [
+                          Expanded(
+                            child: TextFormField(
+                              controller: _reCtrl,
+                              textInputAction: TextInputAction.next,
+                              keyboardType: TextInputType.number,
+                              inputFormatters: [
+                                FilteringTextInputFormatter.digitsOnly,
+                              ],
+                              decoration: const InputDecoration(
+                                labelText:
+                                    'R.E. do Preparador', // ajuste o texto se for Operador
+                                border: OutlineInputBorder(),
+                              ),
+                              validator: (v) {
+                                final s = (v ?? '').trim();
+                                if (s.isEmpty) return 'Obrigatório';
+                                if (!RegExp(r'^\d+$').hasMatch(s))
+                                  return 'Apenas números';
+                                return null;
+                              },
+                            ),
+                          ),
+                          const SizedBox(width: 12),
+                          SizedBox(
+                            width: 140, // igual ao campo Operação
+                            child: TextFormField(
+                              controller: _osCtrl,
+                              textInputAction: TextInputAction.next,
+                              keyboardType: TextInputType.number,
+                              inputFormatters: [
+                                FilteringTextInputFormatter.digitsOnly,
+                              ],
+                              decoration: const InputDecoration(
+                                labelText: 'O.S.',
+                                border: OutlineInputBorder(),
+                              ),
+                              validator: (v) {
+                                final s = (v ?? '').trim();
+                                if (s.isEmpty) return 'Obrigatório';
+                                if (!RegExp(r'^\d+$').hasMatch(s))
+                                  return 'Apenas números';
+                                return null;
+                              },
+                            ),
+                          ),
+                        ],
+                      ),
+
+                      const SizedBox(height: 12),
+
+                      Row(
+                        children: [
+                          Expanded(
+                            child: DropdownButtonFormField<String>(
+                              value: categoriaValue,
+                              decoration: const InputDecoration(
+                                labelText: 'Categoria',
+                                border: OutlineInputBorder(),
+                              ),
+                              items: _categorias
+                                  .map(
+                                    (c) => DropdownMenuItem(
+                                      value: c,
+                                      child: Text(c),
+                                    ),
+                                  )
+                                  .toList(),
+                              onChanged: (v) {
+                                ref
+                                    .read(sharedSearchFormProvider.notifier)
+                                    .setCategoria(v);
+                                setState(() {
+                                  _categoriaSel = v;
+                                  _maquinaSel = null;
+                                });
+                              },
+                              validator: (v) => (v == null || v.isEmpty)
+                                  ? 'Obrigatório'
+                                  : null,
+                            ),
+                          ),
+                          const SizedBox(width: 12),
+                          Expanded(
+                            child: DropdownButtonFormField<String>(
+                              value: maquinaValue,
+                              decoration: const InputDecoration(
+                                labelText: 'Código da máquina',
+                                border: OutlineInputBorder(),
+                              ),
+                              items: maquinasDisponiveis
+                                  .map(
+                                    (m) => DropdownMenuItem(
+                                      value: m.codigo,
+                                      child: Text(m.codigo),
+                                    ),
+                                  )
+                                  .toList(),
+                              onChanged: (v) {
+                                ref
+                                    .read(sharedSearchFormProvider.notifier)
+                                    .setMaquina(v);
+                                setState(() => _maquinaSel = v);
+                              },
+                              validator: (v) => (v == null || v.isEmpty)
+                                  ? 'Obrigatório'
+                                  : null,
+                            ),
+                          ),
+                        ],
+                      ),
+
+                      const SizedBox(height: 12),
+
+                      // ---------- PartNumber + Operação (Operação só números) ----------
+                      Row(
+                        children: [
+                          Expanded(
+                            child: TextFormField(
+                              controller: _partCtrl,
+                              textInputAction: TextInputAction.next,
+                              decoration: const InputDecoration(
+                                labelText: 'Código da peça (PartNumber)',
+                                border: OutlineInputBorder(),
+                              ),
+                              validator: (v) => (v == null || v.trim().isEmpty)
+                                  ? 'Obrigatório'
+                                  : null,
+                            ),
+                          ),
+                          const SizedBox(width: 12),
+                          SizedBox(
+                            width: 140,
+                            child: TextFormField(
+                              controller: _opCtrl,
+                              keyboardType: TextInputType.number,
+                              inputFormatters: [
+                                FilteringTextInputFormatter.digitsOnly,
+                              ],
+                              decoration: const InputDecoration(
+                                labelText: 'Operação',
+                                border: OutlineInputBorder(),
+                              ),
+                              validator: (v) {
+                                final s = (v ?? '').trim();
+                                if (s.isEmpty) return 'Obrigatório';
+                                if (!RegExp(r'^\d+$').hasMatch(s))
+                                  return 'Apenas números';
+                                return null;
+                              },
+                            ),
+                          ),
+                        ],
+                      ),
+
+                      const SizedBox(height: 12),
+                      SizedBox(
+                        width: double.infinity,
+                        child: FilledButton.icon(
+                          onPressed: () async {
+                            if (_formKey.currentState!.validate()) {
+                              FocusScope.of(context).unfocus();
+                              await ref
+                                  .read(
+                                    medidasOperadorControllerProvider.notifier,
+                                  )
+                                  .carregar(
+                                    partnumber: normalizeCode(_partCtrl.text),
+                                    operacao: normalizeCode(_opCtrl.text),
+                                  );
+                              if (mounted) {
+                                setState(() => _mostrarResumo = true);
+                              }
+                            }
+                          },
+                          icon: const Icon(Icons.search),
+                          label: const Text('Carregar medidas'),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
               const SizedBox(height: 16),
               Expanded(
                 child: medidasAsync.when(

--- a/lib/features/preparacao/presentation/preparacao_page.dart
+++ b/lib/features/preparacao/presentation/preparacao_page.dart
@@ -13,6 +13,7 @@ import 'package:admin/features/operador/presentation/operador_page.dart';
 import 'package:admin/features/operador/presentation/widgets/measurement_tile.dart';
 import 'package:admin/features/shared/providers/search_flow_form_provider.dart';
 import 'package:admin/screens/main/components/side_menu.dart';
+import 'package:admin/widgets/search_summary_card.dart';
 import 'package:admin/widgets/window_bar.dart';
 import 'package:admin/utils/string_utils.dart';
 import 'package:admin/services/machine_service.dart';
@@ -137,6 +138,7 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
 
   bool _registrando = false;
   bool _osLiberada = false;
+  bool _mostrarResumo = false;
 
   late final VoidCallback _osSyncListener;
   late final VoidCallback _partSyncListener;
@@ -464,188 +466,223 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
           padding: const EdgeInsets.all(16.0),
           child: Column(
             children: [
-              Form(
-                key: _formKey,
-                child: Column(
-                  children: [
-                    Row(
-                      children: [
-                        Expanded(
-                          child: TextFormField(
-                            controller: _reCtrl,
-                            textInputAction: TextInputAction.next,
-                            keyboardType: TextInputType.number,
-                            inputFormatters: [
-                              FilteringTextInputFormatter.digitsOnly,
-                            ],
-                            decoration: const InputDecoration(
-                              labelText:
-                                  'R.E. do Preparador', // ajuste o texto se for Operador
-                              border: OutlineInputBorder(),
-                            ),
-                            validator: (v) {
-                              final s = (v ?? '').trim();
-                              if (s.isEmpty) return 'Obrigatório';
-                              if (!RegExp(r'^\d+$').hasMatch(s))
-                                return 'Apenas números';
-                              return null;
-                            },
-                          ),
-                        ),
-                        const SizedBox(width: 12),
-                        SizedBox(
-                          width: 140, // igual ao campo Operação
-                          child: TextFormField(
-                            controller: _osCtrl,
-                            textInputAction: TextInputAction.next,
-                            keyboardType: TextInputType.number,
-                            inputFormatters: [
-                              FilteringTextInputFormatter.digitsOnly,
-                            ],
-                            decoration: const InputDecoration(
-                              labelText: 'O.S.',
-                              border: OutlineInputBorder(),
-                            ),
-                            validator: (v) {
-                              final s = (v ?? '').trim();
-                              if (s.isEmpty) return 'Obrigatório';
-                              if (!RegExp(r'^\d+$').hasMatch(s))
-                                return 'Apenas números';
-                              return null;
-                            },
-                          ),
-                        ),
-                      ],
-                    ),
-
-                    const SizedBox(height: 12),
-
-                    Row(
-                      children: [
-                        Expanded(
-                          child: DropdownButtonFormField<String>(
-                            value: categoriaValue,
-                            decoration: const InputDecoration(
-                              labelText: 'Categoria',
-                              border: OutlineInputBorder(),
-                            ),
-                            items: _categorias
-                                .map(
-                                  (c) => DropdownMenuItem(
-                                    value: c,
-                                    child: Text(c),
-                                  ),
-                                )
-                                .toList(),
-                            onChanged: (v) {
-                              ref
-                                  .read(sharedSearchFormProvider.notifier)
-                                  .setCategoria(v);
-                              setState(() {
-                                _categoriaSel = v;
-                                _maquinaSel = null;
-                              });
-                            },
-                            validator: (v) =>
-                                (v == null || v.isEmpty) ? 'Obrigatório' : null,
-                          ),
-                        ),
-                        const SizedBox(width: 12),
-                        Expanded(
-                          child: DropdownButtonFormField<String>(
-                            value: maquinaValue,
-                            decoration: const InputDecoration(
-                              labelText: 'Código da máquina',
-                              border: OutlineInputBorder(),
-                            ),
-                            items: maquinasDisponiveis
-                                .map(
-                                  (m) => DropdownMenuItem(
-                                    value: m.codigo,
-                                    child: Text(m.codigo),
-                                  ),
-                                )
-                                .toList(),
-                            onChanged: (v) {
-                              ref
-                                  .read(sharedSearchFormProvider.notifier)
-                                  .setMaquina(v);
-                              setState(() => _maquinaSel = v);
-                            },
-                            validator: (v) =>
-                                (v == null || v.isEmpty) ? 'Obrigatório' : null,
-                          ),
-                        ),
-                      ],
-                    ),
-
-                    const SizedBox(height: 12),
-
-                    // ---------- PartNumber + Operação (Operação só números) ----------
-                    Row(
-                      children: [
-                        Expanded(
-                          child: TextFormField(
-                            controller: _partCtrl,
-                            textInputAction: TextInputAction.next,
-                            decoration: const InputDecoration(
-                              labelText: 'Código da peça (PartNumber)',
-                              border: OutlineInputBorder(),
-                            ),
-                            validator: (v) => (v == null || v.trim().isEmpty)
-                                ? 'Obrigatório'
-                                : null,
-                          ),
-                        ),
-                        const SizedBox(width: 12),
-                        SizedBox(
-                          width: 140,
-                          child: TextFormField(
-                            controller: _opCtrl,
-                            keyboardType: TextInputType.number,
-                            inputFormatters: [
-                              FilteringTextInputFormatter.digitsOnly,
-                            ],
-                            decoration: const InputDecoration(
-                              labelText: 'Operação',
-                              border: OutlineInputBorder(),
-                            ),
-                            validator: (v) {
-                              final s = (v ?? '').trim();
-                              if (s.isEmpty) return 'Obrigatório';
-                              if (!RegExp(r'^\d+$').hasMatch(s))
-                                return 'Apenas números';
-                              return null;
-                            },
-                          ),
-                        ),
-                      ],
-                    ),
-
-                    const SizedBox(height: 12),
-                    SizedBox(
-                      width: double.infinity,
-                      child: FilledButton.icon(
-                        onPressed: () async {
-                          if (_formKey.currentState!.validate()) {
-                            FocusScope.of(context).unfocus();
-                            await ref
-                                .read(
-                                  medidasPreparadorControllerProvider.notifier,
-                                )
-                                .carregar(
-                                  partnumber: normalizeCode(_partCtrl.text),
-                                  operacao: normalizeCode(_opCtrl.text),
-                                );
-                          }
-                        },
-                        icon: const Icon(Icons.search),
-                        label: const Text('Carregar medidas'),
-                      ),
-                    ),
+              if (_mostrarResumo) ...[
+                SearchSummaryCard(
+                  reController: _reCtrl,
+                  reLabel: 'R.E. do Preparador',
+                  reHint: 'Informe o R.E.',
+                  items: [
+                    SummaryInfo(label: 'O.S.', value: _osCtrl.text),
+                    SummaryInfo(label: 'Peça', value: _partCtrl.text),
+                    SummaryInfo(label: 'Operação', value: _opCtrl.text),
+                    if ((maquinaValue ?? '').isNotEmpty)
+                      SummaryInfo(label: 'Máquina', value: maquinaValue!),
+                    if ((categoriaValue ?? '').isNotEmpty)
+                      SummaryInfo(label: 'Categoria', value: categoriaValue!),
                   ],
                 ),
-              ),
+                const SizedBox(height: 8),
+                Align(
+                  alignment: Alignment.centerRight,
+                  child: TextButton.icon(
+                    onPressed: () {
+                      FocusScope.of(context).unfocus();
+                      setState(() => _mostrarResumo = false);
+                    },
+                    icon: const Icon(Icons.edit_outlined),
+                    label: const Text('Alterar dados da busca'),
+                  ),
+                ),
+              ] else ...[
+                Form(
+                  key: _formKey,
+                  child: Column(
+                    children: [
+                      Row(
+                        children: [
+                          Expanded(
+                            child: TextFormField(
+                              controller: _reCtrl,
+                              textInputAction: TextInputAction.next,
+                              keyboardType: TextInputType.number,
+                              inputFormatters: [
+                                FilteringTextInputFormatter.digitsOnly,
+                              ],
+                              decoration: const InputDecoration(
+                                labelText:
+                                    'R.E. do Preparador', // ajuste o texto se for Operador
+                                border: OutlineInputBorder(),
+                              ),
+                              validator: (v) {
+                                final s = (v ?? '').trim();
+                                if (s.isEmpty) return 'Obrigatório';
+                                if (!RegExp(r'^\d+$').hasMatch(s))
+                                  return 'Apenas números';
+                                return null;
+                              },
+                            ),
+                          ),
+                          const SizedBox(width: 12),
+                          SizedBox(
+                            width: 140, // igual ao campo Operação
+                            child: TextFormField(
+                              controller: _osCtrl,
+                              textInputAction: TextInputAction.next,
+                              keyboardType: TextInputType.number,
+                              inputFormatters: [
+                                FilteringTextInputFormatter.digitsOnly,
+                              ],
+                              decoration: const InputDecoration(
+                                labelText: 'O.S.',
+                                border: OutlineInputBorder(),
+                              ),
+                              validator: (v) {
+                                final s = (v ?? '').trim();
+                                if (s.isEmpty) return 'Obrigatório';
+                                if (!RegExp(r'^\d+$').hasMatch(s))
+                                  return 'Apenas números';
+                                return null;
+                              },
+                            ),
+                          ),
+                        ],
+                      ),
+
+                      const SizedBox(height: 12),
+
+                      Row(
+                        children: [
+                          Expanded(
+                            child: DropdownButtonFormField<String>(
+                              value: categoriaValue,
+                              decoration: const InputDecoration(
+                                labelText: 'Categoria',
+                                border: OutlineInputBorder(),
+                              ),
+                              items: _categorias
+                                  .map(
+                                    (c) => DropdownMenuItem(
+                                      value: c,
+                                      child: Text(c),
+                                    ),
+                                  )
+                                  .toList(),
+                              onChanged: (v) {
+                                ref
+                                    .read(sharedSearchFormProvider.notifier)
+                                    .setCategoria(v);
+                                setState(() {
+                                  _categoriaSel = v;
+                                  _maquinaSel = null;
+                                });
+                              },
+                              validator: (v) => (v == null || v.isEmpty)
+                                  ? 'Obrigatório'
+                                  : null,
+                            ),
+                          ),
+                          const SizedBox(width: 12),
+                          Expanded(
+                            child: DropdownButtonFormField<String>(
+                              value: maquinaValue,
+                              decoration: const InputDecoration(
+                                labelText: 'Código da máquina',
+                                border: OutlineInputBorder(),
+                              ),
+                              items: maquinasDisponiveis
+                                  .map(
+                                    (m) => DropdownMenuItem(
+                                      value: m.codigo,
+                                      child: Text(m.codigo),
+                                    ),
+                                  )
+                                  .toList(),
+                              onChanged: (v) {
+                                ref
+                                    .read(sharedSearchFormProvider.notifier)
+                                    .setMaquina(v);
+                                setState(() => _maquinaSel = v);
+                              },
+                              validator: (v) => (v == null || v.isEmpty)
+                                  ? 'Obrigatório'
+                                  : null,
+                            ),
+                          ),
+                        ],
+                      ),
+
+                      const SizedBox(height: 12),
+
+                      // ---------- PartNumber + Operação (Operação só números) ----------
+                      Row(
+                        children: [
+                          Expanded(
+                            child: TextFormField(
+                              controller: _partCtrl,
+                              textInputAction: TextInputAction.next,
+                              decoration: const InputDecoration(
+                                labelText: 'Código da peça (PartNumber)',
+                                border: OutlineInputBorder(),
+                              ),
+                              validator: (v) => (v == null || v.trim().isEmpty)
+                                  ? 'Obrigatório'
+                                  : null,
+                            ),
+                          ),
+                          const SizedBox(width: 12),
+                          SizedBox(
+                            width: 140,
+                            child: TextFormField(
+                              controller: _opCtrl,
+                              keyboardType: TextInputType.number,
+                              inputFormatters: [
+                                FilteringTextInputFormatter.digitsOnly,
+                              ],
+                              decoration: const InputDecoration(
+                                labelText: 'Operação',
+                                border: OutlineInputBorder(),
+                              ),
+                              validator: (v) {
+                                final s = (v ?? '').trim();
+                                if (s.isEmpty) return 'Obrigatório';
+                                if (!RegExp(r'^\d+$').hasMatch(s))
+                                  return 'Apenas números';
+                                return null;
+                              },
+                            ),
+                          ),
+                        ],
+                      ),
+
+                      const SizedBox(height: 12),
+                      SizedBox(
+                        width: double.infinity,
+                        child: FilledButton.icon(
+                          onPressed: () async {
+                            if (_formKey.currentState!.validate()) {
+                              FocusScope.of(context).unfocus();
+                              await ref
+                                  .read(
+                                    medidasPreparadorControllerProvider
+                                        .notifier,
+                                  )
+                                  .carregar(
+                                    partnumber: normalizeCode(_partCtrl.text),
+                                    operacao: normalizeCode(_opCtrl.text),
+                                  );
+                              if (mounted) {
+                                setState(() => _mostrarResumo = true);
+                              }
+                            }
+                          },
+                          icon: const Icon(Icons.search),
+                          label: const Text('Carregar medidas'),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
               const SizedBox(height: 16),
               Expanded(
                 child: medidasAsync.when(

--- a/lib/widgets/search_summary_card.dart
+++ b/lib/widgets/search_summary_card.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+/// Representation of a summary item shown in the [SearchSummaryCard].
+class SummaryInfo {
+  const SummaryInfo({required this.label, required this.value});
+
+  final String label;
+  final String value;
+}
+
+/// Card used to present a compact summary of the search parameters once the
+/// form is hidden.
+class SearchSummaryCard extends StatelessWidget {
+  const SearchSummaryCard({
+    super.key,
+    required this.reController,
+    required this.reLabel,
+    required this.items,
+    this.reHint,
+    this.itemWidth = 160,
+  });
+
+  final TextEditingController reController;
+  final String reLabel;
+  final List<SummaryInfo> items;
+  final String? reHint;
+  final double itemWidth;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final visibleItems = items.where((e) => e.value.trim().isNotEmpty).toList();
+
+    return Card(
+      margin: EdgeInsets.zero,
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Wrap(
+          spacing: 24,
+          runSpacing: 12,
+          children: [
+            SizedBox(
+              width: itemWidth,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(reLabel, style: theme.textTheme.labelSmall),
+                  const SizedBox(height: 4),
+                  TextField(
+                    controller: reController,
+                    keyboardType: TextInputType.number,
+                    inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                    decoration: InputDecoration(
+                      hintText: reHint ?? 'Informe o R.E.',
+                      border: const OutlineInputBorder(),
+                      isDense: true,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            ...visibleItems.map(
+              (item) => SizedBox(
+                width: itemWidth,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(item.label, style: theme.textTheme.labelSmall),
+                    const SizedBox(height: 4),
+                    Text(
+                      item.value.isEmpty ? '-' : item.value,
+                      style: theme.textTheme.titleMedium,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- introduce a reusable `SearchSummaryCard` that shows the current search context while keeping the R.E. field editable
- hide the full search form after loading data on the Liberação, Amostragem and Finalização flows, surfacing a compact summary with an option to edit the inputs
- persist the summary visibility with a new `_mostrarResumo` flag so users can reopen the form when necessary

## Testing
- flutter analyze

------
https://chatgpt.com/codex/tasks/task_e_68d1427ea7c483319543e4b207521fa8