### PR TITLE
Preserve measurement selection counters across sessions

### DIFF
--- a/app_db.py
+++ b/app_db.py
@@ -679,8 +679,11 @@ def _medidas_preparador_db(part: str, op: str):
                 mn = 0.0
             elif mn is None and mx is not None:
                 mn = 0.0
+        idx = row.get("idx_medida")
         medidas.append(
             {
+                "indice": idx,
+                "idx_medida": idx,
                 "titulo": titulo,
                 "faixaTexto": faixa,
                 "min": mn,
@@ -774,6 +777,8 @@ def _medidas_operador_db(part: str, op: str):
         raw_counts = contagens_por_indice.get(idx) or {}
         medidas.append(
             {
+                "indice": idx,
+                "idx_medida": idx,
                 "titulo": titulo,
                 "faixaTexto": faixa,
                 "min": mn,

--- a/lib/features/finalizar_os/presentation/finalizar_os_page.dart
+++ b/lib/features/finalizar_os/presentation/finalizar_os_page.dart
@@ -57,6 +57,7 @@ class MedidasFinalizadorController
       final normalizados = itens
           .map(
             (m) => MedidaItem(
+              indice: m.indice,
               titulo: m.titulo,
               faixaTexto: m.faixaTexto,
               minimo: m.minimo,
@@ -84,6 +85,7 @@ class MedidasFinalizadorController
     if (index < 0 || index >= current.length) return;
     final old = current[index];
     current[index] = MedidaItem(
+      indice: old.indice,
       titulo: old.titulo,
       faixaTexto: old.faixaTexto,
       minimo: old.minimo,
@@ -105,6 +107,7 @@ class MedidasFinalizadorController
     for (var i = 0; i < current.length; i++) {
       final old = current[i];
       current[i] = MedidaItem(
+        indice: old.indice,
         titulo: old.titulo,
         faixaTexto: old.faixaTexto,
         minimo: old.minimo,
@@ -318,7 +321,7 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
     for (var i = 0; i < medidas.length; i++) {
       final m = medidas[i];
       itens.add({
-        'indice': i,
+        'indice': m.indice ?? i,
         'titulo': m.titulo,
         'faixaTexto': m.faixaTexto,
         'min': m.minimo,

--- a/lib/features/operador/data/models.dart
+++ b/lib/features/operador/data/models.dart
@@ -63,6 +63,7 @@ String statusToString(StatusMedida s) {
 class MedidaItem {
   // Básicos
   final String titulo;
+  final int? indice;
 
   /// Texto amigável da faixa (ex.: "10,00 ~ 12,00 mm", "≥ 15,30 mm", "≤ 3,2 µm")
   final String faixaTexto;
@@ -91,6 +92,7 @@ class MedidaItem {
 
   MedidaItem({
     required this.titulo,
+    this.indice,
     this.faixaTexto = '',
     this.minimo,
     this.maximo,
@@ -308,8 +310,18 @@ class MedidaItem {
       });
     }
 
+    int? idx;
+    final rawIdx =
+        map['indice'] ?? map['idx_medida'] ?? map['idx'] ?? map['index'];
+    if (rawIdx is num) {
+      idx = rawIdx.toInt();
+    } else if (rawIdx != null) {
+      idx = int.tryParse(rawIdx.toString());
+    }
+
     return MedidaItem(
       titulo: titulo,
+      indice: idx,
       faixaTexto: faixaOut,
       minimo: minimo,
       maximo: maximo,
@@ -326,6 +338,7 @@ class MedidaItem {
 
   Map<String, dynamic> toMap() => {
     'titulo': titulo,
+    'indice': indice,
     'faixaTexto': faixaTexto,
     'minimo': minimo,
     'maximo': maximo,

--- a/lib/features/operador/presentation/operador_page.dart
+++ b/lib/features/operador/presentation/operador_page.dart
@@ -59,6 +59,7 @@ class MedidasOperadorController
     if (index < 0 || index >= current.length) return;
     final old = current[index];
     current[index] = MedidaItem(
+      indice: old.indice,
       titulo: old.titulo,
       faixaTexto: old.faixaTexto,
       minimo: old.minimo,
@@ -81,6 +82,7 @@ class MedidasOperadorController
     for (var i = 0; i < current.length; i++) {
       final old = current[i];
       current[i] = MedidaItem(
+        indice: old.indice,
         titulo: old.titulo,
         faixaTexto: old.faixaTexto,
         minimo: old.minimo,
@@ -124,6 +126,7 @@ class MedidasOperadorController
       }
 
       current[i] = MedidaItem(
+        indice: old.indice,
         titulo: old.titulo,
         faixaTexto: old.faixaTexto,
         minimo: old.minimo,
@@ -301,7 +304,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
       final m = medidas[i];
       final map = m.toMap();
       // índice esperado pelo backend
-      map['indice'] = i;
+      map['indice'] = m.indice ?? map['indice'] ?? i;
       // backend espera 'min'/'max' e não 'minimo'/'maximo'
       map['min'] = m.minimo;
       map['max'] = m.maximo;

--- a/lib/features/operador/presentation/troca_ferramenta_page.dart
+++ b/lib/features/operador/presentation/troca_ferramenta_page.dart
@@ -131,6 +131,7 @@ class _TrocaFerramentaPageState extends State<TrocaFerramentaPage> {
     final selecionadas = ordenadas.map((idx) {
       final item = _todas[idx];
       return MedidaItem(
+        indice: item.indice,
         titulo: item.titulo,
         faixaTexto: item.faixaTexto,
         minimo: item.minimo,
@@ -157,6 +158,7 @@ class _TrocaFerramentaPageState extends State<TrocaFerramentaPage> {
     if (index < 0 || index >= itens.length) return;
     final antigo = itens[index];
     itens[index] = MedidaItem(
+      indice: antigo.indice,
       titulo: antigo.titulo,
       faixaTexto: antigo.faixaTexto,
       minimo: antigo.minimo,
@@ -252,7 +254,7 @@ class _TrocaFerramentaPageState extends State<TrocaFerramentaPage> {
     for (var i = 0; i < _medidasSelecionadas.length; i++) {
       final m = _medidasSelecionadas[i];
       itens.add({
-        'indice': i,
+        'indice': m.indice ?? i,
         'titulo': m.titulo,
         'faixaTexto': m.faixaTexto,
         'min': m.minimo,

--- a/lib/features/preparacao/data/local_excel_repository.dart
+++ b/lib/features/preparacao/data/local_excel_repository.dart
@@ -51,6 +51,14 @@ class LocalExcelRepository implements MedidasRepository {
         double? min = _toDouble(map['minimo'] ?? map['min']);
         double? max = _toDouble(map['maximo'] ?? map['max']);
         String? unidade = map['unidade']?.toString();
+        int? indice;
+        final rawIdx =
+            map['indice'] ?? map['idx_medida'] ?? map['idx'] ?? map['index'];
+        if (rawIdx is num) {
+          indice = rawIdx.toInt();
+        } else if (rawIdx != null) {
+          indice = int.tryParse(rawIdx.toString());
+        }
 
         if (faixaTexto.isEmpty && (min != null || max != null)) {
           final minStr = min?.toStringAsFixed(2) ?? '';
@@ -67,6 +75,7 @@ class LocalExcelRepository implements MedidasRepository {
 
         return MedidaItem(
           titulo: (map['titulo'] ?? '').toString(),
+          indice: indice,
           faixaTexto: faixaTexto,
           minimo: min,
           maximo: max,

--- a/lib/features/preparacao/data/models.dart
+++ b/lib/features/preparacao/data/models.dart
@@ -61,6 +61,7 @@ String statusToString(StatusMedida s) {
 class MedidaItem {
   // Básicos
   final String titulo;
+  final int? indice;
 
   /// Texto amigável da faixa (ex.: "10,00 ~ 12,00 mm", "≥ 15,30 mm", "≤ 3,2 µm")
   final String faixaTexto;
@@ -89,6 +90,7 @@ class MedidaItem {
 
   MedidaItem({
     required this.titulo,
+    this.indice,
     this.faixaTexto = '',
     this.minimo,
     this.maximo,
@@ -306,8 +308,18 @@ class MedidaItem {
       });
     }
 
+    int? idx;
+    final rawIdx =
+        map['indice'] ?? map['idx_medida'] ?? map['idx'] ?? map['index'];
+    if (rawIdx is num) {
+      idx = rawIdx.toInt();
+    } else if (rawIdx != null) {
+      idx = int.tryParse(rawIdx.toString());
+    }
+
     return MedidaItem(
       titulo: titulo,
+      indice: idx,
       faixaTexto: faixaOut,
       minimo: minimo,
       maximo: maximo,
@@ -324,6 +336,7 @@ class MedidaItem {
 
   Map<String, dynamic> toMap() => {
     'titulo': titulo,
+    'indice': indice,
     'faixaTexto': faixaTexto,
     'minimo': minimo,
     'maximo': maximo,

--- a/lib/features/preparacao/presentation/preparacao_page.dart
+++ b/lib/features/preparacao/presentation/preparacao_page.dart
@@ -58,6 +58,7 @@ class MedidasPreparadorController
       final normalizados = itens
           .map(
             (m) => MedidaItem(
+              indice: m.indice,
               titulo: m.titulo,
               faixaTexto: m.faixaTexto,
               minimo: m.minimo,
@@ -85,6 +86,7 @@ class MedidasPreparadorController
     if (index < 0 || index >= current.length) return;
     final old = current[index];
     current[index] = MedidaItem(
+      indice: old.indice,
       titulo: old.titulo,
       faixaTexto: old.faixaTexto,
       minimo: old.minimo,
@@ -106,6 +108,7 @@ class MedidasPreparadorController
     for (var i = 0; i < current.length; i++) {
       final old = current[i];
       current[i] = MedidaItem(
+        indice: old.indice,
         titulo: old.titulo,
         faixaTexto: old.faixaTexto,
         minimo: old.minimo,
@@ -333,7 +336,7 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
     for (var i = 0; i < medidas.length; i++) {
       final m = medidas[i];
       itens.add({
-        'indice': i,
+        'indice': m.indice ?? i,
         'titulo': m.titulo,
         'faixaTexto': m.faixaTexto,
         'min': m.minimo,


### PR DESCRIPTION
## Summary
- include the original `idx_medida` value in the sampling endpoints so the client can reuse the real index when submitting measurements
- extend `MedidaItem` to carry the backend index and propagate it through the operador, preparação and finalização flows (including troca de ferramenta) when building payloads
- update the local data adapter to read the optional index value from assets, keeping state updates and history counters aligned

## Testing
- flutter analyze

------
https://chatgpt.com/codex/tasks/task_e_68d14c1f365483319056a6bc923c60c0