### PR TITLE
Robustly persist operator measurement counters across reloads

### DIFF
--- a/app_db.py
+++ b/app_db.py
@@ -9,6 +9,7 @@ import re
 import json
 import io
 import math
+import unicodedata
 from decimal import Decimal
 from datetime import date, datetime
 
@@ -679,8 +680,11 @@ def _medidas_preparador_db(part: str, op: str):
                 mn = 0.0
             elif mn is None and mx is not None:
                 mn = 0.0
+        idx = row.get("idx_medida")
         medidas.append(
             {
+                "indice": idx,
+                "idx_medida": idx,
                 "titulo": titulo,
                 "faixaTexto": faixa,
                 "min": mn,
@@ -690,6 +694,18 @@ def _medidas_preparador_db(part: str, op: str):
             }
         )
     return medidas
+
+
+def _normalize_title_key(text: str) -> str:
+    t = _norm(text).lower()
+    if not t:
+        return ""
+    norm = unicodedata.normalize("NFD", t)
+    without_marks = "".join(
+        ch for ch in norm if unicodedata.category(ch) != "Mn"
+    )
+    collapsed = re.sub(r"\s+", " ", without_marks)
+    return collapsed.strip()
 
 
 def _medidas_operador_db(part: str, op: str):
@@ -717,30 +733,36 @@ def _medidas_operador_db(part: str, op: str):
             cur.execute(
                 """
                 SELECT i.idx_medida,
+                       i.titulo,
                        i.escolha,
                        COUNT(*) AS qtd
                   FROM operador_amostragem_item i
                   JOIN operador_amostragem a ON a.id = i.amostragem_id
                  WHERE TRIM(LEADING '0' FROM TRIM(a.partnumber))=%s
                    AND TRIM(LEADING '0' FROM TRIM(a.operacao))=%s
-                 GROUP BY i.idx_medida, i.escolha
+                 GROUP BY i.idx_medida, i.titulo, i.escolha
                 """,
                 (part, op),
             )
             contagens_rows = cur.fetchall()
 
     contagens_por_indice = defaultdict(lambda: defaultdict(int))
+    contagens_por_titulo = defaultdict(lambda: defaultdict(int))
     for cnt in contagens_rows:
         idx = cnt.get("idx_medida")
         escolha = (cnt.get("escolha") or "").strip()
+        titulo_key = _normalize_title_key(cnt.get("titulo"))
         qtd = int(cnt.get("qtd") or 0)
-        if idx is None or not escolha or qtd <= 0:
+        if not escolha or qtd <= 0:
             continue
         partes = [p.strip() for p in escolha.split("|") if p.strip()]
         if not partes:
             partes = [escolha]
         for parte in partes:
-            contagens_por_indice[idx][parte] += qtd
+            if idx is not None:
+                contagens_por_indice[idx][parte] += qtd
+            if titulo_key:
+                contagens_por_titulo[titulo_key][parte] += qtd
 
     medidas = []
     for row in rows:
@@ -771,9 +793,14 @@ def _medidas_operador_db(part: str, op: str):
             row.get("reprovada_acima"),
         ]
         tolerancias = [t for t in tolerancias if t is not None]
-        raw_counts = contagens_por_indice.get(idx) or {}
+        raw_counts = contagens_por_indice.get(idx)
+        if not raw_counts:
+            raw_counts = contagens_por_titulo.get(_normalize_title_key(titulo))
+        raw_counts = {k: int(v) for k, v in (raw_counts or {}).items()}
         medidas.append(
             {
+                "indice": idx,
+                "idx_medida": idx,
                 "titulo": titulo,
                 "faixaTexto": faixa,
                 "min": mn,
@@ -1684,6 +1711,27 @@ def operador_registrar():
                 if not cur.fetchone():
                     return jsonify({"error": "máquina não cadastrada"}), 400
 
+            titulo_idx_map = {}
+            with c.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT idx_medida, titulo
+                      FROM for09_norm
+                     WHERE TRIM(LEADING '0' FROM TRIM(partnumber))=%s
+                       AND TRIM(LEADING '0' FROM TRIM(operacao))=%s
+                    """,
+                    (part, op),
+                )
+                for row in cur.fetchall():
+                    idx_row = row.get("idx_medida")
+                    titulo_row = _normalize_title_key(row.get("titulo"))
+                    if idx_row is None or not titulo_row:
+                        continue
+                    try:
+                        titulo_idx_map[titulo_row] = int(idx_row)
+                    except (TypeError, ValueError):
+                        continue
+
             # BLOQUEIO: exige liberação
             ok, fonte, detalhe = _maquina_liberada(c, os_num, part, op, maquina)
             if not ok:
@@ -1718,8 +1766,28 @@ def operador_registrar():
 
                 # itens
                 for it in itens:
-                    idx = int(it.get("indice", 0))
+                    raw_idx = it.get("indice")
+                    idx = None
+                    if isinstance(raw_idx, (int, float)):
+                        idx = int(raw_idx)
+                    elif raw_idx is not None:
+                        try:
+                            idx = int(str(raw_idx).strip())
+                        except Exception:
+                            idx = None
+
+                    if idx is not None and idx < 0:
+                        idx = None
+
                     titulo = _norm(it.get("titulo"))
+                    titulo_key = _normalize_title_key(titulo)
+                    if (idx is None or idx == 0) and titulo_key:
+                        guessed = titulo_idx_map.get(titulo_key)
+                        if guessed is not None:
+                            idx = guessed
+                    if idx is None:
+                        idx = i
+
                     instrumento = _norm(it.get("instrumento"))
                     faixa_texto = _norm(it.get("faixaTexto"))
                     minimo = it.get("min")

--- a/lib/features/finalizar_os/presentation/finalizar_os_page.dart
+++ b/lib/features/finalizar_os/presentation/finalizar_os_page.dart
@@ -57,6 +57,7 @@ class MedidasFinalizadorController
       final normalizados = itens
           .map(
             (m) => MedidaItem(
+              indice: m.indice,
               titulo: m.titulo,
               faixaTexto: m.faixaTexto,
               minimo: m.minimo,
@@ -84,6 +85,7 @@ class MedidasFinalizadorController
     if (index < 0 || index >= current.length) return;
     final old = current[index];
     current[index] = MedidaItem(
+      indice: old.indice,
       titulo: old.titulo,
       faixaTexto: old.faixaTexto,
       minimo: old.minimo,
@@ -105,6 +107,7 @@ class MedidasFinalizadorController
     for (var i = 0; i < current.length; i++) {
       final old = current[i];
       current[i] = MedidaItem(
+        indice: old.indice,
         titulo: old.titulo,
         faixaTexto: old.faixaTexto,
         minimo: old.minimo,
@@ -318,7 +321,7 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
     for (var i = 0; i < medidas.length; i++) {
       final m = medidas[i];
       itens.add({
-        'indice': i,
+        'indice': m.indice ?? i,
         'titulo': m.titulo,
         'faixaTexto': m.faixaTexto,
         'min': m.minimo,

--- a/lib/features/operador/data/models.dart
+++ b/lib/features/operador/data/models.dart
@@ -63,6 +63,7 @@ String statusToString(StatusMedida s) {
 class MedidaItem {
   // Básicos
   final String titulo;
+  final int? indice;
 
   /// Texto amigável da faixa (ex.: "10,00 ~ 12,00 mm", "≥ 15,30 mm", "≤ 3,2 µm")
   final String faixaTexto;
@@ -91,6 +92,7 @@ class MedidaItem {
 
   MedidaItem({
     required this.titulo,
+    this.indice,
     this.faixaTexto = '',
     this.minimo,
     this.maximo,
@@ -308,8 +310,18 @@ class MedidaItem {
       });
     }
 
+    int? idx;
+    final rawIdx =
+        map['indice'] ?? map['idx_medida'] ?? map['idx'] ?? map['index'];
+    if (rawIdx is num) {
+      idx = rawIdx.toInt();
+    } else if (rawIdx != null) {
+      idx = int.tryParse(rawIdx.toString());
+    }
+
     return MedidaItem(
       titulo: titulo,
+      indice: idx,
       faixaTexto: faixaOut,
       minimo: minimo,
       maximo: maximo,
@@ -326,6 +338,7 @@ class MedidaItem {
 
   Map<String, dynamic> toMap() => {
     'titulo': titulo,
+    'indice': indice,
     'faixaTexto': faixaTexto,
     'minimo': minimo,
     'maximo': maximo,

--- a/lib/features/operador/presentation/operador_page.dart
+++ b/lib/features/operador/presentation/operador_page.dart
@@ -59,6 +59,7 @@ class MedidasOperadorController
     if (index < 0 || index >= current.length) return;
     final old = current[index];
     current[index] = MedidaItem(
+      indice: old.indice,
       titulo: old.titulo,
       faixaTexto: old.faixaTexto,
       minimo: old.minimo,
@@ -81,6 +82,7 @@ class MedidasOperadorController
     for (var i = 0; i < current.length; i++) {
       final old = current[i];
       current[i] = MedidaItem(
+        indice: old.indice,
         titulo: old.titulo,
         faixaTexto: old.faixaTexto,
         minimo: old.minimo,
@@ -124,6 +126,7 @@ class MedidasOperadorController
       }
 
       current[i] = MedidaItem(
+        indice: old.indice,
         titulo: old.titulo,
         faixaTexto: old.faixaTexto,
         minimo: old.minimo,
@@ -301,7 +304,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
       final m = medidas[i];
       final map = m.toMap();
       // índice esperado pelo backend
-      map['indice'] = i;
+      map['indice'] = m.indice ?? map['indice'] ?? i;
       // backend espera 'min'/'max' e não 'minimo'/'maximo'
       map['min'] = m.minimo;
       map['max'] = m.maximo;

--- a/lib/features/operador/presentation/troca_ferramenta_page.dart
+++ b/lib/features/operador/presentation/troca_ferramenta_page.dart
@@ -131,6 +131,7 @@ class _TrocaFerramentaPageState extends State<TrocaFerramentaPage> {
     final selecionadas = ordenadas.map((idx) {
       final item = _todas[idx];
       return MedidaItem(
+        indice: item.indice,
         titulo: item.titulo,
         faixaTexto: item.faixaTexto,
         minimo: item.minimo,
@@ -157,6 +158,7 @@ class _TrocaFerramentaPageState extends State<TrocaFerramentaPage> {
     if (index < 0 || index >= itens.length) return;
     final antigo = itens[index];
     itens[index] = MedidaItem(
+      indice: antigo.indice,
       titulo: antigo.titulo,
       faixaTexto: antigo.faixaTexto,
       minimo: antigo.minimo,
@@ -252,7 +254,7 @@ class _TrocaFerramentaPageState extends State<TrocaFerramentaPage> {
     for (var i = 0; i < _medidasSelecionadas.length; i++) {
       final m = _medidasSelecionadas[i];
       itens.add({
-        'indice': i,
+        'indice': m.indice ?? i,
         'titulo': m.titulo,
         'faixaTexto': m.faixaTexto,
         'min': m.minimo,

--- a/lib/features/preparacao/data/local_excel_repository.dart
+++ b/lib/features/preparacao/data/local_excel_repository.dart
@@ -51,6 +51,14 @@ class LocalExcelRepository implements MedidasRepository {
         double? min = _toDouble(map['minimo'] ?? map['min']);
         double? max = _toDouble(map['maximo'] ?? map['max']);
         String? unidade = map['unidade']?.toString();
+        int? indice;
+        final rawIdx =
+            map['indice'] ?? map['idx_medida'] ?? map['idx'] ?? map['index'];
+        if (rawIdx is num) {
+          indice = rawIdx.toInt();
+        } else if (rawIdx != null) {
+          indice = int.tryParse(rawIdx.toString());
+        }
 
         if (faixaTexto.isEmpty && (min != null || max != null)) {
           final minStr = min?.toStringAsFixed(2) ?? '';
@@ -67,6 +75,7 @@ class LocalExcelRepository implements MedidasRepository {
 
         return MedidaItem(
           titulo: (map['titulo'] ?? '').toString(),
+          indice: indice,
           faixaTexto: faixaTexto,
           minimo: min,
           maximo: max,

--- a/lib/features/preparacao/data/models.dart
+++ b/lib/features/preparacao/data/models.dart
@@ -61,6 +61,7 @@ String statusToString(StatusMedida s) {
 class MedidaItem {
   // Básicos
   final String titulo;
+  final int? indice;
 
   /// Texto amigável da faixa (ex.: "10,00 ~ 12,00 mm", "≥ 15,30 mm", "≤ 3,2 µm")
   final String faixaTexto;
@@ -89,6 +90,7 @@ class MedidaItem {
 
   MedidaItem({
     required this.titulo,
+    this.indice,
     this.faixaTexto = '',
     this.minimo,
     this.maximo,
@@ -306,8 +308,18 @@ class MedidaItem {
       });
     }
 
+    int? idx;
+    final rawIdx =
+        map['indice'] ?? map['idx_medida'] ?? map['idx'] ?? map['index'];
+    if (rawIdx is num) {
+      idx = rawIdx.toInt();
+    } else if (rawIdx != null) {
+      idx = int.tryParse(rawIdx.toString());
+    }
+
     return MedidaItem(
       titulo: titulo,
+      indice: idx,
       faixaTexto: faixaOut,
       minimo: minimo,
       maximo: maximo,
@@ -324,6 +336,7 @@ class MedidaItem {
 
   Map<String, dynamic> toMap() => {
     'titulo': titulo,
+    'indice': indice,
     'faixaTexto': faixaTexto,
     'minimo': minimo,
     'maximo': maximo,

--- a/lib/features/preparacao/presentation/preparacao_page.dart
+++ b/lib/features/preparacao/presentation/preparacao_page.dart
@@ -58,6 +58,7 @@ class MedidasPreparadorController
       final normalizados = itens
           .map(
             (m) => MedidaItem(
+              indice: m.indice,
               titulo: m.titulo,
               faixaTexto: m.faixaTexto,
               minimo: m.minimo,
@@ -85,6 +86,7 @@ class MedidasPreparadorController
     if (index < 0 || index >= current.length) return;
     final old = current[index];
     current[index] = MedidaItem(
+      indice: old.indice,
       titulo: old.titulo,
       faixaTexto: old.faixaTexto,
       minimo: old.minimo,
@@ -106,6 +108,7 @@ class MedidasPreparadorController
     for (var i = 0; i < current.length; i++) {
       final old = current[i];
       current[i] = MedidaItem(
+        indice: old.indice,
         titulo: old.titulo,
         faixaTexto: old.faixaTexto,
         minimo: old.minimo,
@@ -333,7 +336,7 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
     for (var i = 0; i < medidas.length; i++) {
       final m = medidas[i];
       itens.add({
-        'indice': i,
+        'indice': m.indice ?? i,
         'titulo': m.titulo,
         'faixaTexto': m.faixaTexto,
         'min': m.minimo,


### PR DESCRIPTION
## Summary
- normalize measurement titles when computing aggregated operator counts so history persists even without idx values
- reuse the same normalization when storing new operator entries to recover the backend idx_medida whenever possible before falling back to a safe default

## Testing
- flutter analyze

------
https://chatgpt.com/codex/tasks/task_e_68d14c1f365483319056a6bc923c60c0