### PR TITLE
Rename app display name to Relic - Controle de Qualidade

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
     package="com.example.admin">
    <uses-permission android:name="android.permission.INTERNET"/>
    <application
-        android:label="admin"
+        android:label="Relic - Controle de Qualidade"
         android:icon="@mipmap/ic_launcher">
         <activity
             android:name=".MainActivity"

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -10,8 +10,8 @@
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
-	<key>CFBundleName</key>
-	<string>admin</string>
+        <key>CFBundleName</key>
+        <string>Relic - Controle de Qualidade</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -55,7 +55,7 @@
 /* Begin PBXFileReference section */
 		333000ED22D3DE5D00554162 /* Warnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Warnings.xcconfig; sourceTree = "<group>"; };
 		335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeneratedPluginRegistrant.swift; sourceTree = "<group>"; };
-		33CC10ED2044A3C60003C045 /* admin.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = admin.app; sourceTree = BUILT_PRODUCTS_DIR; };
+                33CC10ED2044A3C60003C045 /* Relic - Controle de Qualidade.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Relic - Controle de Qualidade.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		33CC10F02044A3C60003C045 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		33CC10F22044A3C60003C045 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = Runner/Assets.xcassets; sourceTree = "<group>"; };
 		33CC10F52044A3C60003C045 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
@@ -112,7 +112,7 @@
 		33CC10EE2044A3C60003C045 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				33CC10ED2044A3C60003C045 /* admin.app */,
+                                33CC10ED2044A3C60003C045 /* Relic - Controle de Qualidade.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -193,7 +193,7 @@
 			);
 			name = Runner;
 			productName = Runner;
-			productReference = 33CC10ED2044A3C60003C045 /* admin.app */;
+                        productReference = 33CC10ED2044A3C60003C045 /* Relic - Controle de Qualidade.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */

--- a/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-               BuildableName = "admin.app"
+               BuildableName = "Relic - Controle de Qualidade.app"
                BlueprintName = "Runner"
                ReferencedContainer = "container:Runner.xcodeproj">
             </BuildableReference>
@@ -31,7 +31,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "admin.app"
+            BuildableName = "Relic - Controle de Qualidade.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
@@ -54,7 +54,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "admin.app"
+            BuildableName = "Relic - Controle de Qualidade.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
@@ -73,7 +73,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "admin.app"
+            BuildableName = "Relic - Controle de Qualidade.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>

--- a/macos/Runner/Configs/AppInfo.xcconfig
+++ b/macos/Runner/Configs/AppInfo.xcconfig
@@ -5,7 +5,7 @@
 // 'flutter create' template.
 
 // The application's name. By default this is also the title of the Flutter window.
-PRODUCT_NAME = admin
+PRODUCT_NAME = Relic - Controle de Qualidade
 
 // The application's bundle identifier
 PRODUCT_BUNDLE_IDENTIFIER = com.example.admin

--- a/web/index.html
+++ b/web/index.html
@@ -21,13 +21,13 @@
     <!-- iOS meta tags & icons -->
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black" />
-    <meta name="apple-mobile-web-app-title" content="admin" />
+    <meta name="apple-mobile-web-app-title" content="Relic - Controle de Qualidade" />
     <link rel="apple-touch-icon" href="icons/Icon-192.png" />
 
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="favicon.png" />
 
-    <title>admin</title>
+    <title>Relic - Controle de Qualidade</title>
     <link rel="manifest" href="manifest.json" />
     <!-- Styling for loading indicator -->
     <style>

--- a/web/manifest.json
+++ b/web/manifest.json
@@ -1,6 +1,6 @@
 {
-    "name": "admin",
-    "short_name": "admin",
+    "name": "Relic - Controle de Qualidade",
+    "short_name": "Relic - Controle de Qualidade",
     "start_url": ".",
     "display": "standalone",
     "background_color": "#0175C2",

--- a/windows/runner/Runner.rc
+++ b/windows/runner/Runner.rc
@@ -90,12 +90,12 @@ BEGIN
         BLOCK "040904e4"
         BEGIN
             VALUE "CompanyName", "Med Genie" "\0"
-            VALUE "FileDescription", "A new Flutter project." "\0"
+            VALUE "FileDescription", "Relic - Controle de Qualidade" "\0"
             VALUE "FileVersion", VERSION_AS_STRING "\0"
-            VALUE "InternalName", "flutter_admin_portal" "\0"
+            VALUE "InternalName", "Relic - Controle de Qualidade" "\0"
             VALUE "LegalCopyright", "Copyright (C) 2021 FAP. All rights reserved." "\0"
             VALUE "OriginalFilename", "fdp.exe" "\0"
-            VALUE "ProductName", "flutter_admin_portal" "\0"
+            VALUE "ProductName", "Relic - Controle de Qualidade" "\0"
             VALUE "ProductVersion", VERSION_AS_STRING "\0"
         END
     END

--- a/windows/runner/main.cpp
+++ b/windows/runner/main.cpp
@@ -30,7 +30,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   FlutterWindow window(&run_loop, project);
   Win32Window::Point origin(100, 100);    
   Win32Window::Size size(1200, 650);    
-  if (!window.CreateAndShow(L"FAP", origin, size)) {
+  if (!window.CreateAndShow(L"Relic - Controle de Qualidade", origin, size)) {
     return EXIT_FAILURE;
   }  
   window.SetQuitOnClose(true);


### PR DESCRIPTION
## Summary
- update platform manifests and configuration to display "Relic - Controle de Qualidade"
- align macOS and Windows project metadata and window title with the new branding
- refresh web manifest and HTML metadata to use the updated app name

## Testing
- flutter test

------
https://chatgpt.com/codex/tasks/task_e_68d16f4b9dc88331bc750764cf25983c