### PR TITLE
Enforce single active OS flow per device

### DIFF
--- a/lib/features/finalizar_os/presentation/finalizar_os_page.dart
+++ b/lib/features/finalizar_os/presentation/finalizar_os_page.dart
@@ -231,6 +231,37 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
     );
   }
 
+  bool _flowMatchesCurrentForm(SharedSearchFormState shared) {
+    if (!shared.isActive) return true;
+    return shared.matchesValues(
+      os: _osCtrl.text,
+      partNumber: _partCtrl.text,
+      operacao: _opCtrl.text,
+      categoria: _categoriaSel,
+      maquina: _maquinaSel,
+    );
+  }
+
+  void _showFlowBlockedSnackBar(SharedSearchFormState shared) {
+    if (!mounted) return;
+    final osAtual = shared.os.trim();
+    final mensagem = osAtual.isEmpty
+        ? 'Finalize a O.S. em andamento antes de iniciar outra.'
+        : 'Finalize a O.S. $osAtual antes de iniciar outra.';
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(mensagem)));
+  }
+
+  bool _ensureFlowConsistency() {
+    final shared = ref.read(sharedSearchFormProvider);
+    if (_flowMatchesCurrentForm(shared)) {
+      return true;
+    }
+    _showFlowBlockedSnackBar(shared);
+    return false;
+  }
+
   @override
   void dispose() {
     _osCtrl.removeListener(_resetFinalizada);
@@ -297,6 +328,8 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
       );
       return;
     }
+
+    if (!_ensureFlowConsistency()) return;
 
     // Verifica se há alguma medida reprovada
     final reprovadas = medidas
@@ -397,6 +430,8 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
   Widget build(BuildContext context) {
     final medidasAsync = ref.watch(medidasFinalizadorControllerProvider);
     final medidas = medidasAsync.value ?? [];
+    final flowState = ref.watch(sharedSearchFormProvider);
+    final flowLocked = flowState.isActive;
 
     // Pode registrar quando: RE e OS preenchidos + todas as medições preenchidas
     final reOk = _reCtrl.text.trim().isNotEmpty;
@@ -414,6 +449,15 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
         ? _maquinaSel
         : null;
     final maquinaOk = (maquinaValue ?? '').isNotEmpty;
+    final formMatchesFlow =
+        !flowLocked ||
+        flowState.matchesValues(
+          os: _osCtrl.text,
+          partNumber: _partCtrl.text,
+          operacao: _opCtrl.text,
+          categoria: categoriaValue,
+          maquina: maquinaValue,
+        );
     final todasOk =
         medidas.isNotEmpty &&
         medidas.every(
@@ -421,7 +465,13 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
               (m.medicao ?? '').isNotEmpty && m.status != StatusMedida.pendente,
         );
     final podeRegistrar =
-        reOk && osOk && maquinaOk && todasOk && !_registrando && !_osFinalizada;
+        formMatchesFlow &&
+        reOk &&
+        osOk &&
+        maquinaOk &&
+        todasOk &&
+        !_registrando &&
+        !_osFinalizada;
 
     return Scaffold(
       appBar: WindowBar(
@@ -448,6 +498,37 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
           padding: const EdgeInsets.all(16.0),
           child: Column(
             children: [
+              if (flowLocked)
+                Container(
+                  width: double.infinity,
+                  margin: const EdgeInsets.only(bottom: 12),
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color: Theme.of(
+                      context,
+                    ).colorScheme.surfaceContainerHighest,
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Icon(
+                        Icons.lock,
+                        size: 18,
+                        color: Theme.of(context).colorScheme.primary,
+                      ),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: Text(
+                          flowState.os.trim().isEmpty
+                              ? 'Existe um fluxo de O.S. em andamento. Finalize a O.S. atual para iniciar outra.'
+                              : 'Fluxo ativo para a O.S. ${flowState.os}. Finalize a O.S. atual para iniciar outra.',
+                          style: Theme.of(context).textTheme.bodyMedium,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
               if (_mostrarResumo) ...[
                 SearchSummaryCard(
                   reLabel: 'R.E. do Preparador',
@@ -466,10 +547,12 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
                 Align(
                   alignment: Alignment.centerRight,
                   child: TextButton.icon(
-                    onPressed: () {
-                      FocusScope.of(context).unfocus();
-                      setState(() => _mostrarResumo = false);
-                    },
+                    onPressed: flowLocked
+                        ? null
+                        : () {
+                            FocusScope.of(context).unfocus();
+                            setState(() => _mostrarResumo = false);
+                          },
                     icon: const Icon(Icons.edit_outlined),
                     label: const Text('Alterar dados da busca'),
                   ),
@@ -508,6 +591,7 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
                             width: 140, // igual ao campo Operação
                             child: TextFormField(
                               controller: _osCtrl,
+                              enabled: !flowLocked,
                               textInputAction: TextInputAction.next,
                               keyboardType: TextInputType.number,
                               inputFormatters: [
@@ -548,15 +632,19 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
                                     ),
                                   )
                                   .toList(),
-                              onChanged: (v) {
-                                ref
-                                    .read(sharedSearchFormProvider.notifier)
-                                    .setCategoria(v);
-                                setState(() {
-                                  _categoriaSel = v;
-                                  _maquinaSel = null;
-                                });
-                              },
+                              onChanged: flowLocked
+                                  ? null
+                                  : (v) {
+                                      ref
+                                          .read(
+                                            sharedSearchFormProvider.notifier,
+                                          )
+                                          .setCategoria(v);
+                                      setState(() {
+                                        _categoriaSel = v;
+                                        _maquinaSel = null;
+                                      });
+                                    },
                               validator: (v) => (v == null || v.isEmpty)
                                   ? 'Obrigatório'
                                   : null,
@@ -578,12 +666,16 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
                                     ),
                                   )
                                   .toList(),
-                              onChanged: (v) {
-                                ref
-                                    .read(sharedSearchFormProvider.notifier)
-                                    .setMaquina(v);
-                                setState(() => _maquinaSel = v);
-                              },
+                              onChanged: flowLocked
+                                  ? null
+                                  : (v) {
+                                      ref
+                                          .read(
+                                            sharedSearchFormProvider.notifier,
+                                          )
+                                          .setMaquina(v);
+                                      setState(() => _maquinaSel = v);
+                                    },
                               validator: (v) => (v == null || v.isEmpty)
                                   ? 'Obrigatório'
                                   : null,
@@ -600,6 +692,7 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
                           Expanded(
                             child: TextFormField(
                               controller: _partCtrl,
+                              enabled: !flowLocked,
                               textInputAction: TextInputAction.next,
                               decoration: const InputDecoration(
                                 labelText: 'Código da peça (PartNumber)',
@@ -615,6 +708,7 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
                             width: 140,
                             child: TextFormField(
                               controller: _opCtrl,
+                              enabled: !flowLocked,
                               keyboardType: TextInputType.number,
                               inputFormatters: [
                                 FilteringTextInputFormatter.digitsOnly,
@@ -641,6 +735,7 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
                         child: FilledButton.icon(
                           onPressed: () async {
                             if (_formKey.currentState!.validate()) {
+                              if (!_ensureFlowConsistency()) return;
                               FocusScope.of(context).unfocus();
                               await ref
                                   .read(

--- a/lib/features/operador/presentation/operador_page.dart
+++ b/lib/features/operador/presentation/operador_page.dart
@@ -251,6 +251,37 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
     );
   }
 
+  bool _flowMatchesCurrentForm(SharedSearchFormState shared) {
+    if (!shared.isActive) return true;
+    return shared.matchesValues(
+      os: _osCtrl.text,
+      partNumber: _partCtrl.text,
+      operacao: _opCtrl.text,
+      categoria: _categoriaSel,
+      maquina: _maquinaSel,
+    );
+  }
+
+  void _showFlowBlockedSnackBar(SharedSearchFormState shared) {
+    if (!mounted) return;
+    final osAtual = shared.os.trim();
+    final mensagem = osAtual.isEmpty
+        ? 'Finalize a O.S. em andamento antes de iniciar outra.'
+        : 'Finalize a O.S. $osAtual antes de iniciar outra.';
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(mensagem)));
+  }
+
+  bool _ensureFlowConsistency() {
+    final shared = ref.read(sharedSearchFormProvider);
+    if (_flowMatchesCurrentForm(shared)) {
+      return true;
+    }
+    _showFlowBlockedSnackBar(shared);
+    return false;
+  }
+
   @override
   void dispose() {
     _osCtrl.removeListener(_osSyncListener);
@@ -278,6 +309,8 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
       );
       return;
     }
+
+    if (!_ensureFlowConsistency()) return;
 
     // Todas respondidas?
     final faltando = <int>[];
@@ -391,6 +424,8 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
       );
       return;
     }
+
+    if (!_ensureFlowConsistency()) return;
 
     final body = jsonEncode({
       're': _reCtrl.text.trim(),
@@ -551,6 +586,8 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
       return;
     }
 
+    if (!_ensureFlowConsistency()) return;
+
     final body = jsonEncode({'os': _osCtrl.text.trim()});
     final uri = buildApiUri('/operador/encerrar_producao');
     try {
@@ -600,14 +637,21 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
   }
 
   Future<void> _abrirPaginaFinalizacaoOs() async {
+    if (!_ensureFlowConsistency()) return;
+
     final notifier = ref.read(sharedSearchFormProvider.notifier);
-    notifier.beginFlow(
+    final iniciouFluxo = notifier.beginFlow(
       os: _osCtrl.text,
       partNumber: _partCtrl.text,
       operacao: _opCtrl.text,
       categoria: _categoriaSel,
       maquina: _maquinaSel,
     );
+
+    if (!iniciouFluxo) {
+      _showFlowBlockedSnackBar(ref.read(sharedSearchFormProvider));
+      return;
+    }
 
     if (mounted) {
       FocusScope.of(context).unfocus();
@@ -625,6 +669,8 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
   Widget build(BuildContext context) {
     final medidasAsync = ref.watch(medidasOperadorControllerProvider);
     final medidas = medidasAsync.value ?? [];
+    final flowState = ref.watch(sharedSearchFormProvider);
+    final flowLocked = flowState.isActive;
     final reOk = _reCtrl.text.trim().isNotEmpty;
     final osOk = _osCtrl.text.trim().isNotEmpty;
     final categoriaValue =
@@ -640,6 +686,15 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
         ? _maquinaSel
         : null;
     final maquinaOk = (maquinaValue ?? '').isNotEmpty;
+    final formMatchesFlow =
+        !flowLocked ||
+        flowState.matchesValues(
+          os: _osCtrl.text,
+          partNumber: _partCtrl.text,
+          operacao: _opCtrl.text,
+          categoria: categoriaValue,
+          maquina: maquinaValue,
+        );
 
     // todas respondidas?
     final todasRespondidas =
@@ -650,7 +705,12 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
         );
 
     final podeRegistrar =
-        reOk && osOk && maquinaOk && todasRespondidas && !_registrando;
+        formMatchesFlow &&
+        reOk &&
+        osOk &&
+        maquinaOk &&
+        todasRespondidas &&
+        !_registrando;
 
     return Scaffold(
       appBar: WindowBar(
@@ -677,6 +737,37 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
           padding: const EdgeInsets.all(16.0),
           child: Column(
             children: [
+              if (flowLocked)
+                Container(
+                  width: double.infinity,
+                  margin: const EdgeInsets.only(bottom: 12),
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color: Theme.of(
+                      context,
+                    ).colorScheme.surfaceContainerHighest,
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Icon(
+                        Icons.lock,
+                        size: 18,
+                        color: Theme.of(context).colorScheme.primary,
+                      ),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: Text(
+                          flowState.os.trim().isEmpty
+                              ? 'Existe um fluxo de O.S. em andamento. Finalize a O.S. atual para iniciar outra.'
+                              : 'Fluxo ativo para a O.S. ${flowState.os}. Finalize a O.S. atual para iniciar outra.',
+                          style: Theme.of(context).textTheme.bodyMedium,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
               if (_mostrarResumo) ...[
                 SearchSummaryCard(
                   reLabel: 'R.E. do Preparador',
@@ -695,10 +786,12 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                 Align(
                   alignment: Alignment.centerRight,
                   child: TextButton.icon(
-                    onPressed: () {
-                      FocusScope.of(context).unfocus();
-                      setState(() => _mostrarResumo = false);
-                    },
+                    onPressed: flowLocked
+                        ? null
+                        : () {
+                            FocusScope.of(context).unfocus();
+                            setState(() => _mostrarResumo = false);
+                          },
                     icon: const Icon(Icons.edit_outlined),
                     label: const Text('Alterar dados da busca'),
                   ),
@@ -737,6 +830,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                             width: 140, // igual ao campo Operação
                             child: TextFormField(
                               controller: _osCtrl,
+                              enabled: !flowLocked,
                               textInputAction: TextInputAction.next,
                               keyboardType: TextInputType.number,
                               inputFormatters: [
@@ -777,15 +871,19 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                                     ),
                                   )
                                   .toList(),
-                              onChanged: (v) {
-                                ref
-                                    .read(sharedSearchFormProvider.notifier)
-                                    .setCategoria(v);
-                                setState(() {
-                                  _categoriaSel = v;
-                                  _maquinaSel = null;
-                                });
-                              },
+                              onChanged: flowLocked
+                                  ? null
+                                  : (v) {
+                                      ref
+                                          .read(
+                                            sharedSearchFormProvider.notifier,
+                                          )
+                                          .setCategoria(v);
+                                      setState(() {
+                                        _categoriaSel = v;
+                                        _maquinaSel = null;
+                                      });
+                                    },
                               validator: (v) => (v == null || v.isEmpty)
                                   ? 'Obrigatório'
                                   : null,
@@ -807,12 +905,16 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                                     ),
                                   )
                                   .toList(),
-                              onChanged: (v) {
-                                ref
-                                    .read(sharedSearchFormProvider.notifier)
-                                    .setMaquina(v);
-                                setState(() => _maquinaSel = v);
-                              },
+                              onChanged: flowLocked
+                                  ? null
+                                  : (v) {
+                                      ref
+                                          .read(
+                                            sharedSearchFormProvider.notifier,
+                                          )
+                                          .setMaquina(v);
+                                      setState(() => _maquinaSel = v);
+                                    },
                               validator: (v) => (v == null || v.isEmpty)
                                   ? 'Obrigatório'
                                   : null,
@@ -829,6 +931,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                           Expanded(
                             child: TextFormField(
                               controller: _partCtrl,
+                              enabled: !flowLocked,
                               textInputAction: TextInputAction.next,
                               decoration: const InputDecoration(
                                 labelText: 'Código da peça (PartNumber)',
@@ -844,6 +947,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                             width: 140,
                             child: TextFormField(
                               controller: _opCtrl,
+                              enabled: !flowLocked,
                               keyboardType: TextInputType.number,
                               inputFormatters: [
                                 FilteringTextInputFormatter.digitsOnly,
@@ -870,6 +974,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                         child: FilledButton.icon(
                           onPressed: () async {
                             if (_formKey.currentState!.validate()) {
+                              if (!_ensureFlowConsistency()) return;
                               FocusScope.of(context).unfocus();
                               await ref
                                   .read(

--- a/lib/features/preparacao/presentation/preparacao_page.dart
+++ b/lib/features/preparacao/presentation/preparacao_page.dart
@@ -224,15 +224,53 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
     }
   }
 
-  Future<void> _abrirPaginaOperador() async {
-    final notifier = ref.read(sharedSearchFormProvider.notifier);
-    notifier.beginFlow(
+  bool _flowMatchesCurrentForm(SharedSearchFormState shared) {
+    if (!shared.isActive) return true;
+    return shared.matchesValues(
       os: _osCtrl.text,
       partNumber: _partCtrl.text,
       operacao: _opCtrl.text,
       categoria: _categoriaSel,
       maquina: _maquinaSel,
     );
+  }
+
+  void _showFlowBlockedSnackBar(SharedSearchFormState shared) {
+    if (!mounted) return;
+    final osAtual = shared.os.trim();
+    final mensagem = osAtual.isEmpty
+        ? 'Finalize a O.S. em andamento antes de iniciar outra.'
+        : 'Finalize a O.S. $osAtual antes de iniciar outra.';
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(mensagem)));
+  }
+
+  bool _ensureFlowConsistency() {
+    final shared = ref.read(sharedSearchFormProvider);
+    if (_flowMatchesCurrentForm(shared)) {
+      return true;
+    }
+    _showFlowBlockedSnackBar(shared);
+    return false;
+  }
+
+  Future<void> _abrirPaginaOperador() async {
+    if (!_ensureFlowConsistency()) return;
+
+    final notifier = ref.read(sharedSearchFormProvider.notifier);
+    final iniciouFluxo = notifier.beginFlow(
+      os: _osCtrl.text,
+      partNumber: _partCtrl.text,
+      operacao: _opCtrl.text,
+      categoria: _categoriaSel,
+      maquina: _maquinaSel,
+    );
+
+    if (!iniciouFluxo) {
+      _showFlowBlockedSnackBar(ref.read(sharedSearchFormProvider));
+      return;
+    }
 
     if (mounted) {
       FocusScope.of(context).unfocus();
@@ -293,6 +331,8 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
       );
       return;
     }
+
+    if (!_ensureFlowConsistency()) return;
 
     // Todas respondidas? (para Preparador, cada item precisa de medição)
     final faltando = <int>[];
@@ -416,6 +456,8 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
   Widget build(BuildContext context) {
     final medidasAsync = ref.watch(medidasPreparadorControllerProvider);
     final medidas = medidasAsync.value ?? [];
+    final flowState = ref.watch(sharedSearchFormProvider);
+    final flowLocked = flowState.isActive;
 
     // Pode registrar quando: RE e OS preenchidos + todas as medições preenchidas
     final reOk = _reCtrl.text.trim().isNotEmpty;
@@ -433,6 +475,15 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
         ? _maquinaSel
         : null;
     final maquinaOk = (maquinaValue ?? '').isNotEmpty;
+    final formMatchesFlow =
+        !flowLocked ||
+        flowState.matchesValues(
+          os: _osCtrl.text,
+          partNumber: _partCtrl.text,
+          operacao: _opCtrl.text,
+          categoria: categoriaValue,
+          maquina: maquinaValue,
+        );
     final todasOk =
         medidas.isNotEmpty &&
         medidas.every(
@@ -440,7 +491,13 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
               (m.medicao ?? '').isNotEmpty && m.status != StatusMedida.pendente,
         );
     final podeRegistrar =
-        reOk && osOk && maquinaOk && todasOk && !_registrando && !_osLiberada;
+        formMatchesFlow &&
+        reOk &&
+        osOk &&
+        maquinaOk &&
+        todasOk &&
+        !_registrando &&
+        !_osLiberada;
 
     return Scaffold(
       appBar: WindowBar(
@@ -467,6 +524,37 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
           padding: const EdgeInsets.all(16.0),
           child: Column(
             children: [
+              if (flowLocked)
+                Container(
+                  width: double.infinity,
+                  margin: const EdgeInsets.only(bottom: 12),
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color: Theme.of(
+                      context,
+                    ).colorScheme.surfaceContainerHighest,
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Icon(
+                        Icons.lock,
+                        size: 18,
+                        color: Theme.of(context).colorScheme.primary,
+                      ),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: Text(
+                          flowState.os.trim().isEmpty
+                              ? 'Existe um fluxo de O.S. em andamento. Finalize a O.S. atual para iniciar outra.'
+                              : 'Fluxo ativo para a O.S. ${flowState.os}. Finalize a O.S. atual para iniciar outra.',
+                          style: Theme.of(context).textTheme.bodyMedium,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
               if (_mostrarResumo) ...[
                 SearchSummaryCard(
                   reLabel: 'R.E. do Preparador',
@@ -485,10 +573,12 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
                 Align(
                   alignment: Alignment.centerRight,
                   child: TextButton.icon(
-                    onPressed: () {
-                      FocusScope.of(context).unfocus();
-                      setState(() => _mostrarResumo = false);
-                    },
+                    onPressed: flowLocked
+                        ? null
+                        : () {
+                            FocusScope.of(context).unfocus();
+                            setState(() => _mostrarResumo = false);
+                          },
                     icon: const Icon(Icons.edit_outlined),
                     label: const Text('Alterar dados da busca'),
                   ),
@@ -527,6 +617,7 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
                             width: 140, // igual ao campo Operação
                             child: TextFormField(
                               controller: _osCtrl,
+                              enabled: !flowLocked,
                               textInputAction: TextInputAction.next,
                               keyboardType: TextInputType.number,
                               inputFormatters: [
@@ -567,15 +658,19 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
                                     ),
                                   )
                                   .toList(),
-                              onChanged: (v) {
-                                ref
-                                    .read(sharedSearchFormProvider.notifier)
-                                    .setCategoria(v);
-                                setState(() {
-                                  _categoriaSel = v;
-                                  _maquinaSel = null;
-                                });
-                              },
+                              onChanged: flowLocked
+                                  ? null
+                                  : (v) {
+                                      ref
+                                          .read(
+                                            sharedSearchFormProvider.notifier,
+                                          )
+                                          .setCategoria(v);
+                                      setState(() {
+                                        _categoriaSel = v;
+                                        _maquinaSel = null;
+                                      });
+                                    },
                               validator: (v) => (v == null || v.isEmpty)
                                   ? 'Obrigatório'
                                   : null,
@@ -597,12 +692,16 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
                                     ),
                                   )
                                   .toList(),
-                              onChanged: (v) {
-                                ref
-                                    .read(sharedSearchFormProvider.notifier)
-                                    .setMaquina(v);
-                                setState(() => _maquinaSel = v);
-                              },
+                              onChanged: flowLocked
+                                  ? null
+                                  : (v) {
+                                      ref
+                                          .read(
+                                            sharedSearchFormProvider.notifier,
+                                          )
+                                          .setMaquina(v);
+                                      setState(() => _maquinaSel = v);
+                                    },
                               validator: (v) => (v == null || v.isEmpty)
                                   ? 'Obrigatório'
                                   : null,
@@ -619,6 +718,7 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
                           Expanded(
                             child: TextFormField(
                               controller: _partCtrl,
+                              enabled: !flowLocked,
                               textInputAction: TextInputAction.next,
                               decoration: const InputDecoration(
                                 labelText: 'Código da peça (PartNumber)',
@@ -634,6 +734,7 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
                             width: 140,
                             child: TextFormField(
                               controller: _opCtrl,
+                              enabled: !flowLocked,
                               keyboardType: TextInputType.number,
                               inputFormatters: [
                                 FilteringTextInputFormatter.digitsOnly,
@@ -660,6 +761,7 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
                         child: FilledButton.icon(
                           onPressed: () async {
                             if (_formKey.currentState!.validate()) {
+                              if (!_ensureFlowConsistency()) return;
                               FocusScope.of(context).unfocus();
                               await ref
                                   .read(

--- a/lib/features/shared/providers/search_flow_form_provider.dart
+++ b/lib/features/shared/providers/search_flow_form_provider.dart
@@ -1,5 +1,11 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+String? _normalizeOptional(String? value) {
+  final trimmed = value?.trim();
+  if (trimmed == null || trimmed.isEmpty) return null;
+  return trimmed;
+}
+
 class SharedSearchFormState {
   const SharedSearchFormState({
     this.isActive = false,
@@ -36,6 +42,33 @@ class SharedSearchFormState {
       maquina: maquina == _sentinel ? this.maquina : maquina as String?,
     );
   }
+
+  bool matches(SharedSearchFormState other) {
+    return os == other.os &&
+        partNumber == other.partNumber &&
+        operacao == other.operacao &&
+        categoria == other.categoria &&
+        maquina == other.maquina;
+  }
+
+  bool matchesValues({
+    required String os,
+    required String partNumber,
+    required String operacao,
+    String? categoria,
+    String? maquina,
+  }) {
+    return matches(
+      SharedSearchFormState(
+        isActive: true,
+        os: os.trim(),
+        partNumber: partNumber.trim(),
+        operacao: operacao.trim(),
+        categoria: _normalizeOptional(categoria),
+        maquina: _normalizeOptional(maquina),
+      ),
+    );
+  }
 }
 
 class SharedSearchFormController extends StateNotifier<SharedSearchFormState> {
@@ -43,27 +76,28 @@ class SharedSearchFormController extends StateNotifier<SharedSearchFormState> {
 
   bool get _isActive => state.isActive;
 
-  void beginFlow({
+  bool beginFlow({
     required String os,
     required String partNumber,
     required String operacao,
     String? categoria,
     String? maquina,
   }) {
-    String? normalizeOptional(String? value) {
-      final trimmed = value?.trim();
-      if (trimmed == null || trimmed.isEmpty) return null;
-      return trimmed;
-    }
-
-    state = SharedSearchFormState(
+    final candidate = SharedSearchFormState(
       isActive: true,
       os: os.trim(),
       partNumber: partNumber.trim(),
       operacao: operacao.trim(),
-      categoria: normalizeOptional(categoria),
-      maquina: normalizeOptional(maquina),
+      categoria: _normalizeOptional(categoria),
+      maquina: _normalizeOptional(maquina),
     );
+
+    if (_isActive && state.matches(candidate) == false) {
+      return false;
+    }
+
+    state = candidate;
+    return true;
   }
 
   void setOs(String value) {
@@ -74,7 +108,6 @@ class SharedSearchFormController extends StateNotifier<SharedSearchFormState> {
   }
 
   void setPartNumber(String value) {
-
     if (_isActive == false) return;
     final trimmed = value.trim();
     if (trimmed == state.partNumber) return;

--- a/lib/screens/main/components/side_menu.dart
+++ b/lib/screens/main/components/side_menu.dart
@@ -25,17 +25,55 @@ class SideMenu extends ConsumerWidget {
 
   final SideMenuSection current;
 
+  bool _isFlowPage(Widget page) {
+    return page is PreparacaoPage ||
+        page is OperadorPage ||
+        page is FinalizarOsPage;
+  }
+
+  void _showFlowLockedMessage(
+    BuildContext context,
+    SharedSearchFormState shared,
+  ) {
+    final osAtual = shared.os.trim();
+    final mensagem = osAtual.isEmpty
+        ? 'Finalize a O.S. em andamento antes de iniciar outra.'
+        : 'Finalize a O.S. $osAtual antes de iniciar outra.';
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(mensagem)));
+  }
+
   void _navigate(BuildContext context, WidgetRef ref, Widget page) {
     final navigator = Navigator.of(context, rootNavigator: true);
+    final shared = ref.read(sharedSearchFormProvider);
+    final hasActiveFlow = shared.isActive;
+    final flowPage = _isFlowPage(page);
+
+    if (hasActiveFlow && !flowPage) {
+      navigator.pop();
+      _showFlowLockedMessage(context, shared);
+      return;
+    }
+
     navigator.pop();
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      ref.read(sharedSearchFormProvider.notifier).clear();
+      if (!hasActiveFlow || !flowPage) {
+        ref.read(sharedSearchFormProvider.notifier).clear();
+      }
       navigator.push(MaterialPageRoute(builder: (_) => page));
     });
   }
 
   void _goHome(BuildContext context, WidgetRef ref) {
     final navigator = Navigator.of(context, rootNavigator: true);
+    final shared = ref.read(sharedSearchFormProvider);
+    if (shared.isActive) {
+      navigator.pop();
+      _showFlowLockedMessage(context, shared);
+      return;
+    }
+
     navigator.pop();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       ref.read(sharedSearchFormProvider.notifier).clear();


### PR DESCRIPTION
## Summary
- add flow state matching helpers so an active OS cannot be replaced by a new flow
- lock preparador, operador and finalização forms to the active OS and surface warnings when a mismatch is attempted
- block side menu navigation to unrelated areas while an OS flow is active to keep the device focused on the current order

## Testing
- flutter analyze

------
https://chatgpt.com/codex/tasks/task_e_68d1739dc1e08331877a7a737eeae874