### PR TITLE
Allow dashboard access during active OS

### DIFF
--- a/lib/features/main_menu/main_menu_page.dart
+++ b/lib/features/main_menu/main_menu_page.dart
@@ -79,10 +79,9 @@ class _MainMenuPageState extends ConsumerState<MainMenuPage> {
       final shared = ref.read(sharedSearchFormProvider);
       if (shared.isActive) {
         showFlowLockedMessage(shared);
-        return;
+      } else {
+        ref.read(sharedSearchFormProvider.notifier).clear();
       }
-
-      ref.read(sharedSearchFormProvider.notifier).clear();
       var auth = ref.read(authServiceProvider);
       if (auth == null) {
         final ok = await Navigator.of(

--- a/lib/screens/main/components/side_menu.dart
+++ b/lib/screens/main/components/side_menu.dart
@@ -30,6 +30,7 @@ class SideMenu extends ConsumerWidget {
         page is OperadorPage ||
         page is FinalizarOsPage;
   }
+
   String _flowLockedMessage(SharedSearchFormState shared) {
     final osAtual = shared.os.trim();
     return osAtual.isEmpty
@@ -46,13 +47,20 @@ class SideMenu extends ConsumerWidget {
     ).showSnackBar(SnackBar(content: Text(_flowLockedMessage(shared))));
   }
 
-  void _navigate(BuildContext context, WidgetRef ref, Widget page) {
+  void _navigate(
+    BuildContext context,
+    WidgetRef ref,
+    Widget page, {
+    bool allowDuringActiveFlow = false,
+  }) {
     final navigator = Navigator.of(context, rootNavigator: true);
     final shared = ref.read(sharedSearchFormProvider);
     final hasActiveFlow = shared.isActive;
     final flowPage = _isFlowPage(page);
+    final shouldIgnoreLock =
+        allowDuringActiveFlow && hasActiveFlow && !flowPage;
 
-    if (hasActiveFlow && !flowPage) {
+    if (hasActiveFlow && !flowPage && !shouldIgnoreLock) {
       navigator.pop();
       _showFlowLockedMessage(context, shared);
       return;
@@ -60,7 +68,7 @@ class SideMenu extends ConsumerWidget {
 
     navigator.pop();
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!hasActiveFlow || !flowPage) {
+      if (!hasActiveFlow || (!flowPage && !shouldIgnoreLock)) {
         ref.read(sharedSearchFormProvider.notifier).clear();
       }
       navigator.push(MaterialPageRoute(builder: (_) => page));
@@ -220,7 +228,12 @@ class SideMenu extends ConsumerWidget {
                 );
                 return;
               }
-              _navigate(context, ref, MainScreen());
+              _navigate(
+                context,
+                ref,
+                MainScreen(),
+                allowDuringActiveFlow: true,
+              );
             },
           ),
         ]);


### PR DESCRIPTION
## Summary
- allow navigation to the dashboard even when a search flow is active
- preserve the active OS state while bypassing the flow lock for the dashboard entry point
- keep informing the user about the active OS when opening the admin area

## Testing
- flutter test

------
https://chatgpt.com/codex/tasks/task_e_68d1851175f08331a264fa7d845b7f9a