### PR TITLE
Make preparacao, amostragem, e finalizacao forms scroll with keyboard

### DIFF
--- a/lib/features/finalizar_os/presentation/finalizar_os_page.dart
+++ b/lib/features/finalizar_os/presentation/finalizar_os_page.dart
@@ -496,323 +496,378 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
       body: SafeArea(
         child: Padding(
           padding: const EdgeInsets.all(16.0),
-          child: Column(
-            children: [
-              if (flowLocked)
-                Container(
-                  width: double.infinity,
-                  margin: const EdgeInsets.only(bottom: 12),
-                  padding: const EdgeInsets.all(12),
-                  decoration: BoxDecoration(
-                    color: Theme.of(
-                      context,
-                    ).colorScheme.surfaceContainerHighest,
-                    borderRadius: BorderRadius.circular(8),
-                  ),
-                  child: Row(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Icon(
-                        Icons.lock,
-                        size: 18,
-                        color: Theme.of(context).colorScheme.primary,
+          child: CustomScrollView(
+            keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
+            slivers: [
+              SliverToBoxAdapter(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    if (flowLocked)
+                      Container(
+                        margin: const EdgeInsets.only(bottom: 12),
+                        padding: const EdgeInsets.all(12),
+                        decoration: BoxDecoration(
+                          color: Theme.of(
+                            context,
+                          ).colorScheme.surfaceContainerHighest,
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        child: Row(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Icon(
+                              Icons.lock,
+                              size: 18,
+                              color: Theme.of(context).colorScheme.primary,
+                            ),
+                            const SizedBox(width: 8),
+                            Expanded(
+                              child: Text(
+                                flowState.os.trim().isEmpty
+                                    ? 'Existe um fluxo de O.S. em andamento. Finalize a O.S. atual para iniciar outra.'
+                                    : 'Fluxo ativo para a O.S. ${flowState.os}. Finalize a O.S. atual para iniciar outra.',
+                                style: Theme.of(context).textTheme.bodyMedium,
+                              ),
+                            ),
+                          ],
+                        ),
                       ),
-                      const SizedBox(width: 8),
-                      Expanded(
-                        child: Text(
-                          flowState.os.trim().isEmpty
-                              ? 'Existe um fluxo de O.S. em andamento. Finalize a O.S. atual para iniciar outra.'
-                              : 'Fluxo ativo para a O.S. ${flowState.os}. Finalize a O.S. atual para iniciar outra.',
-                          style: Theme.of(context).textTheme.bodyMedium,
+                    if (_mostrarResumo) ...[
+                      SearchSummaryCard(
+                        reLabel: 'R.E. do Preparador',
+                        reValue: _reCtrl.text,
+                        items: [
+                          SummaryInfo(label: 'O.S.', value: _osCtrl.text),
+                          SummaryInfo(label: 'Peça', value: _partCtrl.text),
+                          SummaryInfo(label: 'Operação', value: _opCtrl.text),
+                          if ((maquinaValue ?? '').isNotEmpty)
+                            SummaryInfo(label: 'Máquina', value: maquinaValue!),
+                          if ((categoriaValue ?? '').isNotEmpty)
+                            SummaryInfo(
+                              label: 'Categoria',
+                              value: categoriaValue!,
+                            ),
+                        ],
+                      ),
+                      const SizedBox(height: 8),
+                      Align(
+                        alignment: Alignment.centerRight,
+                        child: TextButton.icon(
+                          onPressed: flowLocked
+                              ? null
+                              : () {
+                                  FocusScope.of(context).unfocus();
+                                  setState(() => _mostrarResumo = false);
+                                },
+                          icon: const Icon(Icons.edit_outlined),
+                          label: const Text('Alterar dados da busca'),
+                        ),
+                      ),
+                    ] else ...[
+                      Form(
+                        key: _formKey,
+                        child: Column(
+                          children: [
+                            Row(
+                              children: [
+                                Expanded(
+                                  child: TextFormField(
+                                    controller: _reCtrl,
+                                    textInputAction: TextInputAction.next,
+                                    keyboardType: TextInputType.number,
+                                    inputFormatters: [
+                                      FilteringTextInputFormatter.digitsOnly,
+                                    ],
+                                    decoration: const InputDecoration(
+                                      labelText:
+                                          'R.E. do Preparador', // ajuste o texto se for Operador
+                                      border: OutlineInputBorder(),
+                                    ),
+                                    validator: (v) {
+                                      final s = (v ?? '').trim();
+                                      if (s.isEmpty) return 'Obrigatório';
+                                      if (!RegExp(r'^[0-9]+$').hasMatch(s)) {
+                                        return 'Apenas números';
+                                      }
+                                      return null;
+                                    },
+                                  ),
+                                ),
+                                const SizedBox(width: 12),
+                                SizedBox(
+                                  width: 140, // igual ao campo Operação
+                                  child: TextFormField(
+                                    controller: _osCtrl,
+                                    enabled: !flowLocked,
+                                    textInputAction: TextInputAction.next,
+                                    keyboardType: TextInputType.number,
+                                    inputFormatters: [
+                                      FilteringTextInputFormatter.digitsOnly,
+                                    ],
+                                    decoration: const InputDecoration(
+                                      labelText: 'O.S.',
+                                      border: OutlineInputBorder(),
+                                    ),
+                                    validator: (v) {
+                                      final s = (v ?? '').trim();
+                                      if (s.isEmpty) return 'Obrigatório';
+                                      if (!RegExp(r'^[0-9]+$').hasMatch(s)) {
+                                        return 'Apenas números';
+                                      }
+                                      return null;
+                                    },
+                                  ),
+                                ),
+                              ],
+                            ),
+                            const SizedBox(height: 12),
+
+                            Row(
+                              children: [
+                                Expanded(
+                                  child: DropdownButtonFormField<String>(
+                                    value: categoriaValue,
+                                    decoration: const InputDecoration(
+                                      labelText: 'Categoria',
+                                      border: OutlineInputBorder(),
+                                    ),
+                                    items: _categorias
+                                        .map(
+                                          (c) => DropdownMenuItem(
+                                            value: c,
+                                            child: Text(c),
+                                          ),
+                                        )
+                                        .toList(),
+                                    onChanged: flowLocked
+                                        ? null
+                                        : (v) {
+                                            ref
+                                                .read(
+                                                  sharedSearchFormProvider
+                                                      .notifier,
+                                                )
+                                                .setCategoria(v);
+                                            setState(() {
+                                              _categoriaSel = v;
+                                              _maquinaSel = null;
+                                            });
+                                          },
+                                    validator: (v) => (v == null || v.isEmpty)
+                                        ? 'Obrigatório'
+                                        : null,
+                                  ),
+                                ),
+                                const SizedBox(width: 12),
+                                Expanded(
+                                  child: DropdownButtonFormField<String>(
+                                    value: maquinaValue,
+                                    decoration: const InputDecoration(
+                                      labelText: 'Código da máquina',
+                                      border: OutlineInputBorder(),
+                                    ),
+                                    items: maquinasDisponiveis
+                                        .map(
+                                          (m) => DropdownMenuItem(
+                                            value: m.codigo,
+                                            child: Text(m.codigo),
+                                          ),
+                                        )
+                                        .toList(),
+                                    onChanged: flowLocked
+                                        ? null
+                                        : (v) {
+                                            ref
+                                                .read(
+                                                  sharedSearchFormProvider
+                                                      .notifier,
+                                                )
+                                                .setMaquina(v);
+                                            setState(() => _maquinaSel = v);
+                                          },
+                                    validator: (v) => (v == null || v.isEmpty)
+                                        ? 'Obrigatório'
+                                        : null,
+                                  ),
+                                ),
+                              ],
+                            ),
+
+                            const SizedBox(height: 12),
+
+                            // ---------- PartNumber + Operação (Operação só números) ----------
+                            Row(
+                              children: [
+                                Expanded(
+                                  child: TextFormField(
+                                    controller: _partCtrl,
+                                    enabled: !flowLocked,
+                                    textInputAction: TextInputAction.next,
+                                    decoration: const InputDecoration(
+                                      labelText: 'Código da peça (PartNumber)',
+                                      border: OutlineInputBorder(),
+                                    ),
+                                    validator: (v) =>
+                                        (v == null || v.trim().isEmpty)
+                                        ? 'Obrigatório'
+                                        : null,
+                                  ),
+                                ),
+                                const SizedBox(width: 12),
+                                SizedBox(
+                                  width: 140,
+                                  child: TextFormField(
+                                    controller: _opCtrl,
+                                    enabled: !flowLocked,
+                                    keyboardType: TextInputType.number,
+                                    inputFormatters: [
+                                      FilteringTextInputFormatter.digitsOnly,
+                                    ],
+                                    decoration: const InputDecoration(
+                                      labelText: 'Operação',
+                                      border: OutlineInputBorder(),
+                                    ),
+                                    validator: (v) {
+                                      final s = (v ?? '').trim();
+                                      if (s.isEmpty) return 'Obrigatório';
+                                      if (!RegExp(r'^[0-9]+$').hasMatch(s)) {
+                                        return 'Apenas números';
+                                      }
+                                      return null;
+                                    },
+                                  ),
+                                ),
+                              ],
+                            ),
+
+                            const SizedBox(height: 12),
+                            SizedBox(
+                              width: double.infinity,
+                              child: FilledButton.icon(
+                                onPressed: () async {
+                                  if (_formKey.currentState!.validate()) {
+                                    if (!_ensureFlowConsistency()) return;
+                                    FocusScope.of(context).unfocus();
+                                    await ref
+                                        .read(
+                                          medidasFinalizadorControllerProvider
+                                              .notifier,
+                                        )
+                                        .carregar(
+                                          partnumber: normalizeCode(
+                                            _partCtrl.text,
+                                          ),
+                                          operacao: normalizeCode(_opCtrl.text),
+                                        );
+                                    if (mounted) {
+                                      setState(() => _mostrarResumo = true);
+                                    }
+                                  }
+                                },
+                                icon: const Icon(Icons.search),
+                                label: const Text('Carregar medidas'),
+                              ),
+                            ),
+                          ],
                         ),
                       ),
                     ],
-                  ),
-                ),
-              if (_mostrarResumo) ...[
-                SearchSummaryCard(
-                  reLabel: 'R.E. do Preparador',
-                  reValue: _reCtrl.text,
-                  items: [
-                    SummaryInfo(label: 'O.S.', value: _osCtrl.text),
-                    SummaryInfo(label: 'Peça', value: _partCtrl.text),
-                    SummaryInfo(label: 'Operação', value: _opCtrl.text),
-                    if ((maquinaValue ?? '').isNotEmpty)
-                      SummaryInfo(label: 'Máquina', value: maquinaValue!),
-                    if ((categoriaValue ?? '').isNotEmpty)
-                      SummaryInfo(label: 'Categoria', value: categoriaValue!),
+                    const SizedBox(height: 16),
                   ],
                 ),
-                const SizedBox(height: 8),
-                Align(
-                  alignment: Alignment.centerRight,
-                  child: TextButton.icon(
-                    onPressed: flowLocked
-                        ? null
-                        : () {
-                            FocusScope.of(context).unfocus();
-                            setState(() => _mostrarResumo = false);
-                          },
-                    icon: const Icon(Icons.edit_outlined),
-                    label: const Text('Alterar dados da busca'),
-                  ),
-                ),
-              ] else ...[
-                Form(
-                  key: _formKey,
-                  child: Column(
-                    children: [
-                      Row(
-                        children: [
-                          Expanded(
-                            child: TextFormField(
-                              controller: _reCtrl,
-                              textInputAction: TextInputAction.next,
-                              keyboardType: TextInputType.number,
-                              inputFormatters: [
-                                FilteringTextInputFormatter.digitsOnly,
-                              ],
-                              decoration: const InputDecoration(
-                                labelText:
-                                    'R.E. do Preparador', // ajuste o texto se for Operador
-                                border: OutlineInputBorder(),
-                              ),
-                              validator: (v) {
-                                final s = (v ?? '').trim();
-                                if (s.isEmpty) return 'Obrigatório';
-                                if (!RegExp(r'^\d+$').hasMatch(s))
-                                  return 'Apenas números';
-                                return null;
-                              },
-                            ),
-                          ),
-                          const SizedBox(width: 12),
-                          SizedBox(
-                            width: 140, // igual ao campo Operação
-                            child: TextFormField(
-                              controller: _osCtrl,
-                              enabled: !flowLocked,
-                              textInputAction: TextInputAction.next,
-                              keyboardType: TextInputType.number,
-                              inputFormatters: [
-                                FilteringTextInputFormatter.digitsOnly,
-                              ],
-                              decoration: const InputDecoration(
-                                labelText: 'O.S.',
-                                border: OutlineInputBorder(),
-                              ),
-                              validator: (v) {
-                                final s = (v ?? '').trim();
-                                if (s.isEmpty) return 'Obrigatório';
-                                if (!RegExp(r'^\d+$').hasMatch(s))
-                                  return 'Apenas números';
-                                return null;
-                              },
-                            ),
-                          ),
-                        ],
-                      ),
-
-                      const SizedBox(height: 12),
-
-                      Row(
-                        children: [
-                          Expanded(
-                            child: DropdownButtonFormField<String>(
-                              value: categoriaValue,
-                              decoration: const InputDecoration(
-                                labelText: 'Categoria',
-                                border: OutlineInputBorder(),
-                              ),
-                              items: _categorias
-                                  .map(
-                                    (c) => DropdownMenuItem(
-                                      value: c,
-                                      child: Text(c),
-                                    ),
-                                  )
-                                  .toList(),
-                              onChanged: flowLocked
-                                  ? null
-                                  : (v) {
-                                      ref
-                                          .read(
-                                            sharedSearchFormProvider.notifier,
-                                          )
-                                          .setCategoria(v);
-                                      setState(() {
-                                        _categoriaSel = v;
-                                        _maquinaSel = null;
-                                      });
-                                    },
-                              validator: (v) => (v == null || v.isEmpty)
-                                  ? 'Obrigatório'
-                                  : null,
-                            ),
-                          ),
-                          const SizedBox(width: 12),
-                          Expanded(
-                            child: DropdownButtonFormField<String>(
-                              value: maquinaValue,
-                              decoration: const InputDecoration(
-                                labelText: 'Código da máquina',
-                                border: OutlineInputBorder(),
-                              ),
-                              items: maquinasDisponiveis
-                                  .map(
-                                    (m) => DropdownMenuItem(
-                                      value: m.codigo,
-                                      child: Text(m.codigo),
-                                    ),
-                                  )
-                                  .toList(),
-                              onChanged: flowLocked
-                                  ? null
-                                  : (v) {
-                                      ref
-                                          .read(
-                                            sharedSearchFormProvider.notifier,
-                                          )
-                                          .setMaquina(v);
-                                      setState(() => _maquinaSel = v);
-                                    },
-                              validator: (v) => (v == null || v.isEmpty)
-                                  ? 'Obrigatório'
-                                  : null,
-                            ),
-                          ),
-                        ],
-                      ),
-
-                      const SizedBox(height: 12),
-
-                      // ---------- PartNumber + Operação (Operação só números) ----------
-                      Row(
-                        children: [
-                          Expanded(
-                            child: TextFormField(
-                              controller: _partCtrl,
-                              enabled: !flowLocked,
-                              textInputAction: TextInputAction.next,
-                              decoration: const InputDecoration(
-                                labelText: 'Código da peça (PartNumber)',
-                                border: OutlineInputBorder(),
-                              ),
-                              validator: (v) => (v == null || v.trim().isEmpty)
-                                  ? 'Obrigatório'
-                                  : null,
-                            ),
-                          ),
-                          const SizedBox(width: 12),
-                          SizedBox(
-                            width: 140,
-                            child: TextFormField(
-                              controller: _opCtrl,
-                              enabled: !flowLocked,
-                              keyboardType: TextInputType.number,
-                              inputFormatters: [
-                                FilteringTextInputFormatter.digitsOnly,
-                              ],
-                              decoration: const InputDecoration(
-                                labelText: 'Operação',
-                                border: OutlineInputBorder(),
-                              ),
-                              validator: (v) {
-                                final s = (v ?? '').trim();
-                                if (s.isEmpty) return 'Obrigatório';
-                                if (!RegExp(r'^\d+$').hasMatch(s))
-                                  return 'Apenas números';
-                                return null;
-                              },
-                            ),
-                          ),
-                        ],
-                      ),
-
-                      const SizedBox(height: 12),
-                      SizedBox(
-                        width: double.infinity,
-                        child: FilledButton.icon(
-                          onPressed: () async {
-                            if (_formKey.currentState!.validate()) {
-                              if (!_ensureFlowConsistency()) return;
-                              FocusScope.of(context).unfocus();
-                              await ref
-                                  .read(
-                                    medidasFinalizadorControllerProvider
-                                        .notifier,
-                                  )
-                                  .carregar(
-                                    partnumber: normalizeCode(_partCtrl.text),
-                                    operacao: normalizeCode(_opCtrl.text),
-                                  );
-                              if (mounted) {
-                                setState(() => _mostrarResumo = true);
-                              }
-                            }
-                          },
-                          icon: const Icon(Icons.search),
-                          label: const Text('Carregar medidas'),
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ],
-              const SizedBox(height: 16),
-              Expanded(
-                child: medidasAsync.when(
-                  data: (list) {
-                    if (list.isEmpty) {
-                      return const Center(
-                        child: Text(
-                          'Nenhuma medida encontrada para a chave informada.',
-                        ),
-                      );
-                    }
-                    return ListView.separated(
-                      itemCount: list.length,
-                      separatorBuilder: (_, __) => const SizedBox(height: 8),
-                      itemBuilder: (context, index) {
-                        final item = list[index];
-                        return MeasurementTile(
-                          index: index,
-                          item: item,
-                          manualEntry: true,
-                          onSelect: (status, medicao) => ref
-                              .read(
-                                medidasFinalizadorControllerProvider.notifier,
-                              )
-                              .setStatusAndMedicao(index, status, medicao),
-                        );
-                      },
-                    );
-                  },
-                  loading: () =>
-                      const Center(child: CircularProgressIndicator()),
-                  error: (e, _) =>
-                      Center(child: Text('Erro ao carregar:\n${e.toString()}')),
-                ),
               ),
-              const SizedBox(height: 10),
-              SizedBox(
-                width: double.infinity,
-                child: FilledButton.icon(
-                  onPressed: podeRegistrar ? _registrarFinalizacao : null,
-                  icon: _registrando
-                      ? const SizedBox(
-                          width: 18,
-                          height: 18,
-                          child: CircularProgressIndicator(strokeWidth: 2),
-                        )
-                      : const Icon(Icons.save_outlined),
-                  label: const Text('Finalizar OS'),
+              ..._buildMedidasSlivers(medidasAsync),
+              SliverFillRemaining(
+                hasScrollBody: false,
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    SizedBox(
+                      width: double.infinity,
+                      child: FilledButton.icon(
+                        onPressed: podeRegistrar ? _registrarFinalizacao : null,
+                        icon: _registrando
+                            ? const SizedBox(
+                                width: 18,
+                                height: 18,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                ),
+                              )
+                            : const Icon(Icons.save_outlined),
+                        label: const Text('Finalizar OS'),
+                      ),
+                    ),
+                  ],
                 ),
               ),
             ],
           ),
         ),
       ),
+    );
+  }
+
+  List<Widget> _buildMedidasSlivers(AsyncValue<List<MedidaItem>> medidasAsync) {
+    return medidasAsync.when(
+      data: (list) {
+        if (list.isEmpty) {
+          return [
+            const SliverToBoxAdapter(
+              child: Padding(
+                padding: EdgeInsets.symmetric(vertical: 24),
+                child: Center(
+                  child: Text(
+                    'Nenhuma medida encontrada para a chave informada.',
+                  ),
+                ),
+              ),
+            ),
+            const SliverToBoxAdapter(child: SizedBox(height: 10)),
+          ];
+        }
+        return [
+          SliverList(
+            delegate: SliverChildBuilderDelegate((context, index) {
+              final item = list[index];
+              return Padding(
+                padding: EdgeInsets.only(
+                  bottom: index == list.length - 1 ? 0 : 8,
+                ),
+                child: MeasurementTile(
+                  index: index,
+                  item: item,
+                  manualEntry: true,
+                  onSelect: (status, medicao) => ref
+                      .read(medidasFinalizadorControllerProvider.notifier)
+                      .setStatusAndMedicao(index, status, medicao),
+                ),
+              );
+            }, childCount: list.length),
+          ),
+          const SliverToBoxAdapter(child: SizedBox(height: 10)),
+        ];
+      },
+      loading: () => [
+        const SliverToBoxAdapter(
+          child: Padding(
+            padding: EdgeInsets.symmetric(vertical: 24),
+            child: Center(child: CircularProgressIndicator()),
+          ),
+        ),
+        const SliverToBoxAdapter(child: SizedBox(height: 10)),
+      ],
+      error: (e, _) => [
+        SliverToBoxAdapter(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(vertical: 24),
+            child: Center(child: Text('Erro ao carregar:\n${e.toString()}')),
+          ),
+        ),
+        const SliverToBoxAdapter(child: SizedBox(height: 10)),
+      ],
     );
   }
 }

--- a/lib/features/operador/presentation/operador_page.dart
+++ b/lib/features/operador/presentation/operador_page.dart
@@ -735,337 +735,397 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
       body: SafeArea(
         child: Padding(
           padding: const EdgeInsets.all(16.0),
-          child: Column(
-            children: [
-              if (flowLocked)
-                Container(
-                  width: double.infinity,
-                  margin: const EdgeInsets.only(bottom: 12),
-                  padding: const EdgeInsets.all(12),
-                  decoration: BoxDecoration(
-                    color: Theme.of(
-                      context,
-                    ).colorScheme.surfaceContainerHighest,
-                    borderRadius: BorderRadius.circular(8),
-                  ),
-                  child: Row(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Icon(
-                        Icons.lock,
-                        size: 18,
-                        color: Theme.of(context).colorScheme.primary,
+          child: CustomScrollView(
+            keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
+            slivers: [
+              SliverToBoxAdapter(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    if (flowLocked)
+                      Container(
+                        margin: const EdgeInsets.only(bottom: 12),
+                        padding: const EdgeInsets.all(12),
+                        decoration: BoxDecoration(
+                          color: Theme.of(
+                            context,
+                          ).colorScheme.surfaceContainerHighest,
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        child: Row(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Icon(
+                              Icons.lock,
+                              size: 18,
+                              color: Theme.of(context).colorScheme.primary,
+                            ),
+                            const SizedBox(width: 8),
+                            Expanded(
+                              child: Text(
+                                flowState.os.trim().isEmpty
+                                    ? 'Existe um fluxo de O.S. em andamento. Finalize a O.S. atual para iniciar outra.'
+                                    : 'Fluxo ativo para a O.S. ${flowState.os}. Finalize a O.S. atual para iniciar outra.',
+                                style: Theme.of(context).textTheme.bodyMedium,
+                              ),
+                            ),
+                          ],
+                        ),
                       ),
-                      const SizedBox(width: 8),
-                      Expanded(
-                        child: Text(
-                          flowState.os.trim().isEmpty
-                              ? 'Existe um fluxo de O.S. em andamento. Finalize a O.S. atual para iniciar outra.'
-                              : 'Fluxo ativo para a O.S. ${flowState.os}. Finalize a O.S. atual para iniciar outra.',
-                          style: Theme.of(context).textTheme.bodyMedium,
+                    if (_mostrarResumo) ...[
+                      SearchSummaryCard(
+                        reLabel: 'R.E. do Preparador',
+                        reValue: _reCtrl.text,
+                        items: [
+                          SummaryInfo(label: 'O.S.', value: _osCtrl.text),
+                          SummaryInfo(label: 'Peça', value: _partCtrl.text),
+                          SummaryInfo(label: 'Operação', value: _opCtrl.text),
+                          if ((maquinaValue ?? '').isNotEmpty)
+                            SummaryInfo(label: 'Máquina', value: maquinaValue!),
+                          if ((categoriaValue ?? '').isNotEmpty)
+                            SummaryInfo(
+                              label: 'Categoria',
+                              value: categoriaValue!,
+                            ),
+                        ],
+                      ),
+                      const SizedBox(height: 8),
+                      Align(
+                        alignment: Alignment.centerRight,
+                        child: TextButton.icon(
+                          onPressed: flowLocked
+                              ? null
+                              : () {
+                                  FocusScope.of(context).unfocus();
+                                  setState(() => _mostrarResumo = false);
+                                },
+                          icon: const Icon(Icons.edit_outlined),
+                          label: const Text('Alterar dados da busca'),
+                        ),
+                      ),
+                    ] else ...[
+                      Form(
+                        key: _formKey,
+                        child: Column(
+                          children: [
+                            Row(
+                              children: [
+                                Expanded(
+                                  child: TextFormField(
+                                    controller: _reCtrl,
+                                    textInputAction: TextInputAction.next,
+                                    keyboardType: TextInputType.number,
+                                    inputFormatters: [
+                                      FilteringTextInputFormatter.digitsOnly,
+                                    ],
+                                    decoration: const InputDecoration(
+                                      labelText:
+                                          'R.E. do Preparador', // ajuste o texto se for Operador
+                                      border: OutlineInputBorder(),
+                                    ),
+                                    validator: (v) {
+                                      final s = (v ?? '').trim();
+                                      if (s.isEmpty) return 'Obrigatório';
+                                      if (!RegExp(r'^[0-9]+$').hasMatch(s)) {
+                                        return 'Apenas números';
+                                      }
+                                      return null;
+                                    },
+                                  ),
+                                ),
+                                const SizedBox(width: 12),
+                                SizedBox(
+                                  width: 140, // igual ao campo Operação
+                                  child: TextFormField(
+                                    controller: _osCtrl,
+                                    enabled: !flowLocked,
+                                    textInputAction: TextInputAction.next,
+                                    keyboardType: TextInputType.number,
+                                    inputFormatters: [
+                                      FilteringTextInputFormatter.digitsOnly,
+                                    ],
+                                    decoration: const InputDecoration(
+                                      labelText: 'O.S.',
+                                      border: OutlineInputBorder(),
+                                    ),
+                                    validator: (v) {
+                                      final s = (v ?? '').trim();
+                                      if (s.isEmpty) return 'Obrigatório';
+                                      if (!RegExp(r'^[0-9]+$').hasMatch(s)) {
+                                        return 'Apenas números';
+                                      }
+                                      return null;
+                                    },
+                                  ),
+                                ),
+                              ],
+                            ),
+                            const SizedBox(height: 12),
+
+                            Row(
+                              children: [
+                                Expanded(
+                                  child: DropdownButtonFormField<String>(
+                                    value: categoriaValue,
+                                    decoration: const InputDecoration(
+                                      labelText: 'Categoria',
+                                      border: OutlineInputBorder(),
+                                    ),
+                                    items: _categorias
+                                        .map(
+                                          (c) => DropdownMenuItem(
+                                            value: c,
+                                            child: Text(c),
+                                          ),
+                                        )
+                                        .toList(),
+                                    onChanged: flowLocked
+                                        ? null
+                                        : (v) {
+                                            ref
+                                                .read(
+                                                  sharedSearchFormProvider
+                                                      .notifier,
+                                                )
+                                                .setCategoria(v);
+                                            setState(() {
+                                              _categoriaSel = v;
+                                              _maquinaSel = null;
+                                            });
+                                          },
+                                    validator: (v) => (v == null || v.isEmpty)
+                                        ? 'Obrigatório'
+                                        : null,
+                                  ),
+                                ),
+                                const SizedBox(width: 12),
+                                Expanded(
+                                  child: DropdownButtonFormField<String>(
+                                    value: maquinaValue,
+                                    decoration: const InputDecoration(
+                                      labelText: 'Código da máquina',
+                                      border: OutlineInputBorder(),
+                                    ),
+                                    items: maquinasDisponiveis
+                                        .map(
+                                          (m) => DropdownMenuItem(
+                                            value: m.codigo,
+                                            child: Text(m.codigo),
+                                          ),
+                                        )
+                                        .toList(),
+                                    onChanged: flowLocked
+                                        ? null
+                                        : (v) {
+                                            ref
+                                                .read(
+                                                  sharedSearchFormProvider
+                                                      .notifier,
+                                                )
+                                                .setMaquina(v);
+                                            setState(() => _maquinaSel = v);
+                                          },
+                                    validator: (v) => (v == null || v.isEmpty)
+                                        ? 'Obrigatório'
+                                        : null,
+                                  ),
+                                ),
+                              ],
+                            ),
+
+                            const SizedBox(height: 12),
+
+                            Row(
+                              children: [
+                                Expanded(
+                                  child: TextFormField(
+                                    controller: _partCtrl,
+                                    enabled: !flowLocked,
+                                    textInputAction: TextInputAction.next,
+                                    decoration: const InputDecoration(
+                                      labelText: 'Código da peça (PartNumber)',
+                                      border: OutlineInputBorder(),
+                                    ),
+                                    validator: (v) =>
+                                        (v == null || v.trim().isEmpty)
+                                        ? 'Obrigatório'
+                                        : null,
+                                  ),
+                                ),
+                                const SizedBox(width: 12),
+                                SizedBox(
+                                  width: 140,
+                                  child: TextFormField(
+                                    controller: _opCtrl,
+                                    enabled: !flowLocked,
+                                    keyboardType: TextInputType.number,
+                                    inputFormatters: [
+                                      FilteringTextInputFormatter.digitsOnly,
+                                    ],
+                                    decoration: const InputDecoration(
+                                      labelText: 'Operação',
+                                      border: OutlineInputBorder(),
+                                    ),
+                                    validator: (v) {
+                                      final s = (v ?? '').trim();
+                                      if (s.isEmpty) return 'Obrigatório';
+                                      if (!RegExp(r'^[0-9]+$').hasMatch(s)) {
+                                        return 'Apenas números';
+                                      }
+                                      return null;
+                                    },
+                                  ),
+                                ),
+                              ],
+                            ),
+
+                            const SizedBox(height: 12),
+                            SizedBox(
+                              width: double.infinity,
+                              child: FilledButton.icon(
+                                onPressed: () async {
+                                  if (_formKey.currentState!.validate()) {
+                                    if (!_ensureFlowConsistency()) return;
+                                    FocusScope.of(context).unfocus();
+                                    await ref
+                                        .read(
+                                          medidasOperadorControllerProvider
+                                              .notifier,
+                                        )
+                                        .carregar(
+                                          os: _osCtrl.text.trim(),
+                                          partnumber: normalizeCode(
+                                            _partCtrl.text,
+                                          ),
+                                          operacao: normalizeCode(_opCtrl.text),
+                                        );
+                                    if (mounted) {
+                                      setState(() => _mostrarResumo = true);
+                                    }
+                                  }
+                                },
+                                icon: const Icon(Icons.search),
+                                label: const Text('Carregar medidas'),
+                              ),
+                            ),
+                          ],
                         ),
                       ),
                     ],
-                  ),
-                ),
-              if (_mostrarResumo) ...[
-                SearchSummaryCard(
-                  reLabel: 'R.E. do Preparador',
-                  reValue: _reCtrl.text,
-                  items: [
-                    SummaryInfo(label: 'O.S.', value: _osCtrl.text),
-                    SummaryInfo(label: 'Peça', value: _partCtrl.text),
-                    SummaryInfo(label: 'Operação', value: _opCtrl.text),
-                    if ((maquinaValue ?? '').isNotEmpty)
-                      SummaryInfo(label: 'Máquina', value: maquinaValue!),
-                    if ((categoriaValue ?? '').isNotEmpty)
-                      SummaryInfo(label: 'Categoria', value: categoriaValue!),
+                    const SizedBox(height: 16),
                   ],
                 ),
-                const SizedBox(height: 8),
-                Align(
-                  alignment: Alignment.centerRight,
-                  child: TextButton.icon(
-                    onPressed: flowLocked
-                        ? null
-                        : () {
-                            FocusScope.of(context).unfocus();
-                            setState(() => _mostrarResumo = false);
-                          },
-                    icon: const Icon(Icons.edit_outlined),
-                    label: const Text('Alterar dados da busca'),
-                  ),
-                ),
-              ] else ...[
-                Form(
-                  key: _formKey,
-                  child: Column(
-                    children: [
-                      Row(
-                        children: [
-                          Expanded(
-                            child: TextFormField(
-                              controller: _reCtrl,
-                              textInputAction: TextInputAction.next,
-                              keyboardType: TextInputType.number,
-                              inputFormatters: [
-                                FilteringTextInputFormatter.digitsOnly,
-                              ],
-                              decoration: const InputDecoration(
-                                labelText:
-                                    'R.E. do Preparador', // ajuste o texto se for Operador
-                                border: OutlineInputBorder(),
-                              ),
-                              validator: (v) {
-                                final s = (v ?? '').trim();
-                                if (s.isEmpty) return 'Obrigatório';
-                                if (!RegExp(r'^\d+$').hasMatch(s))
-                                  return 'Apenas números';
-                                return null;
-                              },
-                            ),
-                          ),
-                          const SizedBox(width: 12),
-                          SizedBox(
-                            width: 140, // igual ao campo Operação
-                            child: TextFormField(
-                              controller: _osCtrl,
-                              enabled: !flowLocked,
-                              textInputAction: TextInputAction.next,
-                              keyboardType: TextInputType.number,
-                              inputFormatters: [
-                                FilteringTextInputFormatter.digitsOnly,
-                              ],
-                              decoration: const InputDecoration(
-                                labelText: 'O.S.',
-                                border: OutlineInputBorder(),
-                              ),
-                              validator: (v) {
-                                final s = (v ?? '').trim();
-                                if (s.isEmpty) return 'Obrigatório';
-                                if (!RegExp(r'^\d+$').hasMatch(s))
-                                  return 'Apenas números';
-                                return null;
-                              },
-                            ),
-                          ),
-                        ],
-                      ),
-
-                      const SizedBox(height: 12),
-
-                      Row(
-                        children: [
-                          Expanded(
-                            child: DropdownButtonFormField<String>(
-                              value: categoriaValue,
-                              decoration: const InputDecoration(
-                                labelText: 'Categoria',
-                                border: OutlineInputBorder(),
-                              ),
-                              items: _categorias
-                                  .map(
-                                    (c) => DropdownMenuItem(
-                                      value: c,
-                                      child: Text(c),
-                                    ),
-                                  )
-                                  .toList(),
-                              onChanged: flowLocked
-                                  ? null
-                                  : (v) {
-                                      ref
-                                          .read(
-                                            sharedSearchFormProvider.notifier,
-                                          )
-                                          .setCategoria(v);
-                                      setState(() {
-                                        _categoriaSel = v;
-                                        _maquinaSel = null;
-                                      });
-                                    },
-                              validator: (v) => (v == null || v.isEmpty)
-                                  ? 'Obrigatório'
-                                  : null,
-                            ),
-                          ),
-                          const SizedBox(width: 12),
-                          Expanded(
-                            child: DropdownButtonFormField<String>(
-                              value: maquinaValue,
-                              decoration: const InputDecoration(
-                                labelText: 'Código da máquina',
-                                border: OutlineInputBorder(),
-                              ),
-                              items: maquinasDisponiveis
-                                  .map(
-                                    (m) => DropdownMenuItem(
-                                      value: m.codigo,
-                                      child: Text(m.codigo),
-                                    ),
-                                  )
-                                  .toList(),
-                              onChanged: flowLocked
-                                  ? null
-                                  : (v) {
-                                      ref
-                                          .read(
-                                            sharedSearchFormProvider.notifier,
-                                          )
-                                          .setMaquina(v);
-                                      setState(() => _maquinaSel = v);
-                                    },
-                              validator: (v) => (v == null || v.isEmpty)
-                                  ? 'Obrigatório'
-                                  : null,
-                            ),
-                          ),
-                        ],
-                      ),
-
-                      const SizedBox(height: 12),
-
-                      // ---------- PartNumber + Operação (Operação só números) ----------
-                      Row(
-                        children: [
-                          Expanded(
-                            child: TextFormField(
-                              controller: _partCtrl,
-                              enabled: !flowLocked,
-                              textInputAction: TextInputAction.next,
-                              decoration: const InputDecoration(
-                                labelText: 'Código da peça (PartNumber)',
-                                border: OutlineInputBorder(),
-                              ),
-                              validator: (v) => (v == null || v.trim().isEmpty)
-                                  ? 'Obrigatório'
-                                  : null,
-                            ),
-                          ),
-                          const SizedBox(width: 12),
-                          SizedBox(
-                            width: 140,
-                            child: TextFormField(
-                              controller: _opCtrl,
-                              enabled: !flowLocked,
-                              keyboardType: TextInputType.number,
-                              inputFormatters: [
-                                FilteringTextInputFormatter.digitsOnly,
-                              ],
-                              decoration: const InputDecoration(
-                                labelText: 'Operação',
-                                border: OutlineInputBorder(),
-                              ),
-                              validator: (v) {
-                                final s = (v ?? '').trim();
-                                if (s.isEmpty) return 'Obrigatório';
-                                if (!RegExp(r'^\d+$').hasMatch(s))
-                                  return 'Apenas números';
-                                return null;
-                              },
-                            ),
-                          ),
-                        ],
-                      ),
-
-                      const SizedBox(height: 12),
-                      SizedBox(
-                        width: double.infinity,
-                        child: FilledButton.icon(
-                          onPressed: () async {
-                            if (_formKey.currentState!.validate()) {
-                              if (!_ensureFlowConsistency()) return;
-                              FocusScope.of(context).unfocus();
-                              await ref
-                                  .read(
-                                    medidasOperadorControllerProvider.notifier,
-                                  )
-                                  .carregar(
-                                    os: _osCtrl.text.trim(),
-                                    partnumber: normalizeCode(_partCtrl.text),
-                                    operacao: normalizeCode(_opCtrl.text),
-                                  );
-                              if (mounted) {
-                                setState(() => _mostrarResumo = true);
-                              }
-                            }
-                          },
-                          icon: const Icon(Icons.search),
-                          label: const Text('Carregar medidas'),
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ],
-              const SizedBox(height: 16),
-              Expanded(
-                child: medidasAsync.when(
-                  data: (list) {
-                    if (list.isEmpty) {
-                      return const Center(
-                        child: Text(
-                          'Nenhuma medida encontrada para a chave informada.',
-                        ),
-                      );
-                    }
-                    return ListView.separated(
-                      itemCount: list.length,
-                      separatorBuilder: (_, __) => const SizedBox(height: 8),
-                      itemBuilder: (context, index) {
-                        final item = list[index];
-                        return MeasurementTile(
-                          index: index,
-                          item: item,
-                          onSelect: (status, medicao) => ref
-                              .read(medidasOperadorControllerProvider.notifier)
-                              .setStatusAndMedicao(index, status, medicao),
-                        );
-                      },
-                    );
-                  },
-                  loading: () =>
-                      const Center(child: CircularProgressIndicator()),
-                  error: (e, _) =>
-                      Center(child: Text('Erro ao carregar:\n${e.toString()}')),
-                ),
               ),
-              const SizedBox(height: 10),
-              Align(
-                alignment: Alignment.centerRight,
-                child: PopupMenuButton<String>(
-                  onSelected: (value) {
-                    if (value == 'fim') _showFimJornadaDialog();
-                    if (value == 'encerrar') _confirmEncerrarProducao();
-                  },
-                  itemBuilder: (context) => const [
-                    PopupMenuItem(value: 'fim', child: Text('Fim de Jornada')),
-                    PopupMenuItem(
-                      value: 'encerrar',
-                      child: Text('Encerrar produção'),
+              ..._buildMedidasSlivers(medidasAsync),
+              SliverFillRemaining(
+                hasScrollBody: false,
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Align(
+                      alignment: Alignment.centerRight,
+                      child: PopupMenuButton<String>(
+                        onSelected: (value) {
+                          if (value == 'fim') _showFimJornadaDialog();
+                          if (value == 'encerrar') _confirmEncerrarProducao();
+                        },
+                        itemBuilder: (context) => const [
+                          PopupMenuItem(
+                            value: 'fim',
+                            child: Text('Fim de Jornada'),
+                          ),
+                          PopupMenuItem(
+                            value: 'encerrar',
+                            child: Text('Encerrar produção'),
+                          ),
+                        ],
+                      ),
+                    ),
+                    const SizedBox(height: 10),
+                    SizedBox(
+                      width: double.infinity,
+                      child: FilledButton.icon(
+                        onPressed: podeRegistrar ? _registrarAmostragem : null,
+                        icon: _registrando
+                            ? const SizedBox(
+                                width: 18,
+                                height: 18,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                ),
+                              )
+                            : const Icon(Icons.save_outlined),
+                        label: const Text('Registrar amostragem'),
+                      ),
                     ),
                   ],
-                ),
-              ),
-              const SizedBox(height: 10),
-              SizedBox(
-                width: double.infinity,
-                child: FilledButton.icon(
-                  onPressed: podeRegistrar ? _registrarAmostragem : null,
-                  icon: _registrando
-                      ? const SizedBox(
-                          width: 18,
-                          height: 18,
-                          child: CircularProgressIndicator(strokeWidth: 2),
-                        )
-                      : const Icon(Icons.save_outlined),
-                  label: const Text('Registrar amostragem'),
                 ),
               ),
             ],
           ),
         ),
       ),
+    );
+  }
+
+  List<Widget> _buildMedidasSlivers(AsyncValue<List<MedidaItem>> medidasAsync) {
+    return medidasAsync.when(
+      data: (list) {
+        if (list.isEmpty) {
+          return [
+            const SliverToBoxAdapter(
+              child: Padding(
+                padding: EdgeInsets.symmetric(vertical: 24),
+                child: Center(
+                  child: Text(
+                    'Nenhuma medida encontrada para a chave informada.',
+                  ),
+                ),
+              ),
+            ),
+            const SliverToBoxAdapter(child: SizedBox(height: 10)),
+          ];
+        }
+        return [
+          SliverList(
+            delegate: SliverChildBuilderDelegate((context, index) {
+              final item = list[index];
+              return Padding(
+                padding: EdgeInsets.only(
+                  bottom: index == list.length - 1 ? 0 : 8,
+                ),
+                child: MeasurementTile(
+                  index: index,
+                  item: item,
+                  onSelect: (status, medicao) => ref
+                      .read(medidasOperadorControllerProvider.notifier)
+                      .setStatusAndMedicao(index, status, medicao),
+                ),
+              );
+            }, childCount: list.length),
+          ),
+          const SliverToBoxAdapter(child: SizedBox(height: 10)),
+        ];
+      },
+      loading: () => [
+        const SliverToBoxAdapter(
+          child: Padding(
+            padding: EdgeInsets.symmetric(vertical: 24),
+            child: Center(child: CircularProgressIndicator()),
+          ),
+        ),
+        const SliverToBoxAdapter(child: SizedBox(height: 10)),
+      ],
+      error: (e, _) => [
+        SliverToBoxAdapter(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(vertical: 24),
+            child: Center(child: Text('Erro ao carregar:\n${e.toString()}')),
+          ),
+        ),
+        const SliverToBoxAdapter(child: SizedBox(height: 10)),
+      ],
     );
   }
 }

--- a/lib/features/preparacao/presentation/preparacao_page.dart
+++ b/lib/features/preparacao/presentation/preparacao_page.dart
@@ -126,6 +126,8 @@ class MedidasPreparadorController
 }
 
 class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
+  static const double _compactFormBreakpoint = 600;
+
   final _formKey = GlobalKey<FormState>();
   final _reCtrl = TextEditingController(); // <<< RE
   final _osCtrl = TextEditingController(); // <<< OS
@@ -522,323 +524,434 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
       body: SafeArea(
         child: Padding(
           padding: const EdgeInsets.all(16.0),
-          child: Column(
-            children: [
-              if (flowLocked)
-                Container(
-                  width: double.infinity,
-                  margin: const EdgeInsets.only(bottom: 12),
-                  padding: const EdgeInsets.all(12),
-                  decoration: BoxDecoration(
-                    color: Theme.of(
-                      context,
-                    ).colorScheme.surfaceContainerHighest,
-                    borderRadius: BorderRadius.circular(8),
-                  ),
-                  child: Row(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Icon(
-                        Icons.lock,
-                        size: 18,
-                        color: Theme.of(context).colorScheme.primary,
+          child: CustomScrollView(
+            keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
+            slivers: [
+              SliverToBoxAdapter(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    if (flowLocked)
+                      Container(
+                        margin: const EdgeInsets.only(bottom: 12),
+                        padding: const EdgeInsets.all(12),
+                        decoration: BoxDecoration(
+                          color: Theme.of(
+                            context,
+                          ).colorScheme.surfaceContainerHighest,
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        child: Row(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Icon(
+                              Icons.lock,
+                              size: 18,
+                              color: Theme.of(context).colorScheme.primary,
+                            ),
+                            const SizedBox(width: 8),
+                            Expanded(
+                              child: Text(
+                                flowState.os.trim().isEmpty
+                                    ? 'Existe um fluxo de O.S. em andamento. Finalize a O.S. atual para iniciar outra.'
+                                    : 'Fluxo ativo para a O.S. ${flowState.os}. Finalize a O.S. atual para iniciar outra.',
+                                style: Theme.of(context).textTheme.bodyMedium,
+                              ),
+                            ),
+                          ],
+                        ),
                       ),
-                      const SizedBox(width: 8),
-                      Expanded(
-                        child: Text(
-                          flowState.os.trim().isEmpty
-                              ? 'Existe um fluxo de O.S. em andamento. Finalize a O.S. atual para iniciar outra.'
-                              : 'Fluxo ativo para a O.S. ${flowState.os}. Finalize a O.S. atual para iniciar outra.',
-                          style: Theme.of(context).textTheme.bodyMedium,
+                    if (_mostrarResumo) ...[
+                      SearchSummaryCard(
+                        reLabel: 'R.E. do Preparador',
+                        reValue: _reCtrl.text,
+                        items: [
+                          SummaryInfo(label: 'O.S.', value: _osCtrl.text),
+                          SummaryInfo(label: 'Peça', value: _partCtrl.text),
+                          SummaryInfo(label: 'Operação', value: _opCtrl.text),
+                          if ((maquinaValue ?? '').isNotEmpty)
+                            SummaryInfo(label: 'Máquina', value: maquinaValue!),
+                          if ((categoriaValue ?? '').isNotEmpty)
+                            SummaryInfo(
+                              label: 'Categoria',
+                              value: categoriaValue!,
+                            ),
+                        ],
+                      ),
+                      const SizedBox(height: 8),
+                      Align(
+                        alignment: Alignment.centerRight,
+                        child: TextButton.icon(
+                          onPressed: flowLocked
+                              ? null
+                              : () {
+                                  FocusScope.of(context).unfocus();
+                                  setState(() => _mostrarResumo = false);
+                                },
+                          icon: const Icon(Icons.edit_outlined),
+                          label: const Text('Alterar dados da busca'),
+                        ),
+                      ),
+                    ] else ...[
+                      Form(
+                        key: _formKey,
+                        child: Column(
+                          children: [
+                            LayoutBuilder(
+                              builder: (context, constraints) {
+                                final isCompact =
+                                    constraints.maxWidth <
+                                    _compactFormBreakpoint;
+                                final reField = TextFormField(
+                                  controller: _reCtrl,
+                                  textInputAction: TextInputAction.next,
+                                  keyboardType: TextInputType.number,
+                                  inputFormatters: [
+                                    FilteringTextInputFormatter.digitsOnly,
+                                  ],
+                                  decoration: const InputDecoration(
+                                    labelText: 'R.E. do Preparador',
+                                    border: OutlineInputBorder(),
+                                  ),
+                                  validator: (v) {
+                                    final s = (v ?? '').trim();
+                                    if (s.isEmpty) return 'Obrigatório';
+                                    if (!RegExp(r'^[0-9]+$').hasMatch(s)) {
+                                      return 'Apenas números';
+                                    }
+                                    return null;
+                                  },
+                                );
+                                final osField = TextFormField(
+                                  controller: _osCtrl,
+                                  enabled: !flowLocked,
+                                  textInputAction: TextInputAction.next,
+                                  keyboardType: TextInputType.number,
+                                  inputFormatters: [
+                                    FilteringTextInputFormatter.digitsOnly,
+                                  ],
+                                  decoration: const InputDecoration(
+                                    labelText: 'O.S.',
+                                    border: OutlineInputBorder(),
+                                  ),
+                                  validator: (v) {
+                                    final s = (v ?? '').trim();
+                                    if (s.isEmpty) return 'Obrigatório';
+                                    if (!RegExp(r'^[0-9]+$').hasMatch(s)) {
+                                      return 'Apenas números';
+                                    }
+                                    return null;
+                                  },
+                                );
+                                if (isCompact) {
+                                  return Column(
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.stretch,
+                                    children: [
+                                      reField,
+                                      const SizedBox(height: 12),
+                                      osField,
+                                    ],
+                                  );
+                                }
+
+                                return Row(
+                                  children: [
+                                    Expanded(child: reField),
+                                    const SizedBox(width: 12),
+                                    SizedBox(
+                                      width: 140, // igual ao campo Operação
+                                      child: osField,
+                                    ),
+                                  ],
+                                );
+                              },
+                            ),
+
+                            const SizedBox(height: 12),
+
+                            LayoutBuilder(
+                              builder: (context, constraints) {
+                                final isCompact =
+                                    constraints.maxWidth <
+                                    _compactFormBreakpoint;
+                                final categoriaDropdown =
+                                    DropdownButtonFormField<String>(
+                                      value: categoriaValue,
+                                      decoration: const InputDecoration(
+                                        labelText: 'Categoria',
+                                        border: OutlineInputBorder(),
+                                      ),
+                                      items: _categorias
+                                          .map(
+                                            (c) => DropdownMenuItem(
+                                              value: c,
+                                              child: Text(c),
+                                            ),
+                                          )
+                                          .toList(),
+                                      onChanged: flowLocked
+                                          ? null
+                                          : (v) {
+                                              ref
+                                                  .read(
+                                                    sharedSearchFormProvider
+                                                        .notifier,
+                                                  )
+                                                  .setCategoria(v);
+                                              setState(() {
+                                                _categoriaSel = v;
+                                                _maquinaSel = null;
+                                              });
+                                            },
+                                      validator: (v) => (v == null || v.isEmpty)
+                                          ? 'Obrigatório'
+                                          : null,
+                                    );
+                                final maquinaDropdown =
+                                    DropdownButtonFormField<String>(
+                                      value: maquinaValue,
+                                      decoration: const InputDecoration(
+                                        labelText: 'Código da máquina',
+                                        border: OutlineInputBorder(),
+                                      ),
+                                      items: maquinasDisponiveis
+                                          .map(
+                                            (m) => DropdownMenuItem(
+                                              value: m.codigo,
+                                              child: Text(m.codigo),
+                                            ),
+                                          )
+                                          .toList(),
+                                      onChanged: flowLocked
+                                          ? null
+                                          : (v) {
+                                              ref
+                                                  .read(
+                                                    sharedSearchFormProvider
+                                                        .notifier,
+                                                  )
+                                                  .setMaquina(v);
+                                              setState(() => _maquinaSel = v);
+                                            },
+                                      validator: (v) => (v == null || v.isEmpty)
+                                          ? 'Obrigatório'
+                                          : null,
+                                    );
+
+                                if (isCompact) {
+                                  return Column(
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.stretch,
+                                    children: [
+                                      categoriaDropdown,
+                                      const SizedBox(height: 12),
+                                      maquinaDropdown,
+                                    ],
+                                  );
+                                }
+
+                                return Row(
+                                  children: [
+                                    Expanded(child: categoriaDropdown),
+                                    const SizedBox(width: 12),
+                                    Expanded(child: maquinaDropdown),
+                                  ],
+                                );
+                              },
+                            ),
+
+                            const SizedBox(height: 12),
+
+                            // ---------- PartNumber + Operação (Operação só números) ----------
+                            LayoutBuilder(
+                              builder: (context, constraints) {
+                                final isCompact =
+                                    constraints.maxWidth <
+                                    _compactFormBreakpoint;
+                                final partField = TextFormField(
+                                  controller: _partCtrl,
+                                  enabled: !flowLocked,
+                                  textInputAction: TextInputAction.next,
+                                  decoration: const InputDecoration(
+                                    labelText: 'Código da peça (PartNumber)',
+                                    border: OutlineInputBorder(),
+                                  ),
+                                  validator: (v) =>
+                                      (v == null || v.trim().isEmpty)
+                                      ? 'Obrigatório'
+                                      : null,
+                                );
+                                final operacaoField = TextFormField(
+                                  controller: _opCtrl,
+                                  enabled: !flowLocked,
+                                  keyboardType: TextInputType.number,
+                                  inputFormatters: [
+                                    FilteringTextInputFormatter.digitsOnly,
+                                  ],
+                                  decoration: const InputDecoration(
+                                    labelText: 'Operação',
+                                    border: OutlineInputBorder(),
+                                  ),
+                                  validator: (v) {
+                                    final s = (v ?? '').trim();
+                                    if (s.isEmpty) return 'Obrigatório';
+                                    if (!RegExp(r'^[0-9]+$').hasMatch(s)) {
+                                      return 'Apenas números';
+                                    }
+                                    return null;
+                                  },
+                                );
+
+                                if (isCompact) {
+                                  return Column(
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.stretch,
+                                    children: [
+                                      partField,
+                                      const SizedBox(height: 12),
+                                      operacaoField,
+                                    ],
+                                  );
+                                }
+
+                                return Row(
+                                  children: [
+                                    Expanded(child: partField),
+                                    const SizedBox(width: 12),
+                                    SizedBox(width: 140, child: operacaoField),
+                                  ],
+                                );
+                              },
+                            ),
+
+                            const SizedBox(height: 12),
+                            SizedBox(
+                              width: double.infinity,
+                              child: FilledButton.icon(
+                                onPressed: () async {
+                                  if (_formKey.currentState!.validate()) {
+                                    if (!_ensureFlowConsistency()) return;
+                                    FocusScope.of(context).unfocus();
+                                    await ref
+                                        .read(
+                                          medidasPreparadorControllerProvider
+                                              .notifier,
+                                        )
+                                        .carregar(
+                                          partnumber: normalizeCode(
+                                            _partCtrl.text,
+                                          ),
+                                          operacao: normalizeCode(_opCtrl.text),
+                                        );
+                                    if (mounted) {
+                                      setState(() => _mostrarResumo = true);
+                                    }
+                                  }
+                                },
+                                icon: const Icon(Icons.search),
+                                label: const Text('Carregar medidas'),
+                              ),
+                            ),
+                          ],
                         ),
                       ),
                     ],
-                  ),
-                ),
-              if (_mostrarResumo) ...[
-                SearchSummaryCard(
-                  reLabel: 'R.E. do Preparador',
-                  reValue: _reCtrl.text,
-                  items: [
-                    SummaryInfo(label: 'O.S.', value: _osCtrl.text),
-                    SummaryInfo(label: 'Peça', value: _partCtrl.text),
-                    SummaryInfo(label: 'Operação', value: _opCtrl.text),
-                    if ((maquinaValue ?? '').isNotEmpty)
-                      SummaryInfo(label: 'Máquina', value: maquinaValue!),
-                    if ((categoriaValue ?? '').isNotEmpty)
-                      SummaryInfo(label: 'Categoria', value: categoriaValue!),
+                    const SizedBox(height: 16),
                   ],
                 ),
-                const SizedBox(height: 8),
-                Align(
-                  alignment: Alignment.centerRight,
-                  child: TextButton.icon(
-                    onPressed: flowLocked
-                        ? null
-                        : () {
-                            FocusScope.of(context).unfocus();
-                            setState(() => _mostrarResumo = false);
-                          },
-                    icon: const Icon(Icons.edit_outlined),
-                    label: const Text('Alterar dados da busca'),
-                  ),
-                ),
-              ] else ...[
-                Form(
-                  key: _formKey,
-                  child: Column(
-                    children: [
-                      Row(
-                        children: [
-                          Expanded(
-                            child: TextFormField(
-                              controller: _reCtrl,
-                              textInputAction: TextInputAction.next,
-                              keyboardType: TextInputType.number,
-                              inputFormatters: [
-                                FilteringTextInputFormatter.digitsOnly,
-                              ],
-                              decoration: const InputDecoration(
-                                labelText:
-                                    'R.E. do Preparador', // ajuste o texto se for Operador
-                                border: OutlineInputBorder(),
-                              ),
-                              validator: (v) {
-                                final s = (v ?? '').trim();
-                                if (s.isEmpty) return 'Obrigatório';
-                                if (!RegExp(r'^\d+$').hasMatch(s))
-                                  return 'Apenas números';
-                                return null;
-                              },
-                            ),
-                          ),
-                          const SizedBox(width: 12),
-                          SizedBox(
-                            width: 140, // igual ao campo Operação
-                            child: TextFormField(
-                              controller: _osCtrl,
-                              enabled: !flowLocked,
-                              textInputAction: TextInputAction.next,
-                              keyboardType: TextInputType.number,
-                              inputFormatters: [
-                                FilteringTextInputFormatter.digitsOnly,
-                              ],
-                              decoration: const InputDecoration(
-                                labelText: 'O.S.',
-                                border: OutlineInputBorder(),
-                              ),
-                              validator: (v) {
-                                final s = (v ?? '').trim();
-                                if (s.isEmpty) return 'Obrigatório';
-                                if (!RegExp(r'^\d+$').hasMatch(s))
-                                  return 'Apenas números';
-                                return null;
-                              },
-                            ),
-                          ),
-                        ],
-                      ),
-
-                      const SizedBox(height: 12),
-
-                      Row(
-                        children: [
-                          Expanded(
-                            child: DropdownButtonFormField<String>(
-                              value: categoriaValue,
-                              decoration: const InputDecoration(
-                                labelText: 'Categoria',
-                                border: OutlineInputBorder(),
-                              ),
-                              items: _categorias
-                                  .map(
-                                    (c) => DropdownMenuItem(
-                                      value: c,
-                                      child: Text(c),
-                                    ),
-                                  )
-                                  .toList(),
-                              onChanged: flowLocked
-                                  ? null
-                                  : (v) {
-                                      ref
-                                          .read(
-                                            sharedSearchFormProvider.notifier,
-                                          )
-                                          .setCategoria(v);
-                                      setState(() {
-                                        _categoriaSel = v;
-                                        _maquinaSel = null;
-                                      });
-                                    },
-                              validator: (v) => (v == null || v.isEmpty)
-                                  ? 'Obrigatório'
-                                  : null,
-                            ),
-                          ),
-                          const SizedBox(width: 12),
-                          Expanded(
-                            child: DropdownButtonFormField<String>(
-                              value: maquinaValue,
-                              decoration: const InputDecoration(
-                                labelText: 'Código da máquina',
-                                border: OutlineInputBorder(),
-                              ),
-                              items: maquinasDisponiveis
-                                  .map(
-                                    (m) => DropdownMenuItem(
-                                      value: m.codigo,
-                                      child: Text(m.codigo),
-                                    ),
-                                  )
-                                  .toList(),
-                              onChanged: flowLocked
-                                  ? null
-                                  : (v) {
-                                      ref
-                                          .read(
-                                            sharedSearchFormProvider.notifier,
-                                          )
-                                          .setMaquina(v);
-                                      setState(() => _maquinaSel = v);
-                                    },
-                              validator: (v) => (v == null || v.isEmpty)
-                                  ? 'Obrigatório'
-                                  : null,
-                            ),
-                          ),
-                        ],
-                      ),
-
-                      const SizedBox(height: 12),
-
-                      // ---------- PartNumber + Operação (Operação só números) ----------
-                      Row(
-                        children: [
-                          Expanded(
-                            child: TextFormField(
-                              controller: _partCtrl,
-                              enabled: !flowLocked,
-                              textInputAction: TextInputAction.next,
-                              decoration: const InputDecoration(
-                                labelText: 'Código da peça (PartNumber)',
-                                border: OutlineInputBorder(),
-                              ),
-                              validator: (v) => (v == null || v.trim().isEmpty)
-                                  ? 'Obrigatório'
-                                  : null,
-                            ),
-                          ),
-                          const SizedBox(width: 12),
-                          SizedBox(
-                            width: 140,
-                            child: TextFormField(
-                              controller: _opCtrl,
-                              enabled: !flowLocked,
-                              keyboardType: TextInputType.number,
-                              inputFormatters: [
-                                FilteringTextInputFormatter.digitsOnly,
-                              ],
-                              decoration: const InputDecoration(
-                                labelText: 'Operação',
-                                border: OutlineInputBorder(),
-                              ),
-                              validator: (v) {
-                                final s = (v ?? '').trim();
-                                if (s.isEmpty) return 'Obrigatório';
-                                if (!RegExp(r'^\d+$').hasMatch(s))
-                                  return 'Apenas números';
-                                return null;
-                              },
-                            ),
-                          ),
-                        ],
-                      ),
-
-                      const SizedBox(height: 12),
-                      SizedBox(
-                        width: double.infinity,
-                        child: FilledButton.icon(
-                          onPressed: () async {
-                            if (_formKey.currentState!.validate()) {
-                              if (!_ensureFlowConsistency()) return;
-                              FocusScope.of(context).unfocus();
-                              await ref
-                                  .read(
-                                    medidasPreparadorControllerProvider
-                                        .notifier,
-                                  )
-                                  .carregar(
-                                    partnumber: normalizeCode(_partCtrl.text),
-                                    operacao: normalizeCode(_opCtrl.text),
-                                  );
-                              if (mounted) {
-                                setState(() => _mostrarResumo = true);
-                              }
-                            }
-                          },
-                          icon: const Icon(Icons.search),
-                          label: const Text('Carregar medidas'),
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ],
-              const SizedBox(height: 16),
-              Expanded(
-                child: medidasAsync.when(
-                  data: (list) {
-                    if (list.isEmpty) {
-                      return const Center(
-                        child: Text(
-                          'Nenhuma medida encontrada para a chave informada.',
-                        ),
-                      );
-                    }
-                    return ListView.separated(
-                      itemCount: list.length,
-                      separatorBuilder: (_, __) => const SizedBox(height: 8),
-                      itemBuilder: (context, index) {
-                        final item = list[index];
-                        return MeasurementTile(
-                          index: index,
-                          item: item,
-                          manualEntry: true,
-                          onSelect: (status, medicao) => ref
-                              .read(
-                                medidasPreparadorControllerProvider.notifier,
-                              )
-                              .setStatusAndMedicao(index, status, medicao),
-                        );
-                      },
-                    );
-                  },
-                  loading: () =>
-                      const Center(child: CircularProgressIndicator()),
-                  error: (e, _) =>
-                      Center(child: Text('Erro ao carregar:\n${e.toString()}')),
-                ),
               ),
-              const SizedBox(height: 10),
-              SizedBox(
-                width: double.infinity,
-                child: FilledButton.icon(
-                  onPressed: podeRegistrar ? _registrarResultado : null,
-                  icon: _registrando
-                      ? const SizedBox(
-                          width: 18,
-                          height: 18,
-                          child: CircularProgressIndicator(strokeWidth: 2),
-                        )
-                      : const Icon(Icons.save_outlined),
-                  label: const Text('Registrar resultado'),
+              ..._buildMedidasSlivers(medidasAsync),
+              SliverFillRemaining(
+                hasScrollBody: false,
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    SizedBox(
+                      width: double.infinity,
+                      child: FilledButton.icon(
+                        onPressed: podeRegistrar ? _registrarResultado : null,
+                        icon: _registrando
+                            ? const SizedBox(
+                                width: 18,
+                                height: 18,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                ),
+                              )
+                            : const Icon(Icons.save_outlined),
+                        label: const Text('Registrar resultado'),
+                      ),
+                    ),
+                  ],
                 ),
               ),
             ],
           ),
         ),
       ),
+    );
+  }
+
+  List<Widget> _buildMedidasSlivers(AsyncValue<List<MedidaItem>> medidasAsync) {
+    return medidasAsync.when(
+      data: (list) {
+        if (list.isEmpty) {
+          return [
+            const SliverToBoxAdapter(
+              child: Padding(
+                padding: EdgeInsets.symmetric(vertical: 24),
+                child: Center(
+                  child: Text(
+                    'Nenhuma medida encontrada para a chave informada.',
+                  ),
+                ),
+              ),
+            ),
+            const SliverToBoxAdapter(child: SizedBox(height: 10)),
+          ];
+        }
+        return [
+          SliverList(
+            delegate: SliverChildBuilderDelegate((context, index) {
+              final item = list[index];
+              return Padding(
+                padding: EdgeInsets.only(
+                  bottom: index == list.length - 1 ? 0 : 8,
+                ),
+                child: MeasurementTile(
+                  index: index,
+                  item: item,
+                  manualEntry: true,
+                  onSelect: (status, medicao) => ref
+                      .read(medidasPreparadorControllerProvider.notifier)
+                      .setStatusAndMedicao(index, status, medicao),
+                ),
+              );
+            }, childCount: list.length),
+          ),
+          const SliverToBoxAdapter(child: SizedBox(height: 10)),
+        ];
+      },
+      loading: () => [
+        const SliverToBoxAdapter(
+          child: Padding(
+            padding: EdgeInsets.symmetric(vertical: 24),
+            child: Center(child: CircularProgressIndicator()),
+          ),
+        ),
+        const SliverToBoxAdapter(child: SizedBox(height: 10)),
+      ],
+      error: (e, _) => [
+        SliverToBoxAdapter(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(vertical: 24),
+            child: Center(child: Text('Erro ao carregar:\n${e.toString()}')),
+          ),
+        ),
+        const SliverToBoxAdapter(child: SizedBox(height: 10)),
+      ],
     );
   }
 }


### PR DESCRIPTION
## Summary
- render the Preparação, Amostragem e Finalização screens inside `CustomScrollView`s so the search section scrolls instead of overflowing when the keyboard is visible
- move the measurement list rendering into sliver helpers and keep the submit actions inside `SliverFillRemaining` so the action buttons stay reachable above the keyboard

## Testing
- flutter analyze

------
https://chatgpt.com/codex/tasks/task_e_68d189409b648331840e5f051331999a