### PR TITLE
Allow editing search summary while flow is active

### DIFF
--- a/lib/features/finalizar_os/presentation/finalizar_os_page.dart
+++ b/lib/features/finalizar_os/presentation/finalizar_os_page.dart
@@ -554,12 +554,10 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
                       Align(
                         alignment: Alignment.centerRight,
                         child: TextButton.icon(
-                          onPressed: flowLocked
-                              ? null
-                              : () {
-                                  FocusScope.of(context).unfocus();
-                                  setState(() => _mostrarResumo = false);
-                                },
+                          onPressed: () {
+                            FocusScope.of(context).unfocus();
+                            setState(() => _mostrarResumo = false);
+                          },
                           icon: const Icon(Icons.edit_outlined),
                           label: const Text('Alterar dados da busca'),
                         ),

--- a/lib/features/operador/presentation/operador_page.dart
+++ b/lib/features/operador/presentation/operador_page.dart
@@ -793,12 +793,10 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                       Align(
                         alignment: Alignment.centerRight,
                         child: TextButton.icon(
-                          onPressed: flowLocked
-                              ? null
-                              : () {
-                                  FocusScope.of(context).unfocus();
-                                  setState(() => _mostrarResumo = false);
-                                },
+                          onPressed: () {
+                            FocusScope.of(context).unfocus();
+                            setState(() => _mostrarResumo = false);
+                          },
                           icon: const Icon(Icons.edit_outlined),
                           label: const Text('Alterar dados da busca'),
                         ),

--- a/lib/features/preparacao/presentation/preparacao_page.dart
+++ b/lib/features/preparacao/presentation/preparacao_page.dart
@@ -582,12 +582,10 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
                       Align(
                         alignment: Alignment.centerRight,
                         child: TextButton.icon(
-                          onPressed: flowLocked
-                              ? null
-                              : () {
-                                  FocusScope.of(context).unfocus();
-                                  setState(() => _mostrarResumo = false);
-                                },
+                          onPressed: () {
+                            FocusScope.of(context).unfocus();
+                            setState(() => _mostrarResumo = false);
+                          },
                           icon: const Icon(Icons.edit_outlined),
                           label: const Text('Alterar dados da busca'),
                         ),


### PR DESCRIPTION
## Summary
- keep the "Alterar dados da busca" action enabled even when a flow is active
- apply the same behavior to the preparação, operador, and finalizar O.S. screens so the RE field can be corrected

## Testing
- flutter test

------
https://chatgpt.com/codex/tasks/task_e_68d1962570108331a27ce6cd44eea8af