### PR TITLE
Fix keyboard overflow for action buttons

### DIFF
--- a/lib/features/finalizar_os/presentation/finalizar_os_page.dart
+++ b/lib/features/finalizar_os/presentation/finalizar_os_page.dart
@@ -432,6 +432,8 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
     final medidas = medidasAsync.value ?? [];
     final flowState = ref.watch(sharedSearchFormProvider);
     final flowLocked = flowState.isActive;
+    final bottomInset = MediaQuery.of(context).viewInsets.bottom;
+    final actionBottomPadding = bottomInset > 0 ? bottomInset + 16.0 : 16.0;
 
     // Pode registrar quando: RE e OS preenchidos + todas as medições preenchidas
     final reOk = _reCtrl.text.trim().isNotEmpty;
@@ -778,27 +780,48 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
               ..._buildMedidasSlivers(medidasAsync),
               SliverFillRemaining(
                 hasScrollBody: false,
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.end,
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
-                    SizedBox(
-                      width: double.infinity,
-                      child: FilledButton.icon(
-                        onPressed: podeRegistrar ? _registrarFinalizacao : null,
-                        icon: _registrando
-                            ? const SizedBox(
-                                width: 18,
-                                height: 18,
-                                child: CircularProgressIndicator(
-                                  strokeWidth: 2,
+                child: LayoutBuilder(
+                  builder: (context, constraints) {
+                    return SingleChildScrollView(
+                      primary: false,
+                      padding: EdgeInsets.zero,
+                      physics: const NeverScrollableScrollPhysics(),
+                      child: ConstrainedBox(
+                        constraints: BoxConstraints(
+                          minHeight: constraints.maxHeight,
+                        ),
+                        child: AnimatedPadding(
+                          duration: const Duration(milliseconds: 200),
+                          curve: Curves.easeOut,
+                          padding: EdgeInsets.only(bottom: actionBottomPadding),
+                          child: Column(
+                            mainAxisAlignment: MainAxisAlignment.end,
+                            crossAxisAlignment: CrossAxisAlignment.stretch,
+                            children: [
+                              SizedBox(
+                                width: double.infinity,
+                                child: FilledButton.icon(
+                                  onPressed: podeRegistrar
+                                      ? _registrarFinalizacao
+                                      : null,
+                                  icon: _registrando
+                                      ? const SizedBox(
+                                          width: 18,
+                                          height: 18,
+                                          child: CircularProgressIndicator(
+                                            strokeWidth: 2,
+                                          ),
+                                        )
+                                      : const Icon(Icons.save_outlined),
+                                  label: const Text('Finalizar OS'),
                                 ),
-                              )
-                            : const Icon(Icons.save_outlined),
-                        label: const Text('Finalizar OS'),
+                              ),
+                            ],
+                          ),
+                        ),
                       ),
-                    ),
-                  ],
+                    );
+                  },
                 ),
               ),
             ],

--- a/lib/features/operador/presentation/operador_page.dart
+++ b/lib/features/operador/presentation/operador_page.dart
@@ -671,6 +671,8 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
     final medidas = medidasAsync.value ?? [];
     final flowState = ref.watch(sharedSearchFormProvider);
     final flowLocked = flowState.isActive;
+    final bottomInset = MediaQuery.of(context).viewInsets.bottom;
+    final actionBottomPadding = bottomInset > 0 ? bottomInset + 16.0 : 16.0;
     final reOk = _reCtrl.text.trim().isNotEmpty;
     final osOk = _osCtrl.text.trim().isNotEmpty;
     final categoriaValue =
@@ -1017,47 +1019,72 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
               ..._buildMedidasSlivers(medidasAsync),
               SliverFillRemaining(
                 hasScrollBody: false,
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.end,
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
-                    Align(
-                      alignment: Alignment.centerRight,
-                      child: PopupMenuButton<String>(
-                        onSelected: (value) {
-                          if (value == 'fim') _showFimJornadaDialog();
-                          if (value == 'encerrar') _confirmEncerrarProducao();
-                        },
-                        itemBuilder: (context) => const [
-                          PopupMenuItem(
-                            value: 'fim',
-                            child: Text('Fim de Jornada'),
-                          ),
-                          PopupMenuItem(
-                            value: 'encerrar',
-                            child: Text('Encerrar produção'),
-                          ),
-                        ],
-                      ),
-                    ),
-                    const SizedBox(height: 10),
-                    SizedBox(
-                      width: double.infinity,
-                      child: FilledButton.icon(
-                        onPressed: podeRegistrar ? _registrarAmostragem : null,
-                        icon: _registrando
-                            ? const SizedBox(
-                                width: 18,
-                                height: 18,
-                                child: CircularProgressIndicator(
-                                  strokeWidth: 2,
+                child: LayoutBuilder(
+                  builder: (context, constraints) {
+                    return SingleChildScrollView(
+                      primary: false,
+                      padding: EdgeInsets.zero,
+                      physics: const NeverScrollableScrollPhysics(),
+                      child: ConstrainedBox(
+                        constraints: BoxConstraints(
+                          minHeight: constraints.maxHeight,
+                        ),
+                        child: AnimatedPadding(
+                          duration: const Duration(milliseconds: 200),
+                          curve: Curves.easeOut,
+                          padding: EdgeInsets.only(bottom: actionBottomPadding),
+                          child: Column(
+                            mainAxisAlignment: MainAxisAlignment.end,
+                            crossAxisAlignment: CrossAxisAlignment.stretch,
+                            children: [
+                              Align(
+                                alignment: Alignment.centerRight,
+                                child: PopupMenuButton<String>(
+                                  onSelected: (value) {
+                                    if (value == 'fim') {
+                                      _showFimJornadaDialog();
+                                    }
+                                    if (value == 'encerrar') {
+                                      _confirmEncerrarProducao();
+                                    }
+                                  },
+                                  itemBuilder: (context) => const [
+                                    PopupMenuItem(
+                                      value: 'fim',
+                                      child: Text('Fim de Jornada'),
+                                    ),
+                                    PopupMenuItem(
+                                      value: 'encerrar',
+                                      child: Text('Encerrar produção'),
+                                    ),
+                                  ],
                                 ),
-                              )
-                            : const Icon(Icons.save_outlined),
-                        label: const Text('Registrar amostragem'),
+                              ),
+                              const SizedBox(height: 10),
+                              SizedBox(
+                                width: double.infinity,
+                                child: FilledButton.icon(
+                                  onPressed: podeRegistrar
+                                      ? _registrarAmostragem
+                                      : null,
+                                  icon: _registrando
+                                      ? const SizedBox(
+                                          width: 18,
+                                          height: 18,
+                                          child: CircularProgressIndicator(
+                                            strokeWidth: 2,
+                                          ),
+                                        )
+                                      : const Icon(Icons.save_outlined),
+                                  label: const Text('Registrar amostragem'),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
                       ),
-                    ),
-                  ],
+                    );
+                  },
                 ),
               ),
             ],

--- a/lib/features/preparacao/presentation/preparacao_page.dart
+++ b/lib/features/preparacao/presentation/preparacao_page.dart
@@ -460,6 +460,8 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
     final medidas = medidasAsync.value ?? [];
     final flowState = ref.watch(sharedSearchFormProvider);
     final flowLocked = flowState.isActive;
+    final bottomInset = MediaQuery.of(context).viewInsets.bottom;
+    final actionBottomPadding = bottomInset > 0 ? bottomInset + 16.0 : 16.0;
 
     // Pode registrar quando: RE e OS preenchidos + todas as medições preenchidas
     final reOk = _reCtrl.text.trim().isNotEmpty;
@@ -862,27 +864,48 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
               ..._buildMedidasSlivers(medidasAsync),
               SliverFillRemaining(
                 hasScrollBody: false,
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.end,
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
-                    SizedBox(
-                      width: double.infinity,
-                      child: FilledButton.icon(
-                        onPressed: podeRegistrar ? _registrarResultado : null,
-                        icon: _registrando
-                            ? const SizedBox(
-                                width: 18,
-                                height: 18,
-                                child: CircularProgressIndicator(
-                                  strokeWidth: 2,
+                child: LayoutBuilder(
+                  builder: (context, constraints) {
+                    return SingleChildScrollView(
+                      primary: false,
+                      padding: EdgeInsets.zero,
+                      physics: const NeverScrollableScrollPhysics(),
+                      child: ConstrainedBox(
+                        constraints: BoxConstraints(
+                          minHeight: constraints.maxHeight,
+                        ),
+                        child: AnimatedPadding(
+                          duration: const Duration(milliseconds: 200),
+                          curve: Curves.easeOut,
+                          padding: EdgeInsets.only(bottom: actionBottomPadding),
+                          child: Column(
+                            mainAxisAlignment: MainAxisAlignment.end,
+                            crossAxisAlignment: CrossAxisAlignment.stretch,
+                            children: [
+                              SizedBox(
+                                width: double.infinity,
+                                child: FilledButton.icon(
+                                  onPressed: podeRegistrar
+                                      ? _registrarResultado
+                                      : null,
+                                  icon: _registrando
+                                      ? const SizedBox(
+                                          width: 18,
+                                          height: 18,
+                                          child: CircularProgressIndicator(
+                                            strokeWidth: 2,
+                                          ),
+                                        )
+                                      : const Icon(Icons.save_outlined),
+                                  label: const Text('Registrar resultado'),
                                 ),
-                              )
-                            : const Icon(Icons.save_outlined),
-                        label: const Text('Registrar resultado'),
+                              ),
+                            ],
+                          ),
+                        ),
                       ),
-                    ),
-                  ],
+                    );
+                  },
                 ),
               ),
             ],


### PR DESCRIPTION
## Summary
- make the preparacao, finalizar and operador screens account for the on-screen keyboard when laying out the footer actions
- wrap the footer slivers in a layout builder with an animated bottom padding so the buttons remain visible on short viewports
- ensure the non-scrollable footer scroll views opt out of the primary scroll controller to prevent nested scroll crashes

## Testing
- flutter analyze

------
https://chatgpt.com/codex/tasks/task_e_68d1984e3c448331929176b33a245ffe