### PR TITLE
Exibe processo atual no aviso de fluxo ativo

### DIFF
--- a/lib/features/finalizar_os/presentation/finalizar_os_page.dart
+++ b/lib/features/finalizar_os/presentation/finalizar_os_page.dart
@@ -432,6 +432,8 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
     final medidas = medidasAsync.value ?? [];
     final flowState = ref.watch(sharedSearchFormProvider);
     final flowLocked = flowState.isActive;
+    final flowProcessName = flowState.processDisplayName;
+    final flowOs = flowState.os.trim();
     final bottomInset = MediaQuery.of(context).viewInsets.bottom;
     final actionBottomPadding = bottomInset > 0 ? bottomInset + 16.0 : 16.0;
 
@@ -526,9 +528,9 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
                             const SizedBox(width: 8),
                             Expanded(
                               child: Text(
-                                flowState.os.trim().isEmpty
-                                    ? 'Existe um fluxo de O.S. em andamento. Finalize a O.S. atual para iniciar outra.'
-                                    : 'Fluxo ativo para a O.S. ${flowState.os}. Finalize a O.S. atual para iniciar outra.',
+                                flowOs.isEmpty
+                                    ? 'Existe um fluxo de $flowProcessName em andamento. Finalize a O.S. atual para iniciar outra.'
+                                    : 'Fluxo de $flowProcessName ativo para a O.S. $flowOs. Finalize a O.S. atual para iniciar outra.',
                                 style: Theme.of(context).textTheme.bodyMedium,
                               ),
                             ),

--- a/lib/features/operador/presentation/operador_page.dart
+++ b/lib/features/operador/presentation/operador_page.dart
@@ -646,6 +646,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
       operacao: _opCtrl.text,
       categoria: _categoriaSel,
       maquina: _maquinaSel,
+      process: SearchFlowProcess.finalizacao,
     );
 
     if (!iniciouFluxo) {
@@ -671,6 +672,8 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
     final medidas = medidasAsync.value ?? [];
     final flowState = ref.watch(sharedSearchFormProvider);
     final flowLocked = flowState.isActive;
+    final flowProcessName = flowState.processDisplayName;
+    final flowOs = flowState.os.trim();
     final bottomInset = MediaQuery.of(context).viewInsets.bottom;
     final actionBottomPadding = bottomInset > 0 ? bottomInset + 16.0 : 16.0;
     final reOk = _reCtrl.text.trim().isNotEmpty;
@@ -765,9 +768,9 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                             const SizedBox(width: 8),
                             Expanded(
                               child: Text(
-                                flowState.os.trim().isEmpty
-                                    ? 'Existe um fluxo de O.S. em andamento. Finalize a O.S. atual para iniciar outra.'
-                                    : 'Fluxo ativo para a O.S. ${flowState.os}. Finalize a O.S. atual para iniciar outra.',
+                                flowOs.isEmpty
+                                    ? 'Existe um fluxo de $flowProcessName em andamento. Finalize a O.S. atual para iniciar outra.'
+                                    : 'Fluxo de $flowProcessName ativo para a O.S. $flowOs. Finalize a O.S. atual para iniciar outra.',
                                 style: Theme.of(context).textTheme.bodyMedium,
                               ),
                             ),

--- a/lib/features/preparacao/presentation/preparacao_page.dart
+++ b/lib/features/preparacao/presentation/preparacao_page.dart
@@ -267,6 +267,7 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
       operacao: _opCtrl.text,
       categoria: _categoriaSel,
       maquina: _maquinaSel,
+      process: SearchFlowProcess.amostragem,
     );
 
     if (!iniciouFluxo) {
@@ -460,6 +461,8 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
     final medidas = medidasAsync.value ?? [];
     final flowState = ref.watch(sharedSearchFormProvider);
     final flowLocked = flowState.isActive;
+    final flowProcessName = flowState.processDisplayName;
+    final flowOs = flowState.os.trim();
     final bottomInset = MediaQuery.of(context).viewInsets.bottom;
     final actionBottomPadding = bottomInset > 0 ? bottomInset + 16.0 : 16.0;
 
@@ -554,9 +557,9 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
                             const SizedBox(width: 8),
                             Expanded(
                               child: Text(
-                                flowState.os.trim().isEmpty
-                                    ? 'Existe um fluxo de O.S. em andamento. Finalize a O.S. atual para iniciar outra.'
-                                    : 'Fluxo ativo para a O.S. ${flowState.os}. Finalize a O.S. atual para iniciar outra.',
+                                flowOs.isEmpty
+                                    ? 'Existe um fluxo de $flowProcessName em andamento. Finalize a O.S. atual para iniciar outra.'
+                                    : 'Fluxo de $flowProcessName ativo para a O.S. $flowOs. Finalize a O.S. atual para iniciar outra.',
                                 style: Theme.of(context).textTheme.bodyMedium,
                               ),
                             ),

--- a/lib/features/shared/providers/search_flow_form_provider.dart
+++ b/lib/features/shared/providers/search_flow_form_provider.dart
@@ -3,6 +3,30 @@ import 'package:hive/hive.dart';
 
 const sharedSearchFlowBoxName = 'shared_search_flow';
 const _sharedSearchFlowStateKey = 'state';
+
+enum SearchFlowProcess { amostragem, finalizacao }
+
+extension SearchFlowProcessDisplay on SearchFlowProcess {
+  String get displayName {
+    switch (this) {
+      case SearchFlowProcess.amostragem:
+        return 'Amostragem';
+      case SearchFlowProcess.finalizacao:
+        return 'Finalização de O.S.';
+    }
+  }
+}
+
+SearchFlowProcess? _parseProcess(dynamic raw) {
+  if (raw is! String) return null;
+  for (final process in SearchFlowProcess.values) {
+    if (process.name == raw) {
+      return process;
+    }
+  }
+  return null;
+}
+
 class SharedSearchFormState {
   const SharedSearchFormState({
     this.isActive = false,
@@ -11,6 +35,7 @@ class SharedSearchFormState {
     this.operacao = '',
     this.categoria,
     this.maquina,
+    this.process,
   });
 
   final bool isActive;
@@ -19,6 +44,7 @@ class SharedSearchFormState {
   final String operacao;
   final String? categoria;
   final String? maquina;
+  final SearchFlowProcess? process;
 
   static const _sentinel = Object();
   static String? _normalizeOptional(String? value) {
@@ -40,6 +66,7 @@ class SharedSearchFormState {
       operacao: _readString(map['operacao']),
       categoria: _readOptional(map['categoria']),
       maquina: _readOptional(map['maquina']),
+      process: _parseProcess(map['process']),
     );
   }
 
@@ -51,6 +78,7 @@ class SharedSearchFormState {
       'operacao': operacao,
       'categoria': categoria,
       'maquina': maquina,
+      'process': process?.name,
     };
   }
 
@@ -61,6 +89,7 @@ class SharedSearchFormState {
     String? operacao,
     Object? categoria = _sentinel,
     Object? maquina = _sentinel,
+    Object? process = _sentinel,
   }) {
     return SharedSearchFormState(
       isActive: isActive ?? this.isActive,
@@ -69,6 +98,9 @@ class SharedSearchFormState {
       operacao: operacao ?? this.operacao,
       categoria: categoria == _sentinel ? this.categoria : categoria as String?,
       maquina: maquina == _sentinel ? this.maquina : maquina as String?,
+      process: process == _sentinel
+          ? this.process
+          : process as SearchFlowProcess?,
     );
   }
 
@@ -81,7 +113,9 @@ class SharedSearchFormState {
   }
 
   bool equals(SharedSearchFormState other) {
-    return isActive == other.isActive && matches(other);
+    return isActive == other.isActive &&
+        matches(other) &&
+        process == other.process;
   }
 
   bool matchesValues({
@@ -102,6 +136,13 @@ class SharedSearchFormState {
       ),
     );
   }
+}
+
+extension SharedSearchFormStateDisplay on SharedSearchFormState {
+  SearchFlowProcess get effectiveProcess =>
+      process ?? SearchFlowProcess.amostragem;
+
+  String get processDisplayName => effectiveProcess.displayName;
 }
 
 SharedSearchFormState _restoreInitialState(Box<Map> box) {
@@ -150,6 +191,7 @@ class SharedSearchFormController extends StateNotifier<SharedSearchFormState> {
     required String operacao,
     String? categoria,
     String? maquina,
+    SearchFlowProcess process = SearchFlowProcess.amostragem,
   }) {
     final candidate = SharedSearchFormState(
       isActive: true,
@@ -158,6 +200,7 @@ class SharedSearchFormController extends StateNotifier<SharedSearchFormState> {
       operacao: operacao.trim(),
       categoria: SharedSearchFormState._normalizeOptional(categoria),
       maquina: SharedSearchFormState._normalizeOptional(maquina),
+      process: process,
     );
 
     if (_isActive && state.matches(candidate) == false) {


### PR DESCRIPTION
## Summary
- adiciona enumeração de processo ao estado compartilhado de fluxo e persiste essa informação
- exibe o nome do processo ativo nas mensagens de fluxo nas páginas de preparação, amostragem e finalização
- ajusta a abertura das telas para informar o processo correto ao iniciar o fluxo

## Testing
- flutter test

------
https://chatgpt.com/codex/tasks/task_e_68d278a6f91c8331a9b33f5f5c9a511a