### PR TITLE
Add OS swap pause option

### DIFF
--- a/app_db.py
+++ b/app_db.py
@@ -876,8 +876,13 @@ def _maquina_liberada(
     with conn.cursor() as cur:
         cur.execute("SELECT status FROM ordem_servico WHERE os=%s", (os_num,))
         st_row = cur.fetchone()
-        if st_row and (st_row.get("status") or "").strip().lower() == "encerrada":
+        status_atual = ""
+        if st_row:
+            status_atual = (st_row.get("status") or "").strip().lower()
+        if status_atual == "encerrada":
             return (False, "ordem_servico", "status=encerrada")
+        if status_atual == "pausada":
+            return (False, "ordem_servico", "status=pausada")
         # 1) Se existir liberação com status final, já libera
 
         cur.execute(
@@ -1913,6 +1918,45 @@ def operador_listar():
         return jsonify({"error": f"Falha ao consultar amostragens: {e}"}), 500
 
 
+def _registrar_pausa_operador(
+        cur,
+        os_num: str,
+        re_op: str,
+        part: Optional[str],
+        op: Optional[str],
+        motivo: Optional[str],
+):
+    """Registra uma pausa de jornada garantindo que não haja sobreposição."""
+
+    cur.execute("INSERT IGNORE INTO ordem_servico (os) VALUES (%s)", (os_num,))
+    cur.execute(
+        """
+        UPDATE operador_jornada
+           SET retorno_at = CURRENT_TIMESTAMP
+         WHERE os=%s
+           AND re_operador=%s
+           AND retorno_at IS NULL
+           AND (partnumber IS NULL OR partnumber = %s OR %s IS NULL)
+           AND (operacao IS NULL OR operacao = %s OR %s IS NULL)
+        """,
+        (
+            os_num,
+            re_op,
+            part or None,
+            part or None,
+            op or None,
+            op or None,
+        ),
+    )
+    cur.execute(
+        """
+        INSERT INTO operador_jornada (os, partnumber, operacao, re_operador, motivo)
+        VALUES (%s, %s, %s, %s, %s)
+        """,
+        (os_num, part or None, op or None, re_op, motivo or None),
+    )
+
+
 @app.route("/operador/fim_jornada", methods=["POST"])
 def operador_fim_jornada():
     payload = request.get_json(silent=True) or {}
@@ -1928,41 +1972,56 @@ def operador_fim_jornada():
     try:
         with _conn_db(DB_NAME) as c:
             with c.cursor() as cur:
-                cur.execute(
-                    "INSERT IGNORE INTO ordem_servico (os) VALUES (%s)", (os_num,)
-                )
-                # Caso exista uma pausa aberta para este operador, encerra-a
-                # antes de registrar a nova pausa, evitando sobreposição.
-                cur.execute(
-                    """
-                    UPDATE operador_jornada
-                       SET retorno_at = CURRENT_TIMESTAMP
-                     WHERE os=%s
-                       AND re_operador=%s
-                       AND retorno_at IS NULL
-                       AND (partnumber IS NULL OR partnumber = %s OR %s IS NULL)
-                       AND (operacao IS NULL OR operacao = %s OR %s IS NULL)
-                    """,
-                    (
-                        os_num,
-                        re_op,
-                        part or None,
-                        part or None,
-                        op or None,
-                        op or None,
-                    ),
-                )
-                cur.execute(
-                    """
-                    INSERT INTO operador_jornada (os, partnumber, operacao, re_operador, motivo)
-                    VALUES (%s, %s, %s, %s, %s)
-                    """,
-                    (os_num, part or None, op or None, re_op, motivo or None),
-                )
+                _registrar_pausa_operador(cur, os_num, re_op, part, op, motivo)
             c.commit()
         return jsonify({"status": "ok"})
     except Exception as e:
         return jsonify({"error": f"Falha ao registrar fim de jornada: {e}"}), 500
+
+
+@app.route("/operador/troca_os", methods=["POST"])
+def operador_troca_os():
+    payload = request.get_json(silent=True) or {}
+    os_num = _norm(payload.get("os"))
+    re_op = _norm(payload.get("re"))
+    part = _norm_part(payload.get("partnumber"))
+    op = _norm_op(payload.get("operacao"))
+    motivo = _norm(payload.get("motivo")) or "Troca de OS"
+    if not os_num or not re_op:
+        return jsonify({"error": "Campos 'os' e 're' são obrigatórios"}), 400
+    try:
+        with _conn_db(DB_NAME) as c:
+            with c.cursor() as cur:
+                cur.execute("SELECT status FROM ordem_servico WHERE os=%s", (os_num,))
+                st_row = cur.fetchone()
+                status_atual = ""
+                if st_row:
+                    status_atual = (st_row.get("status") or "").strip().lower()
+                    if status_atual == "encerrada":
+                        return (
+                            jsonify({
+                                "error": "Ordem de serviço encerrada não pode ser pausada.",
+                                "code": "os_encerrada",
+                            }),
+                            409,
+                        )
+
+                _registrar_pausa_operador(cur, os_num, re_op, part, op, motivo)
+                cur.execute(
+                    "UPDATE ordem_servico SET status=%s WHERE os=%s",
+                    ("pausada", os_num),
+                )
+            c.commit()
+        return jsonify(
+            {
+                "status": "ok",
+                "motivo": motivo,
+                "os_status": "pausada",
+                "status_anterior": status_atual,
+            }
+        )
+    except Exception as e:
+        return jsonify({"error": f"Falha ao registrar troca de OS: {e}"}), 500
 
 
 @app.route("/operador/encerrar_producao", methods=["POST"])
@@ -2647,7 +2706,15 @@ def _mensagem_bloqueio(
     det = str(detalhe or "")
 
     if fonte == "ordem_servico":
-        return base + "\nA ordem de serviço está encerrada."
+        det_lower = det.lower()
+        if "status=pausada" in det_lower:
+            return (
+                base
+                + "\nA ordem de serviço está pausada. Solicite nova liberação ao Preparador."
+            )
+        if "status=encerrada" in det_lower:
+            return base + "\nA ordem de serviço está encerrada."
+        return base + "\nSituação da ordem de serviço impede o registro no momento."
 
     base = "A máquina ainda não foi liberada pelo Preparador.\n" + base
 

--- a/lib/features/operador/presentation/operador_page.dart
+++ b/lib/features/operador/presentation/operador_page.dart
@@ -416,16 +416,16 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
     }
   }
 
-  Future<void> _fimJornada(String motivo) async {
+  Future<bool> _fimJornada(String motivo) async {
     if (_reCtrl.text.trim().isEmpty || _osCtrl.text.trim().isEmpty) {
-      if (!mounted) return;
+      if (!mounted) return false;
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('Preencha RE e O.S. para finalizar.')),
       );
-      return;
+      return false;
     }
 
-    if (!_ensureFlowConsistency()) return;
+    if (!_ensureFlowConsistency()) return false;
 
     final body = jsonEncode({
       're': _reCtrl.text.trim(),
@@ -440,15 +440,73 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
       final resp = await http
           .post(uri, headers: {'Content-Type': 'application/json'}, body: body)
           .timeout(const Duration(seconds: 20));
-      if (!mounted) return;
+      if (!mounted) return false;
       if (resp.statusCode == 200) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text('Jornada pausada. Motivo: $motivo')),
         );
+        return true;
       } else {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text('Falha: ${resp.statusCode} ${resp.body}')),
         );
+      }
+    } catch (e) {
+      if (!mounted) return false;
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('Erro: $e')));
+    }
+    return false;
+  }
+
+  Future<void> _trocarOs() async {
+    if (_reCtrl.text.trim().isEmpty || _osCtrl.text.trim().isEmpty) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Preencha RE e O.S. para trocar.')),
+      );
+      return;
+    }
+
+    if (!_ensureFlowConsistency()) return;
+
+    final body = jsonEncode({
+      're': _reCtrl.text.trim(),
+      'os': _osCtrl.text.trim(),
+      'partnumber': normalizeCode(_partCtrl.text),
+      'operacao': normalizeCode(_opCtrl.text),
+      'motivo': 'Troca de OS',
+    });
+
+    final uri = buildApiUri('/operador/troca_os');
+    try {
+      final resp = await http
+          .post(uri, headers: {'Content-Type': 'application/json'}, body: body)
+          .timeout(const Duration(seconds: 20));
+      if (!mounted) return;
+      if (resp.statusCode == 200) {
+        ref.read(sharedSearchFormProvider.notifier).clear();
+        FocusScope.of(context).unfocus();
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text(
+              'O.S. pausada para troca. Solicite nova liberação antes de retomar.',
+            ),
+          ),
+        );
+      } else {
+        String mensagem = 'Falha: ${resp.statusCode} ${resp.body}';
+        try {
+          final data = jsonDecode(resp.body);
+          if (data is Map && data['error'] is String) {
+            final texto = (data['error'] as String).trim();
+            if (texto.isNotEmpty) mensagem = texto;
+          }
+        } catch (_) {}
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text(mensagem)));
       }
     } catch (e) {
       if (!mounted) return;
@@ -633,6 +691,32 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
     );
     if (confirma == true) {
       await _encerrarProducao();
+    }
+  }
+
+  Future<void> _confirmTrocaOs() async {
+    final confirma = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Troca de O.S.'),
+        content: const Text(
+          'Deseja pausar a O.S. atual e liberar o fluxo para iniciar outra? '
+          'Será necessária nova liberação para retomar a produção desta O.S.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Cancelar'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Confirmar'),
+          ),
+        ],
+      ),
+    );
+    if (confirma == true) {
+      await _trocarOs();
     }
   }
 
@@ -1038,8 +1122,9 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                             onSelected: (value) {
                               if (value == 'fim') {
                                 _showFimJornadaDialog();
-                              }
-                              if (value == 'encerrar') {
+                              } else if (value == 'troca') {
+                                _confirmTrocaOs();
+                              } else if (value == 'encerrar') {
                                 _confirmEncerrarProducao();
                               }
                             },
@@ -1047,6 +1132,10 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                               PopupMenuItem(
                                 value: 'fim',
                                 child: Text('Fim de Jornada'),
+                              ),
+                              PopupMenuItem(
+                                value: 'troca',
+                                child: Text('Troca de O.S.'),
                               ),
                               PopupMenuItem(
                                 value: 'encerrar',
@@ -1059,8 +1148,9 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                         SizedBox(
                           width: double.infinity,
                           child: FilledButton.icon(
-                            onPressed:
-                                podeRegistrar ? _registrarAmostragem : null,
+                            onPressed: podeRegistrar
+                                ? _registrarAmostragem
+                                : null,
                             icon: _registrando
                                 ? const SizedBox(
                                     width: 18,


### PR DESCRIPTION
## Summary
- add a shared helper and `/operador/troca_os` endpoint so operators can pause an OS and reuse the pause logging logic
- mark paused OS as blocked in machine liberation checks and show a clear message when a paused OS is encountered
- surface a "Troca de O.S." action in the operator UI that pauses the OS via the new endpoint, clears the active flow, and informs the operator

## Testing
- dart format lib/features/operador/presentation/operador_page.dart
- python -m compileall app_db.py
- dart analyze

------
https://chatgpt.com/codex/tasks/task_e_68d281d6153c833181aec275f01fd4d1