### PR TITLE
Ensure search summaries expose edit control across flows

### DIFF
--- a/lib/features/finalizar_os/presentation/finalizar_os_page.dart
+++ b/lib/features/finalizar_os/presentation/finalizar_os_page.dart
@@ -538,7 +538,7 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
                         ),
                       ),
                     if (_mostrarResumo) ...[
-                      SearchSummaryCard(
+                      SearchSummarySection(
                         reLabel: 'R.E. do Preparador',
                         reValue: _reCtrl.text,
                         items: [
@@ -553,18 +553,10 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
                               value: categoriaValue!,
                             ),
                         ],
-                      ),
-                      const SizedBox(height: 8),
-                      Align(
-                        alignment: Alignment.centerRight,
-                        child: TextButton.icon(
-                          onPressed: () {
-                            FocusScope.of(context).unfocus();
-                            setState(() => _mostrarResumo = false);
-                          },
-                          icon: const Icon(Icons.edit_outlined),
-                          label: const Text('Alterar dados da busca'),
-                        ),
+                        onEdit: () {
+                          FocusScope.of(context).unfocus();
+                          setState(() => _mostrarResumo = false);
+                        },
                       ),
                     ] else ...[
                       Form(
@@ -795,8 +787,9 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
                         SizedBox(
                           width: double.infinity,
                           child: FilledButton.icon(
-                            onPressed:
-                                podeRegistrar ? _registrarFinalizacao : null,
+                            onPressed: podeRegistrar
+                                ? _registrarFinalizacao
+                                : null,
                             icon: _registrando
                                 ? const SizedBox(
                                     width: 18,

--- a/lib/features/operador/presentation/operador_page.dart
+++ b/lib/features/operador/presentation/operador_page.dart
@@ -862,7 +862,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                         ),
                       ),
                     if (_mostrarResumo) ...[
-                      SearchSummaryCard(
+                      SearchSummarySection(
                         reLabel: 'R.E. do Preparador',
                         reValue: _reCtrl.text,
                         items: [
@@ -877,18 +877,10 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                               value: categoriaValue!,
                             ),
                         ],
-                      ),
-                      const SizedBox(height: 8),
-                      Align(
-                        alignment: Alignment.centerRight,
-                        child: TextButton.icon(
-                          onPressed: () {
-                            FocusScope.of(context).unfocus();
-                            setState(() => _mostrarResumo = false);
-                          },
-                          icon: const Icon(Icons.edit_outlined),
-                          label: const Text('Alterar dados da busca'),
-                        ),
+                        onEdit: () {
+                          FocusScope.of(context).unfocus();
+                          setState(() => _mostrarResumo = false);
+                        },
                       ),
                     ] else ...[
                       Form(

--- a/lib/features/preparacao/presentation/preparacao_page.dart
+++ b/lib/features/preparacao/presentation/preparacao_page.dart
@@ -567,7 +567,7 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
                         ),
                       ),
                     if (_mostrarResumo) ...[
-                      SearchSummaryCard(
+                      SearchSummarySection(
                         reLabel: 'R.E. do Preparador',
                         reValue: _reCtrl.text,
                         items: [
@@ -582,18 +582,10 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
                               value: categoriaValue!,
                             ),
                         ],
-                      ),
-                      const SizedBox(height: 8),
-                      Align(
-                        alignment: Alignment.centerRight,
-                        child: TextButton.icon(
-                          onPressed: () {
-                            FocusScope.of(context).unfocus();
-                            setState(() => _mostrarResumo = false);
-                          },
-                          icon: const Icon(Icons.edit_outlined),
-                          label: const Text('Alterar dados da busca'),
-                        ),
+                        onEdit: () {
+                          FocusScope.of(context).unfocus();
+                          setState(() => _mostrarResumo = false);
+                        },
                       ),
                     ] else ...[
                       Form(
@@ -880,8 +872,9 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
                         SizedBox(
                           width: double.infinity,
                           child: FilledButton.icon(
-                            onPressed:
-                                podeRegistrar ? _registrarResultado : null,
+                            onPressed: podeRegistrar
+                                ? _registrarResultado
+                                : null,
                             icon: _registrando
                                 ? const SizedBox(
                                     width: 18,

--- a/lib/widgets/search_summary_card.dart
+++ b/lib/widgets/search_summary_card.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+
 /// Representation of a summary item shown in the [SearchSummaryCard].
 class SummaryInfo {
   const SummaryInfo({required this.label, required this.value});
@@ -69,6 +70,51 @@ class SearchSummaryCard extends StatelessWidget {
           ],
         ),
       ),
+    );
+  }
+}
+
+/// Convenience wrapper that combines the [SearchSummaryCard] with an action
+/// button to reopen the search form.
+class SearchSummarySection extends StatelessWidget {
+  const SearchSummarySection({
+    super.key,
+    required this.reLabel,
+    required this.reValue,
+    required this.items,
+    required this.onEdit,
+    this.itemWidth = 160,
+    this.editLabel = 'Alterar dados da busca',
+  });
+
+  final String reLabel;
+  final String reValue;
+  final List<SummaryInfo> items;
+  final VoidCallback onEdit;
+  final double itemWidth;
+  final String editLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        SearchSummaryCard(
+          reLabel: reLabel,
+          reValue: reValue,
+          items: items,
+          itemWidth: itemWidth,
+        ),
+        const SizedBox(height: 8),
+        Align(
+          alignment: Alignment.centerRight,
+          child: TextButton.icon(
+            onPressed: onEdit,
+            icon: const Icon(Icons.edit_outlined),
+            label: Text(editLabel),
+          ),
+        ),
+      ],
     );
   }
 }


### PR DESCRIPTION
## Summary
- introduce a `SearchSummarySection` helper that embeds the summary card with an edit action
- update the liberação, finalização and amostragem pages to use the helper so the search form can be reopened after loading results

## Testing
- flutter analyze

------
https://chatgpt.com/codex/tasks/task_e_68d2865d673483318daa84834d213bdf