### PR TITLE
Fix measurement chip selection highlighting

### DIFF
--- a/lib/features/operador/presentation/widgets/measurement_tile.dart
+++ b/lib/features/operador/presentation/widgets/measurement_tile.dart
@@ -663,7 +663,9 @@ class _MeasurementTileState extends State<MeasurementTile> {
                     bg: Colors.green.shade200,
                     border: Colors.green.shade600,
                     fg: Colors.green.shade900,
-                    selected: item.medicao == 'Aprovado',
+                    selected:
+                        item.medicao == 'Aprovado' &&
+                        item.status == StatusMedida.ok,
                     count: _countFor('Aprovado'),
                     onTap: () => widget.onSelect(StatusMedida.ok, 'Aprovado'),
                   ),
@@ -671,7 +673,9 @@ class _MeasurementTileState extends State<MeasurementTile> {
                     text: 'Reprovado',
                     bg: Colors.red.shade100,
                     border: Colors.red.shade400,
-                    selected: item.medicao == 'Reprovado',
+                    selected:
+                        item.medicao == 'Reprovado' &&
+                        item.status == StatusMedida.reprovadaAcima,
                     count: _countFor('Reprovado'),
                     onTap: () => widget.onSelect(
                       StatusMedida.reprovadaAcima,
@@ -786,7 +790,7 @@ class _MeasurementTileState extends State<MeasurementTile> {
                     final label = d != null
                         ? d.toStringAsFixed(2)
                         : raw.toString();
-                    final selected = item.medicao == label;
+                    final selected = item.medicao == label && item.status == st;
 
                     chips.add(
                       _pill(
@@ -807,7 +811,9 @@ class _MeasurementTileState extends State<MeasurementTile> {
                       bg: Colors.green.shade200,
                       border: Colors.green.shade600,
                       fg: Colors.green.shade900,
-                      selected: item.medicao == 'OK',
+                      selected:
+                          item.medicao == 'OK' &&
+                          item.status == StatusMedida.ok,
                       count: _countFor('OK'),
                       onTap: () => widget.onSelect(StatusMedida.ok, 'OK'),
                     ),


### PR DESCRIPTION
## Summary
- ensure automatic measurement chips compare both value and status when determining selection
- keep special option chips, including OK, tied to their corresponding status to avoid double highlighting

## Testing
- flutter test

------
https://chatgpt.com/codex/tasks/task_e_68d2a80d1f9c8331a25b6962dc88558d