### PR TITLE
Adjust chamfer validation and special OK measurement

### DIFF
--- a/lib/features/finalizar_os/presentation/finalizar_os_page.dart
+++ b/lib/features/finalizar_os/presentation/finalizar_os_page.dart
@@ -68,6 +68,8 @@ class MedidasFinalizadorController
               instrumento: m.instrumento,
               tolerancias: m.tolerancias,
               contagens: m.contagens,
+              anguloMinimo: m.anguloMinimo,
+              anguloMaximo: m.anguloMaximo,
             ),
           )
           .toList();
@@ -96,6 +98,8 @@ class MedidasFinalizadorController
       instrumento: old.instrumento,
       tolerancias: old.tolerancias,
       contagens: old.contagens,
+      anguloMinimo: old.anguloMinimo,
+      anguloMaximo: old.anguloMaximo,
     );
     state = AsyncValue.data(current);
   }
@@ -118,6 +122,8 @@ class MedidasFinalizadorController
         instrumento: old.instrumento,
         tolerancias: old.tolerancias,
         contagens: old.contagens,
+        anguloMinimo: old.anguloMinimo,
+        anguloMaximo: old.anguloMaximo,
       );
     }
     state = AsyncValue.data(current);

--- a/lib/features/operador/data/models.dart
+++ b/lib/features/operador/data/models.dart
@@ -89,6 +89,8 @@ class MedidaItem {
   /// Rótulos de tolerância (até 4) vindos do backend do Operador (AE/AF/AG/AH...).
   final List<String> tolerancias;
   final Map<String, int> contagens;
+  final double? anguloMinimo;
+  final double? anguloMaximo;
 
   MedidaItem({
     required this.titulo,
@@ -104,6 +106,8 @@ class MedidaItem {
     this.instrumento,
     this.tolerancias = const [],
     Map<String, int>? contagens,
+    this.anguloMinimo,
+    this.anguloMaximo,
   }) : contagens = Map.unmodifiable(contagens ?? const {});
 
   /// Avalia um valor numérico contra os limites.
@@ -117,6 +121,21 @@ class MedidaItem {
       return StatusMedida.reprovadaAbaixo;
     }
     if (maximo != null && valor > maximo!) {
+      return StatusMedida.reprovadaAcima;
+    }
+    return StatusMedida.ok;
+  }
+
+  StatusMedida avaliarAngulo(double? valor) {
+    final possuiFaixa = anguloMinimo != null || anguloMaximo != null;
+    if (!possuiFaixa) {
+      return valor == null ? StatusMedida.pendente : StatusMedida.ok;
+    }
+    if (valor == null) return StatusMedida.pendente;
+    if (anguloMinimo != null && valor < anguloMinimo!) {
+      return StatusMedida.reprovadaAbaixo;
+    }
+    if (anguloMaximo != null && valor > anguloMaximo!) {
       return StatusMedida.reprovadaAcima;
     }
     return StatusMedida.ok;
@@ -233,6 +252,106 @@ class MedidaItem {
     return '';
   }
 
+  static bool _isPlusMinusConnector(String raw, String compact) {
+    if (raw.contains('±') || compact.contains('±')) return true;
+    final lower = compact.toLowerCase();
+    if (lower.contains('+/-') ||
+        lower.contains('+/−') ||
+        lower.contains('-/+')) {
+      return true;
+    }
+    if (lower == '+-' || lower == '-+' || lower == '+−' || lower == '−+') {
+      return true;
+    }
+    return false;
+  }
+
+  static bool _isRangeConnector(String raw, String normalized, String compact) {
+    if (_isPlusMinusConnector(raw, compact)) return false;
+    if (raw.contains('-') ||
+        raw.contains('–') ||
+        raw.contains('—') ||
+        raw.contains('~')) {
+      return true;
+    }
+    switch (compact) {
+      case 'a':
+      case 'ate':
+      case 'to':
+        return true;
+    }
+    return false;
+  }
+
+  static double? _parseAngleToken(String raw) {
+    var s = raw.trim();
+    if (s.isEmpty) return null;
+    s = s.replaceAll(',', '.');
+    final matches = RegExp(r'-?\d+(?:\.\d+)?').allMatches(s).toList();
+    if (matches.isEmpty) return null;
+    final numbers = matches
+        .map((m) => double.tryParse(m.group(0)!))
+        .whereType<double>()
+        .toList();
+    if (numbers.isEmpty) return null;
+    double value = numbers[0];
+    if (numbers.length >= 2) {
+      value += numbers[1] / 60.0;
+    }
+    if (numbers.length >= 3) {
+      value += numbers[2] / 3600.0;
+    }
+    return value;
+  }
+
+  static ({double? min, double? max})? parseAngleRangeFromText(String texto) {
+    if (texto.trim().isEmpty) return null;
+    final normalized = texto.replaceAll(',', '.');
+    final pattern = RegExp(
+      "-?\\d+(?:[.,]\\d+)?\\s*[°º](?:\\s*\\d+[\\u2019\\u2032']?)?(?:\\s*\\d+(?:[\\u0022\\u2033\\u201d]))?",
+    );
+    final matches = pattern.allMatches(normalized).toList();
+    if (matches.length < 2) return null;
+
+    for (var i = 0; i < matches.length - 1; i++) {
+      final rawA = normalized.substring(matches[i].start, matches[i].end);
+      final rawB = normalized.substring(
+        matches[i + 1].start,
+        matches[i + 1].end,
+      );
+      final betweenRaw = normalized.substring(
+        matches[i].end,
+        matches[i + 1].start,
+      );
+      if (betweenRaw.trim().isEmpty) continue;
+
+      final connectorNormalized = _normalizeLower(betweenRaw);
+      final connectorCompact = connectorNormalized.replaceAll(
+        RegExp(r'\s+'),
+        '',
+      );
+      final valueA = _parseAngleToken(rawA);
+      final valueB = _parseAngleToken(rawB);
+      if (valueA == null || valueB == null) continue;
+
+      if (_isPlusMinusConnector(betweenRaw, connectorCompact)) {
+        final range = [valueA - valueB, valueA + valueB]..sort();
+        return (min: range.first, max: range.last);
+      }
+
+      if (_isRangeConnector(
+        betweenRaw,
+        connectorNormalized,
+        connectorCompact,
+      )) {
+        final range = [valueA, valueB]..sort();
+        return (min: range.first, max: range.last);
+      }
+    }
+
+    return null;
+  }
+
   factory MedidaItem.fromMap(Map<String, dynamic> map) {
     // Valores diretos do JSON
     String titulo = (map['titulo'] ?? '').toString();
@@ -290,6 +409,24 @@ class MedidaItem {
         ? (map['tolerancias'] as List).map((e) => e.toString()).toList()
         : const <String>[];
 
+    final rawObservacao = map['observacao'];
+    final rawPeriodicidade = map['periodicidade'];
+    final rawInstrumento = map['instrumento'];
+    final observacao = rawObservacao?.toString();
+    final periodicidade = rawPeriodicidade?.toString();
+    final instrumento = rawInstrumento?.toString();
+
+    ({double? min, double? max})? anguloRange;
+    for (final fonte in [faixa, titulo, observacao, instrumento]) {
+      final texto = (fonte ?? '').toString();
+      if (texto.trim().isEmpty) continue;
+      final parsed = parseAngleRangeFromText(texto);
+      if (parsed != null) {
+        anguloRange = parsed;
+        break;
+      }
+    }
+
     final rawCounts = map['contagens'];
     final counts = <String, int>{};
     if (rawCounts is Map) {
@@ -328,11 +465,13 @@ class MedidaItem {
       unidade: uni,
       status: statusFromString(map['status']?.toString()),
       medicao: map['medicao']?.toString(),
-      observacao: map['observacao']?.toString(),
-      periodicidade: map['periodicidade']?.toString(),
-      instrumento: map['instrumento']?.toString(),
+      observacao: observacao,
+      periodicidade: periodicidade,
+      instrumento: instrumento,
       tolerancias: tol,
       contagens: counts,
+      anguloMinimo: anguloRange?.min,
+      anguloMaximo: anguloRange?.max,
     );
   }
 

--- a/lib/features/operador/presentation/operador_page.dart
+++ b/lib/features/operador/presentation/operador_page.dart
@@ -72,6 +72,8 @@ class MedidasOperadorController
       instrumento: old.instrumento,
       tolerancias: old.tolerancias,
       contagens: old.contagens,
+      anguloMinimo: old.anguloMinimo,
+      anguloMaximo: old.anguloMaximo,
     );
     state = AsyncValue.data(current);
   }
@@ -95,6 +97,8 @@ class MedidasOperadorController
         instrumento: old.instrumento,
         tolerancias: old.tolerancias,
         contagens: old.contagens,
+        anguloMinimo: old.anguloMinimo,
+        anguloMaximo: old.anguloMaximo,
       );
     }
     state = AsyncValue.data(current);
@@ -139,6 +143,8 @@ class MedidasOperadorController
         instrumento: old.instrumento,
         tolerancias: old.tolerancias,
         contagens: counts,
+        anguloMinimo: old.anguloMinimo,
+        anguloMaximo: old.anguloMaximo,
       );
     }
     state = AsyncValue.data(current);

--- a/lib/features/operador/presentation/troca_ferramenta_page.dart
+++ b/lib/features/operador/presentation/troca_ferramenta_page.dart
@@ -141,6 +141,8 @@ class _TrocaFerramentaPageState extends State<TrocaFerramentaPage> {
         instrumento: item.instrumento,
         tolerancias: item.tolerancias,
         contagens: item.contagens,
+        anguloMinimo: item.anguloMinimo,
+        anguloMaximo: item.anguloMaximo,
       );
     }).toList();
 
@@ -168,6 +170,8 @@ class _TrocaFerramentaPageState extends State<TrocaFerramentaPage> {
       instrumento: antigo.instrumento,
       tolerancias: antigo.tolerancias,
       contagens: antigo.contagens,
+      anguloMinimo: antigo.anguloMinimo,
+      anguloMaximo: antigo.anguloMaximo,
     );
     setState(() {
       _medidasSelecionadas = itens;

--- a/lib/features/operador/presentation/widgets/measurement_tile.dart
+++ b/lib/features/operador/presentation/widgets/measurement_tile.dart
@@ -221,6 +221,13 @@ class _MeasurementTileState extends State<MeasurementTile> {
         _containsAny(obs, ['chanfro']);
   }
 
+  bool _isRepetirTresPontos(MedidaItem item) {
+    final t = _norm(item.titulo);
+    final faixa = _norm(item.faixaTexto);
+    return _containsAny(t, ['repetir 3 pontos de medicao']) ||
+        _containsAny(faixa, ['repetir 3 pontos de medicao']);
+  }
+
   Set<String> _partsFromMedicao(String? medicao) => (medicao ?? '')
       .split('|')
       .map((s) => s.trim())
@@ -349,6 +356,12 @@ class _MeasurementTileState extends State<MeasurementTile> {
     return double.tryParse(normalized);
   }
 
+  double? _parseAngleInput(String txt) {
+    final sanitized = txt.replaceAll(RegExp("[°º'’′\"″”]"), '').trim();
+    if (sanitized.isEmpty) return null;
+    return _parseManualValue(sanitized);
+  }
+
   Color _statusColor(StatusMedida st) {
     switch (st) {
       case StatusMedida.ok:
@@ -395,17 +408,56 @@ class _MeasurementTileState extends State<MeasurementTile> {
     }
   }
 
+  String _repetirHelper(StatusMedida st) {
+    switch (st) {
+      case StatusMedida.ok:
+        return 'Resultado confirmado';
+      case StatusMedida.reprovadaAbaixo:
+      case StatusMedida.reprovadaAcima:
+      case StatusMedida.alertaAbaixo:
+      case StatusMedida.alertaAcima:
+        return 'Resultado fora da tolerância';
+      case StatusMedida.pendente:
+        return 'Selecione OK para confirmar';
+    }
+  }
+
   String _chanfroHelper({
     required StatusMedida status,
     required bool hasAngle,
     required bool hasMedida,
     required bool medidaValida,
+    required bool anguloValido,
+    required StatusMedida medidaStatus,
+    required StatusMedida anguloStatus,
   }) {
     if (!hasAngle || !hasMedida) {
       return 'Informe ângulo e medida para classificar';
     }
+    if (!anguloValido) {
+      return 'Ângulo inválido';
+    }
     if (!medidaValida) {
       return 'Medida inválida';
+    }
+    if (anguloStatus != StatusMedida.ok &&
+        anguloStatus != StatusMedida.pendente) {
+      switch (anguloStatus) {
+        case StatusMedida.reprovadaAbaixo:
+          return 'Ângulo abaixo do mínimo';
+        case StatusMedida.reprovadaAcima:
+          return 'Ângulo acima do máximo';
+        case StatusMedida.alertaAbaixo:
+        case StatusMedida.alertaAcima:
+          return 'Ângulo fora da tolerância';
+        case StatusMedida.ok:
+        case StatusMedida.pendente:
+          break;
+      }
+    }
+    if (medidaStatus != StatusMedida.ok &&
+        medidaStatus != StatusMedida.pendente) {
+      return _statusHelper(medidaStatus);
     }
     return _statusHelper(status);
   }
@@ -425,12 +477,27 @@ class _MeasurementTileState extends State<MeasurementTile> {
         .trim()
         .toLowerCase();
     final angleText = isChanfro ? _chanfroAngCtrl!.text.trim() : '';
-    final medidaText = isChanfro ? _chanfroMedCtrl!.text.trim() : ctrl!.text;
-    final valor = isRosca
-        ? null
-        : isChanfro
-        ? _parseManualValue(medidaText)
-        : _parseManualValue(ctrl!.text);
+    final medidaText = isChanfro
+        ? _chanfroMedCtrl!.text.trim()
+        : (ctrl != null ? ctrl.text : '');
+    final isRepetir3 = !isChanfro && !isRosca && _isRepetirTresPontos(item);
+
+    double? valor;
+    if (isRosca || isRepetir3) {
+      valor = null;
+    } else if (isChanfro) {
+      valor = _parseManualValue(medidaText);
+    } else {
+      valor = _parseManualValue(ctrl!.text);
+    }
+
+    double? angleValue;
+    bool hasAngle = false;
+    bool hasMedida = false;
+    bool medidaValida = false;
+    bool anguloValido = false;
+    StatusMedida medidaStatus = StatusMedida.pendente;
+    StatusMedida anguloStatus = StatusMedida.pendente;
 
     StatusMedida status;
     if (isRosca) {
@@ -440,14 +507,35 @@ class _MeasurementTileState extends State<MeasurementTile> {
           ? StatusMedida.reprovadaAcima
           : StatusMedida.pendente;
     } else if (isChanfro) {
-      final hasAngle = angleText.isNotEmpty;
-      final hasMedida = medidaText.trim().isNotEmpty;
-      final medidaValida = valor != null;
-      status = (!hasAngle || !hasMedida || !medidaValida)
-          ? StatusMedida.pendente
-          : item.avaliarStatus(valor);
+      hasAngle = angleText.isNotEmpty;
+      hasMedida = medidaText.trim().isNotEmpty;
+      angleValue = _parseAngleInput(angleText);
+      anguloValido = angleValue != null;
+      medidaValida = valor != null;
+      if (medidaValida) {
+        medidaStatus = item.avaliarStatus(valor);
+      }
+      if (anguloValido) {
+        anguloStatus = item.avaliarAngulo(angleValue);
+      }
+      if (!hasAngle || !hasMedida || !medidaValida || !anguloValido) {
+        status = StatusMedida.pendente;
+      } else if (medidaStatus != StatusMedida.ok) {
+        status = medidaStatus;
+      } else if (anguloStatus != StatusMedida.ok) {
+        status = anguloStatus;
+      } else {
+        status = StatusMedida.ok;
+      }
+    } else if (isRepetir3) {
+      status = item.status;
     } else {
-      status = item.avaliarStatus(valor);
+      hasMedida = ctrl!.text.trim().isNotEmpty;
+      medidaValida = valor != null;
+      if (medidaValida) {
+        medidaStatus = item.avaliarStatus(valor);
+      }
+      status = medidaValida ? medidaStatus : StatusMedida.pendente;
     }
 
     final theme = Theme.of(context);
@@ -460,10 +548,15 @@ class _MeasurementTileState extends State<MeasurementTile> {
         : isChanfro
         ? _chanfroHelper(
             status: status,
-            hasAngle: angleText.isNotEmpty,
-            hasMedida: medidaText.trim().isNotEmpty,
-            medidaValida: valor != null,
+            hasAngle: hasAngle,
+            hasMedida: hasMedida,
+            medidaValida: medidaValida,
+            anguloValido: anguloValido,
+            medidaStatus: medidaStatus,
+            anguloStatus: anguloStatus,
           )
+        : isRepetir3
+        ? _repetirHelper(status)
         : _statusHelper(status);
     final helperColor = _statusColor(status);
 
@@ -575,6 +668,36 @@ class _MeasurementTileState extends State<MeasurementTile> {
                 ),
                 onChanged: (_) => _handleChanfroChanged(),
               ),
+            ] else if (isRepetir3) ...[
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: [
+                  _pill(
+                    text: 'OK',
+                    bg: Colors.green.shade200,
+                    border: Colors.green.shade600,
+                    fg: Colors.green.shade900,
+                    selected:
+                        item.status == StatusMedida.ok &&
+                        (item.medicao ?? '').trim().toLowerCase() == 'ok',
+                    count: _countFor('OK'),
+                    onTap: () {
+                      FocusScope.of(context).unfocus();
+                      final alreadyOk =
+                          item.status == StatusMedida.ok &&
+                          (item.medicao ?? '').trim().toLowerCase() == 'ok';
+                      widget.onSelect(
+                        alreadyOk ? StatusMedida.pendente : StatusMedida.ok,
+                        alreadyOk ? null : 'OK',
+                      );
+                      setState(() {});
+                    },
+                  ),
+                ],
+              ),
+              const SizedBox(height: 6),
+              Text(helper, style: TextStyle(color: helperColor)),
             ] else ...[
               TextField(
                 controller: ctrl,
@@ -608,12 +731,25 @@ class _MeasurementTileState extends State<MeasurementTile> {
     final angleNormalized = angle.trim();
     final medidaNormalized = medida.trim();
     final valor = _parseManualValue(medidaNormalized);
+    final angleValue = _parseAngleInput(angleNormalized);
     final hasAngle = angleNormalized.isNotEmpty;
     final hasMedida = medidaNormalized.isNotEmpty;
     final medidaValida = valor != null;
-    final novoStatus = (!hasAngle || !hasMedida || !medidaValida)
-        ? StatusMedida.pendente
-        : widget.item.avaliarStatus(valor);
+    final anguloValido = angleValue != null;
+    StatusMedida novoStatus;
+    if (!hasAngle || !hasMedida || !medidaValida || !anguloValido) {
+      novoStatus = StatusMedida.pendente;
+    } else {
+      final medidaStatus = widget.item.avaliarStatus(valor);
+      if (medidaStatus != StatusMedida.ok) {
+        novoStatus = medidaStatus;
+      } else {
+        final anguloStatus = widget.item.avaliarAngulo(angleValue);
+        novoStatus = anguloStatus != StatusMedida.ok
+            ? anguloStatus
+            : StatusMedida.ok;
+      }
+    }
     final combined = (hasAngle || hasMedida)
         ? '${angleNormalized} | ${medidaNormalized}'
         : '';

--- a/lib/features/preparacao/data/local_excel_repository.dart
+++ b/lib/features/preparacao/data/local_excel_repository.dart
@@ -25,12 +25,11 @@ class LocalExcelRepository implements MedidasRepository {
   /// Você pode instanciar de duas formas:
   /// - LocalExcelRepository(assetPath: 'assets/medidas.json')
   /// - LocalExcelRepository(planilhaPath: '/caminho/arquivo.xlsx', aba: 'CADASTRO')
-  LocalExcelRepository({
-    this.assetPath,
-    this.planilhaPath,
-    this.aba,
-  }) : assert(assetPath != null || planilhaPath != null,
-  'Informe assetPath OU planilhaPath');
+  LocalExcelRepository({this.assetPath, this.planilhaPath, this.aba})
+    : assert(
+        assetPath != null || planilhaPath != null,
+        'Informe assetPath OU planilhaPath',
+      );
 
   @override
   Future<List<MedidaItem>> getMedidas({
@@ -48,6 +47,7 @@ class LocalExcelRepository implements MedidasRepository {
       return data.map<MedidaItem>((e) {
         final map = (e as Map).cast<String, dynamic>();
 
+        final titulo = (map['titulo'] ?? '').toString();
         String faixaTexto = (map['faixaTexto'] ?? '').toString();
         double? min = _toDouble(map['minimo'] ?? map['min']);
         double? max = _toDouble(map['maximo'] ?? map['max']);
@@ -74,8 +74,19 @@ class LocalExcelRepository implements MedidasRepository {
           }
         }
 
+        ({double? min, double? max})? anguloRange;
+        for (final fonte in [faixaTexto, titulo]) {
+          final texto = (fonte).toString();
+          if (texto.trim().isEmpty) continue;
+          final parsed = MedidaItem.parseAngleRangeFromText(texto);
+          if (parsed != null) {
+            anguloRange = parsed;
+            break;
+          }
+        }
+
         return MedidaItem(
-          titulo: (map['titulo'] ?? '').toString(),
+          titulo: titulo,
           indice: indice,
           faixaTexto: faixaTexto,
           minimo: min,
@@ -86,6 +97,8 @@ class LocalExcelRepository implements MedidasRepository {
           observacao: map['observacao']?.toString(),
           periodicidade: map['periodicidade']?.toString(),
           instrumento: map['instrumento']?.toString(),
+          anguloMinimo: anguloRange?.min,
+          anguloMaximo: anguloRange?.max,
         );
       }).toList();
     }
@@ -95,7 +108,8 @@ class LocalExcelRepository implements MedidasRepository {
     if (kDebugMode) {
       // Só pra dar um toque no console durante dev.
       print(
-          'LocalExcelRepository: leitura de planilha não implementada ainda. caminho=$planilhaPath aba=$aba');
+        'LocalExcelRepository: leitura de planilha não implementada ainda. caminho=$planilhaPath aba=$aba',
+      );
     }
     return <MedidaItem>[];
   }

--- a/lib/features/preparacao/data/models.dart
+++ b/lib/features/preparacao/data/models.dart
@@ -87,6 +87,8 @@ class MedidaItem {
   /// Rótulos de tolerância (até 4) vindos do backend do Operador (AE/AF/AG/AH...).
   final List<String> tolerancias;
   final Map<String, int> contagens;
+  final double? anguloMinimo;
+  final double? anguloMaximo;
 
   MedidaItem({
     required this.titulo,
@@ -102,6 +104,8 @@ class MedidaItem {
     this.instrumento,
     this.tolerancias = const [],
     Map<String, int>? contagens,
+    this.anguloMinimo,
+    this.anguloMaximo,
   }) : contagens = Map.unmodifiable(contagens ?? const {});
 
   /// Avalia um valor numérico contra os limites.
@@ -115,6 +119,21 @@ class MedidaItem {
       return StatusMedida.reprovadaAbaixo;
     }
     if (maximo != null && valor > maximo!) {
+      return StatusMedida.reprovadaAcima;
+    }
+    return StatusMedida.ok;
+  }
+
+  StatusMedida avaliarAngulo(double? valor) {
+    final possuiFaixa = anguloMinimo != null || anguloMaximo != null;
+    if (!possuiFaixa) {
+      return valor == null ? StatusMedida.pendente : StatusMedida.ok;
+    }
+    if (valor == null) return StatusMedida.pendente;
+    if (anguloMinimo != null && valor < anguloMinimo!) {
+      return StatusMedida.reprovadaAbaixo;
+    }
+    if (anguloMaximo != null && valor > anguloMaximo!) {
       return StatusMedida.reprovadaAcima;
     }
     return StatusMedida.ok;
@@ -231,6 +250,106 @@ class MedidaItem {
     return '';
   }
 
+  static bool _isPlusMinusConnector(String raw, String compact) {
+    if (raw.contains('±') || compact.contains('±')) return true;
+    final lower = compact.toLowerCase();
+    if (lower.contains('+/-') ||
+        lower.contains('+/−') ||
+        lower.contains('-/+')) {
+      return true;
+    }
+    if (lower == '+-' || lower == '-+' || lower == '+−' || lower == '−+') {
+      return true;
+    }
+    return false;
+  }
+
+  static bool _isRangeConnector(String raw, String normalized, String compact) {
+    if (_isPlusMinusConnector(raw, compact)) return false;
+    if (raw.contains('-') ||
+        raw.contains('–') ||
+        raw.contains('—') ||
+        raw.contains('~')) {
+      return true;
+    }
+    switch (compact) {
+      case 'a':
+      case 'ate':
+      case 'to':
+        return true;
+    }
+    return false;
+  }
+
+  static double? _parseAngleToken(String raw) {
+    var s = raw.trim();
+    if (s.isEmpty) return null;
+    s = s.replaceAll(',', '.');
+    final matches = RegExp(r'-?\d+(?:\.\d+)?').allMatches(s).toList();
+    if (matches.isEmpty) return null;
+    final numbers = matches
+        .map((m) => double.tryParse(m.group(0)!))
+        .whereType<double>()
+        .toList();
+    if (numbers.isEmpty) return null;
+    double value = numbers[0];
+    if (numbers.length >= 2) {
+      value += numbers[1] / 60.0;
+    }
+    if (numbers.length >= 3) {
+      value += numbers[2] / 3600.0;
+    }
+    return value;
+  }
+
+  static ({double? min, double? max})? parseAngleRangeFromText(String texto) {
+    if (texto.trim().isEmpty) return null;
+    final normalized = texto.replaceAll(',', '.');
+    final pattern = RegExp(
+      "-?\\d+(?:[.,]\\d+)?\\s*[°º](?:\\s*\\d+[\\u2019\\u2032']?)?(?:\\s*\\d+(?:[\\u0022\\u2033\\u201d]))?",
+    );
+    final matches = pattern.allMatches(normalized).toList();
+    if (matches.length < 2) return null;
+
+    for (var i = 0; i < matches.length - 1; i++) {
+      final rawA = normalized.substring(matches[i].start, matches[i].end);
+      final rawB = normalized.substring(
+        matches[i + 1].start,
+        matches[i + 1].end,
+      );
+      final betweenRaw = normalized.substring(
+        matches[i].end,
+        matches[i + 1].start,
+      );
+      if (betweenRaw.trim().isEmpty) continue;
+
+      final connectorNormalized = _normalizeLower(betweenRaw);
+      final connectorCompact = connectorNormalized.replaceAll(
+        RegExp(r'\s+'),
+        '',
+      );
+      final valueA = _parseAngleToken(rawA);
+      final valueB = _parseAngleToken(rawB);
+      if (valueA == null || valueB == null) continue;
+
+      if (_isPlusMinusConnector(betweenRaw, connectorCompact)) {
+        final range = [valueA - valueB, valueA + valueB]..sort();
+        return (min: range.first, max: range.last);
+      }
+
+      if (_isRangeConnector(
+        betweenRaw,
+        connectorNormalized,
+        connectorCompact,
+      )) {
+        final range = [valueA, valueB]..sort();
+        return (min: range.first, max: range.last);
+      }
+    }
+
+    return null;
+  }
+
   factory MedidaItem.fromMap(Map<String, dynamic> map) {
     // Valores diretos do JSON
     String titulo = (map['titulo'] ?? '').toString();
@@ -288,6 +407,24 @@ class MedidaItem {
         ? (map['tolerancias'] as List).map((e) => e.toString()).toList()
         : const <String>[];
 
+    final rawObservacao = map['observacao'];
+    final rawPeriodicidade = map['periodicidade'];
+    final rawInstrumento = map['instrumento'];
+    final observacao = rawObservacao?.toString();
+    final periodicidade = rawPeriodicidade?.toString();
+    final instrumento = rawInstrumento?.toString();
+
+    ({double? min, double? max})? anguloRange;
+    for (final fonte in [faixa, titulo, observacao, instrumento]) {
+      final texto = (fonte ?? '').toString();
+      if (texto.trim().isEmpty) continue;
+      final parsed = parseAngleRangeFromText(texto);
+      if (parsed != null) {
+        anguloRange = parsed;
+        break;
+      }
+    }
+
     final rawCounts = map['contagens'];
     final counts = <String, int>{};
     if (rawCounts is Map) {
@@ -326,11 +463,13 @@ class MedidaItem {
       unidade: uni,
       status: statusFromString(map['status']?.toString()),
       medicao: map['medicao']?.toString(),
-      observacao: map['observacao']?.toString(),
-      periodicidade: map['periodicidade']?.toString(),
-      instrumento: map['instrumento']?.toString(),
+      observacao: observacao,
+      periodicidade: periodicidade,
+      instrumento: instrumento,
       tolerancias: tol,
       contagens: counts,
+      anguloMinimo: anguloRange?.min,
+      anguloMaximo: anguloRange?.max,
     );
   }
 

--- a/lib/features/preparacao/presentation/preparacao_page.dart
+++ b/lib/features/preparacao/presentation/preparacao_page.dart
@@ -69,6 +69,8 @@ class MedidasPreparadorController
               instrumento: m.instrumento,
               tolerancias: m.tolerancias,
               contagens: m.contagens,
+              anguloMinimo: m.anguloMinimo,
+              anguloMaximo: m.anguloMaximo,
             ),
           )
           .toList();
@@ -97,6 +99,8 @@ class MedidasPreparadorController
       instrumento: old.instrumento,
       tolerancias: old.tolerancias,
       contagens: old.contagens,
+      anguloMinimo: old.anguloMinimo,
+      anguloMaximo: old.anguloMaximo,
     );
     state = AsyncValue.data(current);
   }
@@ -119,6 +123,8 @@ class MedidasPreparadorController
         instrumento: old.instrumento,
         tolerancias: old.tolerancias,
         contagens: old.contagens,
+        anguloMinimo: old.anguloMinimo,
+        anguloMaximo: old.anguloMaximo,
       );
     }
     state = AsyncValue.data(current);


### PR DESCRIPTION
## Summary
- extend MedidaItem models and related controllers to parse chamfer angle ranges and carry them through preparation/finalization flows
- tighten manual entry logic so chamfers require valid angle plus dimension and allow "Repetir 3 pontos de medição" to be marked only as OK

## Testing
- flutter analyze *(shows existing deprecation warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68d2b8a93d308331b8e69037b9e2f688