### PR TITLE
Prioritize pause events in history report groupings

### DIFF
--- a/lib/screens/dashboard/components/personnel_report_chart.dart
+++ b/lib/screens/dashboard/components/personnel_report_chart.dart
@@ -73,31 +73,62 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
     List<Map<String, dynamic>> rows,
   ) {
     final result = <Map<String, dynamic>>[];
-    DateTime? lastGroup;
-    for (final row in rows) {
+    var index = 0;
+    while (index < rows.length) {
+      final row = rows[index];
       final dt = row['__dt'] as DateTime?;
-      if (dt != null) {
-        final normalized = DateTime(
-          dt.year,
-          dt.month,
-          dt.day,
-          dt.hour,
-          dt.minute,
-          dt.second,
-        );
-        if (lastGroup == null || normalized != lastGroup) {
-          final label = DateFormat('dd/MM/yyyy HH:mm:ss').format(dt);
-          result.add({
-            '__isGroup': true,
-            '__dt': normalized,
-            'created_at': label,
-          });
-          lastGroup = normalized;
-        }
-      } else {
-        lastGroup = null;
+      if (dt == null) {
+        result.add(row);
+        index++;
+        continue;
       }
-      result.add(row);
+
+      DateTime normalize(DateTime value) => DateTime(
+        value.year,
+        value.month,
+        value.day,
+        value.hour,
+        value.minute,
+        value.second,
+      );
+
+      final normalized = normalize(dt);
+      final groupRows = <Map<String, dynamic>>[];
+      while (index < rows.length) {
+        final current = rows[index];
+        final currentDt = current['__dt'] as DateTime?;
+        if (currentDt == null) {
+          break;
+        }
+        if (normalize(currentDt) != normalized) {
+          break;
+        }
+        groupRows.add(current);
+        index++;
+      }
+
+      result.add({
+        '__isGroup': true,
+        '__dt': normalized,
+        'created_at': DateFormat(
+          'dd/MM/yyyy HH:mm:ss',
+        ).format(groupRows.first['__dt'] as DateTime),
+      });
+
+      final pauseRows = <Map<String, dynamic>>[];
+      final otherRows = <Map<String, dynamic>>[];
+      for (final item in groupRows) {
+        final event = item['evento']?.toString();
+        if (event == 'pausa_jornada') {
+          pauseRows.add(item);
+        } else {
+          otherRows.add(item);
+        }
+      }
+
+      result
+        ..addAll(pauseRows)
+        ..addAll(otherRows);
     }
     return result;
   }


### PR DESCRIPTION
## Summary
- reorder grouped history rows so pausa de jornada events are inserted immediately after the group header
- keep non-pause events in their original chronological order within each group

## Testing
- flutter analyze

------
https://chatgpt.com/codex/tasks/task_e_68d2c3a859f08331ada619f5e037149c