### PR TITLE
Rework personnel report column visibility controls

### DIFF
--- a/lib/screens/dashboard/components/personnel_report_chart.dart
+++ b/lib/screens/dashboard/components/personnel_report_chart.dart
@@ -219,10 +219,13 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
     });
   }
 
-  void _reorderColumns(int oldIndex, int newIndex) {
+  void _reorderVisibleColumn(String columnKey, int targetIndex) {
     final headerMap = _headerConfigs[_tipo] ?? const {};
     _ensureColumnState(headerMap);
     final hidden = _hiddenColumns[_tipo]!;
+    if (hidden.contains(columnKey)) {
+      return;
+    }
     final order = _columnOrders[_tipo]!;
     final visible = [
       for (final key in order)
@@ -231,28 +234,127 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
     if (visible.length < 2) {
       return;
     }
-    if (newIndex > visible.length) {
-      newIndex = visible.length;
+    final oldIndex = visible.indexOf(columnKey);
+    if (oldIndex == -1) {
+      return;
     }
-    if (newIndex > oldIndex) {
-      newIndex -= 1;
+    if (targetIndex < 0 || targetIndex > visible.length) {
+      return;
+    }
+    var adjustedIndex = targetIndex;
+    if (adjustedIndex > oldIndex) {
+      adjustedIndex -= 1;
+    }
+    if (adjustedIndex == oldIndex) {
+      return;
     }
     final moved = visible.removeAt(oldIndex);
-    visible.insert(newIndex, moved);
-    final newOrder = <String>[];
-    var visibleIndex = 0;
-    for (final key in order) {
-      if (hidden.contains(key)) {
-        newOrder.add(key);
-      } else {
-        newOrder.add(visible[visibleIndex++]);
-      }
-    }
+    visible.insert(adjustedIndex, moved);
+    final hiddenOrder = [
+      for (final key in order)
+        if (hidden.contains(key)) key,
+    ];
     setState(() {
       order
         ..clear()
-        ..addAll(newOrder);
+        ..addAll(visible)
+        ..addAll(hiddenOrder);
     });
+  }
+
+  Widget _buildColumnChip(
+    BuildContext context,
+    String columnKey,
+    String label, {
+    bool enableTooltip = true,
+    bool enableDelete = true,
+  }) {
+    final chip = Chip(
+      avatar: const Icon(Icons.drag_indicator, size: 18),
+      label: Text(label, overflow: TextOverflow.ellipsis),
+      deleteIcon: enableDelete
+          ? const Icon(Icons.visibility_off_outlined, size: 18)
+          : null,
+      onDeleted: enableDelete ? () => _hideColumn(columnKey) : null,
+      deleteButtonTooltipMessage: enableDelete ? 'Ocultar coluna' : null,
+      visualDensity: VisualDensity.compact,
+      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+    );
+    if (!enableTooltip) {
+      return chip;
+    }
+    return Tooltip(message: 'Arraste para reordenar', child: chip);
+  }
+
+  Widget _buildReorderableChip(
+    BuildContext context,
+    Map<String, String> headerMap,
+    String columnKey,
+  ) {
+    final label = headerMap[columnKey] ?? columnKey;
+    return LongPressDraggable<String>(
+      data: columnKey,
+      dragAnchorStrategy: pointerDragAnchorStrategy,
+      feedback: Material(
+        elevation: 6,
+        color: Colors.transparent,
+        child: _buildColumnChip(
+          context,
+          columnKey,
+          label,
+          enableTooltip: false,
+          enableDelete: false,
+        ),
+      ),
+      childWhenDragging: Opacity(
+        opacity: 0.5,
+        child: IgnorePointer(
+          child: _buildColumnChip(
+            context,
+            columnKey,
+            label,
+            enableTooltip: false,
+          ),
+        ),
+      ),
+      child: _buildColumnChip(context, columnKey, label),
+    );
+  }
+
+  Widget _buildDropTarget(
+    BuildContext context,
+    int targetIndex,
+    int totalVisible,
+  ) {
+    final theme = Theme.of(context);
+    return DragTarget<String>(
+      onWillAcceptWithDetails: (details) => true,
+      onAcceptWithDetails: (details) {
+        _reorderVisibleColumn(details.data, targetIndex);
+      },
+      builder: (context, candidate, rejected) {
+        final isActive = candidate.isNotEmpty;
+        final leftMargin = targetIndex == 0 ? 0.0 : 4.0;
+        final rightMargin = targetIndex == totalVisible ? 0.0 : 4.0;
+        return AnimatedContainer(
+          duration: const Duration(milliseconds: 150),
+          width: 12,
+          height: 40,
+          margin: EdgeInsets.only(
+            left: leftMargin,
+            right: rightMargin,
+            top: 4,
+            bottom: 4,
+          ),
+          decoration: BoxDecoration(
+            color: isActive
+                ? theme.colorScheme.primary.withValues(alpha: 0.35)
+                : Colors.transparent,
+            borderRadius: BorderRadius.circular(4),
+          ),
+        );
+      },
+    );
   }
 
   Widget _buildHeaderLabel(
@@ -320,41 +422,35 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
         ],
         Text('Colunas visíveis', style: theme.textTheme.labelMedium),
         const SizedBox(height: 8),
-        SizedBox(
-          height: 56,
-          child: ReorderableListView.builder(
-            scrollDirection: Axis.horizontal,
-            padding: const EdgeInsets.symmetric(horizontal: 4),
-            itemCount: visibleColumns.length,
-            onReorder: _reorderColumns,
-            buildDefaultDragHandles: false,
-            itemBuilder: (context, index) {
-              final key = visibleColumns[index];
-              final label = headerMap[key] ?? key;
-              return ReorderableDragStartListener(
-                key: ValueKey('visible_$key'),
-                index: index,
-                child: Padding(
+        Builder(
+          builder: (context) {
+            final totalVisible = visibleColumns.length;
+            final reorderChildren = <Widget>[];
+            for (var index = 0; index < totalVisible; index++) {
+              reorderChildren.add(
+                _buildDropTarget(context, index, totalVisible),
+              );
+              final columnKey = visibleColumns[index];
+              reorderChildren.add(
+                Padding(
                   padding: const EdgeInsets.symmetric(horizontal: 4),
-                  child: Tooltip(
-                    message: 'Arraste para reordenar',
-                    child: Chip(
-                      avatar: const Icon(Icons.drag_indicator, size: 18),
-                      label: Text(label, overflow: TextOverflow.ellipsis),
-                      deleteIcon: const Icon(
-                        Icons.visibility_off_outlined,
-                        size: 18,
-                      ),
-                      onDeleted: () => _hideColumn(key),
-                      deleteButtonTooltipMessage: 'Ocultar coluna',
-                      visualDensity: VisualDensity.compact,
-                      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                    ),
+                  child: KeyedSubtree(
+                    key: ValueKey('visible_$columnKey'),
+                    child: _buildReorderableChip(context, headerMap, columnKey),
                   ),
                 ),
               );
-            },
-          ),
+            }
+            reorderChildren.add(
+              _buildDropTarget(context, totalVisible, totalVisible),
+            );
+            return Wrap(
+              spacing: 0,
+              runSpacing: 8,
+              crossAxisAlignment: WrapCrossAlignment.center,
+              children: reorderChildren,
+            );
+          },
         ),
         const SizedBox(height: 4),
         Text(

--- a/lib/screens/dashboard/components/personnel_report_chart.dart
+++ b/lib/screens/dashboard/components/personnel_report_chart.dart
@@ -21,6 +21,42 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
   String _tipo = 'operador';
   String _modo = 'os';
   Future<List<Map<String, dynamic>>>? _future;
+  final Map<String, Set<String>> _hiddenColumns = {
+    'operador': <String>{},
+    'preparador': <String>{},
+  };
+  final Map<String, List<String>> _columnOrders = {
+    'operador': <String>[],
+    'preparador': <String>[],
+  };
+
+  static const Map<String, Map<String, String>> _headerConfigs = {
+    'preparador': {
+      'os': 'OS',
+      're_liberacao': 'RE Liberação',
+      're_finalizacao': 'RE Finalização',
+      'partnumber': 'Partnumber',
+      'maquina': 'Máquina',
+      'faixa_texto': 'Faixa',
+      'created_at': 'Horário Inicial',
+      'medicao': 'Medição Inicial',
+      'medicao_final': 'Medição Final',
+      'created_at_final': 'Horário Final',
+    },
+    'operador': {
+      'os': 'OS',
+      're_operador': 'RE',
+      'created_at': 'Início',
+      'retorno_at': 'Retorno',
+      'partnumber': 'Partnumber',
+      'maquina': 'Máquina',
+      'titulo': 'Título',
+      'instrumento': 'Instrumento',
+      'faixa_texto': 'Faixa',
+      'status': 'Status',
+      'motivo': 'Motivo',
+    },
+  };
 
   DateTime? _parseDateTime(dynamic value) {
     final raw = value?.toString().trim();
@@ -73,31 +109,62 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
     List<Map<String, dynamic>> rows,
   ) {
     final result = <Map<String, dynamic>>[];
-    DateTime? lastGroup;
-    for (final row in rows) {
+    var index = 0;
+    while (index < rows.length) {
+      final row = rows[index];
       final dt = row['__dt'] as DateTime?;
-      if (dt != null) {
-        final normalized = DateTime(
-          dt.year,
-          dt.month,
-          dt.day,
-          dt.hour,
-          dt.minute,
-          dt.second,
-        );
-        if (lastGroup == null || normalized != lastGroup) {
-          final label = DateFormat('dd/MM/yyyy HH:mm:ss').format(dt);
-          result.add({
-            '__isGroup': true,
-            '__dt': normalized,
-            'created_at': label,
-          });
-          lastGroup = normalized;
-        }
-      } else {
-        lastGroup = null;
+      if (dt == null) {
+        result.add(row);
+        index++;
+        continue;
       }
-      result.add(row);
+
+      DateTime normalize(DateTime value) => DateTime(
+        value.year,
+        value.month,
+        value.day,
+        value.hour,
+        value.minute,
+        value.second,
+      );
+
+      final normalized = normalize(dt);
+      final groupRows = <Map<String, dynamic>>[];
+      while (index < rows.length) {
+        final current = rows[index];
+        final currentDt = current['__dt'] as DateTime?;
+        if (currentDt == null) {
+          break;
+        }
+        if (normalize(currentDt) != normalized) {
+          break;
+        }
+        groupRows.add(current);
+        index++;
+      }
+
+      result.add({
+        '__isGroup': true,
+        '__dt': normalized,
+        'created_at': DateFormat(
+          'dd/MM/yyyy HH:mm:ss',
+        ).format(groupRows.first['__dt'] as DateTime),
+      });
+
+      final pauseRows = <Map<String, dynamic>>[];
+      final otherRows = <Map<String, dynamic>>[];
+      for (final item in groupRows) {
+        final event = item['evento']?.toString();
+        if (event == 'pausa_jornada') {
+          pauseRows.add(item);
+        } else {
+          otherRows.add(item);
+        }
+      }
+
+      result
+        ..addAll(pauseRows)
+        ..addAll(otherRows);
     }
     return result;
   }
@@ -108,6 +175,194 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
     _partCtrl.dispose();
     _opCtrl.dispose();
     super.dispose();
+  }
+
+  void _ensureColumnState(Map<String, String> headerMap) {
+    final allowedKeys = headerMap.keys.toList(growable: false);
+    final allowedSet = allowedKeys.toSet();
+    final order = _columnOrders.putIfAbsent(_tipo, () => <String>[]);
+    final hidden = _hiddenColumns.putIfAbsent(_tipo, () => <String>{});
+    order.removeWhere((key) => !allowedSet.contains(key));
+    hidden.removeWhere((key) => !allowedSet.contains(key));
+    for (final key in allowedKeys) {
+      if (!order.contains(key)) {
+        order.add(key);
+      }
+    }
+  }
+
+  void _hideColumn(String columnKey) {
+    final headerMap = _headerConfigs[_tipo] ?? const {};
+    _ensureColumnState(headerMap);
+    final hidden = _hiddenColumns[_tipo]!;
+    final order = _columnOrders[_tipo]!;
+    final visibleCount = order.where((key) => !hidden.contains(key)).length;
+    if (visibleCount <= 1) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Mantenha ao menos uma coluna visível.'),
+          duration: Duration(seconds: 2),
+        ),
+      );
+      return;
+    }
+    setState(() {
+      hidden.add(columnKey);
+    });
+  }
+
+  void _showColumn(String columnKey) {
+    final headerMap = _headerConfigs[_tipo] ?? const {};
+    _ensureColumnState(headerMap);
+    setState(() {
+      _hiddenColumns[_tipo]!.remove(columnKey);
+    });
+  }
+
+  void _reorderColumns(int oldIndex, int newIndex) {
+    final headerMap = _headerConfigs[_tipo] ?? const {};
+    _ensureColumnState(headerMap);
+    final hidden = _hiddenColumns[_tipo]!;
+    final order = _columnOrders[_tipo]!;
+    final visible = [
+      for (final key in order)
+        if (!hidden.contains(key)) key,
+    ];
+    if (visible.length < 2) {
+      return;
+    }
+    if (newIndex > visible.length) {
+      newIndex = visible.length;
+    }
+    if (newIndex > oldIndex) {
+      newIndex -= 1;
+    }
+    final moved = visible.removeAt(oldIndex);
+    visible.insert(newIndex, moved);
+    final newOrder = <String>[];
+    var visibleIndex = 0;
+    for (final key in order) {
+      if (hidden.contains(key)) {
+        newOrder.add(key);
+      } else {
+        newOrder.add(visible[visibleIndex++]);
+      }
+    }
+    setState(() {
+      order
+        ..clear()
+        ..addAll(newOrder);
+    });
+  }
+
+  Widget _buildHeaderLabel(
+    String columnKey,
+    String label,
+    VoidCallback onHide,
+  ) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Flexible(
+          child: Text(
+            label,
+            style: const TextStyle(fontSize: 12),
+            overflow: TextOverflow.ellipsis,
+            maxLines: 1,
+          ),
+        ),
+        Tooltip(
+          message: 'Ocultar coluna',
+          child: IconButton(
+            icon: const Icon(Icons.visibility_off_outlined, size: 16),
+            padding: EdgeInsets.zero,
+            constraints: const BoxConstraints(minWidth: 28, minHeight: 28),
+            splashRadius: 18,
+            onPressed: onHide,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildColumnManager(
+    BuildContext context,
+    Map<String, String> headerMap,
+    List<String> visibleColumns,
+    List<String> hiddenColumns,
+  ) {
+    if (headerMap.isEmpty) {
+      return const SizedBox.shrink();
+    }
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (hiddenColumns.isNotEmpty) ...[
+          Text('Colunas ocultas', style: theme.textTheme.labelMedium),
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: hiddenColumns.map((key) {
+              final label = headerMap[key] ?? key;
+              return Tooltip(
+                message: 'Mostrar coluna',
+                child: ActionChip(
+                  avatar: const Icon(Icons.visibility_outlined, size: 18),
+                  label: Text(label),
+                  onPressed: () => _showColumn(key),
+                ),
+              );
+            }).toList(),
+          ),
+          const SizedBox(height: 16),
+        ],
+        Text('Colunas visíveis', style: theme.textTheme.labelMedium),
+        const SizedBox(height: 8),
+        SizedBox(
+          height: 56,
+          child: ReorderableListView.builder(
+            scrollDirection: Axis.horizontal,
+            padding: const EdgeInsets.symmetric(horizontal: 4),
+            itemCount: visibleColumns.length,
+            onReorder: _reorderColumns,
+            buildDefaultDragHandles: false,
+            itemBuilder: (context, index) {
+              final key = visibleColumns[index];
+              final label = headerMap[key] ?? key;
+              return ReorderableDragStartListener(
+                key: ValueKey('visible_$key'),
+                index: index,
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 4),
+                  child: Tooltip(
+                    message: 'Arraste para reordenar',
+                    child: Chip(
+                      avatar: const Icon(Icons.drag_indicator, size: 18),
+                      label: Text(label, overflow: TextOverflow.ellipsis),
+                      deleteIcon: const Icon(
+                        Icons.visibility_off_outlined,
+                        size: 18,
+                      ),
+                      onDeleted: () => _hideColumn(key),
+                      deleteButtonTooltipMessage: 'Ocultar coluna',
+                      visualDensity: VisualDensity.compact,
+                      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    ),
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          'Arraste para mudar a ordem ou oculte colunas pelo ícone de olho.',
+          style: theme.textTheme.bodySmall,
+        ),
+      ],
+    );
   }
 
   void _buscar() {
@@ -439,95 +694,108 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
               if (dados.isEmpty) {
                 return const Text('Nenhum dado encontrado.');
               }
-              final headerMap = _tipo == 'preparador'
-                  ? const {
-                      'os': 'OS',
-                      're_liberacao': 'RE Liberação',
-                      're_finalizacao': 'RE Finalização',
-                      'partnumber': 'Partnumber',
-                      'maquina': 'Máquina',
-                      'faixa_texto': 'Faixa',
-                      'created_at': 'Horário Inicial',
-                      'medicao': 'Medição Inicial',
-                      'medicao_final': 'Medição Final',
-                      'created_at_final': 'Horário Final',
-                    }
-                  : const {
-                      'os': 'OS',
-                      're_operador': 'RE',
-                      'created_at': 'Início',
-                      'retorno_at': 'Retorno',
-                      'partnumber': 'Partnumber',
-                      'maquina': 'Máquina',
-                      'titulo': 'Título',
-                      'instrumento': 'Instrumento',
-                      'faixa_texto': 'Faixa',
-                      'status': 'Status',
-                      'motivo': 'Motivo',
-                    };
-              final headers = headerMap.keys.toList();
-              return LayoutBuilder(
-                builder: (context, constraints) {
-                  final theme = Theme.of(context);
-                  final groupColor = theme.colorScheme.surfaceVariant
-                      .withOpacity(0.25);
-                  final pauseColor = Colors.orange.withOpacity(0.12);
-                  return SingleChildScrollView(
-                    scrollDirection: Axis.horizontal,
-                    child: ConstrainedBox(
-                      constraints: BoxConstraints(
-                        minWidth: constraints.maxWidth,
-                      ),
-                      child: DataTable(
-                        columnSpacing: 12,
-                        horizontalMargin: 12,
-                        columns: headers
-                            .map(
-                              (h) => DataColumn(
-                                label: Text(
-                                  headerMap[h] ?? h,
-                                  style: const TextStyle(fontSize: 12),
-                                ),
-                              ),
-                            )
-                            .toList(),
-                        rows: dados.map((r) {
-                          final isGroup = r['__isGroup'] == true;
-                          final isPause = r['evento'] == 'pausa_jornada';
-                          return DataRow(
-                            color: MaterialStateProperty.resolveWith<Color?>((
-                              states,
-                            ) {
-                              if (isGroup) return groupColor;
-                              if (isPause) return pauseColor;
-                              return null;
-                            }),
-                            cells: headers.map((h) {
-                              if (isGroup) {
-                                final text = h == 'created_at'
-                                    ? 'Horário: ${r['created_at'] ?? ''}'
-                                    : '';
-                                final style = theme.textTheme.labelLarge
-                                    ?.copyWith(fontWeight: FontWeight.bold);
-                                return DataCell(Text(text, style: style));
-                              }
-                              final value = r[h];
-                              final display = value == null
-                                  ? ''
-                                  : value.toString();
-                              return DataCell(
-                                Text(
-                                  display,
-                                  style: const TextStyle(fontSize: 12),
-                                ),
+              final headerMap = _headerConfigs[_tipo] ?? const {};
+              _ensureColumnState(headerMap);
+              final hiddenSet = _hiddenColumns[_tipo] ?? <String>{};
+              final order = _columnOrders[_tipo] ?? <String>[];
+              final visibleColumns = [
+                for (final key in order)
+                  if (!hiddenSet.contains(key)) key,
+              ];
+              final hiddenColumns = [
+                for (final key in order)
+                  if (hiddenSet.contains(key)) key,
+              ];
+              final manager = _buildColumnManager(
+                context,
+                headerMap,
+                visibleColumns,
+                hiddenColumns,
+              );
+              if (visibleColumns.isEmpty) {
+                return Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    manager,
+                    const SizedBox(height: 12),
+                    const Text('Selecione ao menos uma coluna para exibir.'),
+                  ],
+                );
+              }
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  manager,
+                  const SizedBox(height: 12),
+                  LayoutBuilder(
+                    builder: (context, constraints) {
+                      final theme = Theme.of(context);
+                      final groupColor = theme.colorScheme.surfaceVariant
+                          .withOpacity(0.25);
+                      final pauseColor = Colors.orange.withOpacity(0.12);
+                      final firstColumnKey = visibleColumns.isNotEmpty
+                          ? visibleColumns.first
+                          : null;
+                      return SingleChildScrollView(
+                        scrollDirection: Axis.horizontal,
+                        child: ConstrainedBox(
+                          constraints: BoxConstraints(
+                            minWidth: constraints.maxWidth,
+                          ),
+                          child: DataTable(
+                            columnSpacing: 12,
+                            horizontalMargin: 12,
+                            columns: visibleColumns
+                                .map(
+                                  (h) => DataColumn(
+                                    label: _buildHeaderLabel(
+                                      h,
+                                      headerMap[h] ?? h,
+                                      () => _hideColumn(h),
+                                    ),
+                                  ),
+                                )
+                                .toList(),
+                            rows: dados.map((r) {
+                              final isGroup = r['__isGroup'] == true;
+                              final isPause = r['evento'] == 'pausa_jornada';
+                              return DataRow(
+                                color:
+                                    MaterialStateProperty.resolveWith<Color?>((
+                                      states,
+                                    ) {
+                                      if (isGroup) return groupColor;
+                                      if (isPause) return pauseColor;
+                                      return null;
+                                    }),
+                                cells: visibleColumns.map((h) {
+                                  if (isGroup) {
+                                    final text = h == firstColumnKey
+                                        ? 'Horário: ${r['created_at'] ?? ''}'
+                                        : '';
+                                    final style = theme.textTheme.labelLarge
+                                        ?.copyWith(fontWeight: FontWeight.bold);
+                                    return DataCell(Text(text, style: style));
+                                  }
+                                  final value = r[h];
+                                  final display = value == null
+                                      ? ''
+                                      : value.toString();
+                                  return DataCell(
+                                    Text(
+                                      display,
+                                      style: const TextStyle(fontSize: 12),
+                                    ),
+                                  );
+                                }).toList(),
                               );
                             }).toList(),
-                          );
-                        }).toList(),
-                      ),
-                    ),
-                  );
-                },
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+                ],
               );
             },
           ),


### PR DESCRIPTION
## Summary
- add column management chips so hidden columns move to a restore list and visible columns can be reordered
- render the personnel report using only the visible column order and provide header actions to hide and restore columns

## Testing
- flutter analyze
- flutter test

------
https://chatgpt.com/codex/tasks/task_e_68d2c3a859f08331ada619f5e037149c