### PR TITLE
Fix personnel report column drag reordering

### DIFF
--- a/lib/screens/dashboard/components/personnel_report_chart.dart
+++ b/lib/screens/dashboard/components/personnel_report_chart.dart
@@ -21,6 +21,42 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
   String _tipo = 'operador';
   String _modo = 'os';
   Future<List<Map<String, dynamic>>>? _future;
+  final Map<String, Set<String>> _hiddenColumns = {
+    'operador': <String>{},
+    'preparador': <String>{},
+  };
+  final Map<String, List<String>> _columnOrders = {
+    'operador': <String>[],
+    'preparador': <String>[],
+  };
+
+  static const Map<String, Map<String, String>> _headerConfigs = {
+    'preparador': {
+      'os': 'OS',
+      're_liberacao': 'RE Liberação',
+      're_finalizacao': 'RE Finalização',
+      'partnumber': 'Partnumber',
+      'maquina': 'Máquina',
+      'faixa_texto': 'Faixa',
+      'created_at': 'Horário Inicial',
+      'medicao': 'Medição Inicial',
+      'medicao_final': 'Medição Final',
+      'created_at_final': 'Horário Final',
+    },
+    'operador': {
+      'os': 'OS',
+      're_operador': 'RE',
+      'created_at': 'Início',
+      'retorno_at': 'Retorno',
+      'partnumber': 'Partnumber',
+      'maquina': 'Máquina',
+      'titulo': 'Título',
+      'instrumento': 'Instrumento',
+      'faixa_texto': 'Faixa',
+      'status': 'Status',
+      'motivo': 'Motivo',
+    },
+  };
 
   DateTime? _parseDateTime(dynamic value) {
     final raw = value?.toString().trim();
@@ -73,31 +109,62 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
     List<Map<String, dynamic>> rows,
   ) {
     final result = <Map<String, dynamic>>[];
-    DateTime? lastGroup;
-    for (final row in rows) {
+    var index = 0;
+    while (index < rows.length) {
+      final row = rows[index];
       final dt = row['__dt'] as DateTime?;
-      if (dt != null) {
-        final normalized = DateTime(
-          dt.year,
-          dt.month,
-          dt.day,
-          dt.hour,
-          dt.minute,
-          dt.second,
-        );
-        if (lastGroup == null || normalized != lastGroup) {
-          final label = DateFormat('dd/MM/yyyy HH:mm:ss').format(dt);
-          result.add({
-            '__isGroup': true,
-            '__dt': normalized,
-            'created_at': label,
-          });
-          lastGroup = normalized;
-        }
-      } else {
-        lastGroup = null;
+      if (dt == null) {
+        result.add(row);
+        index++;
+        continue;
       }
-      result.add(row);
+
+      DateTime normalize(DateTime value) => DateTime(
+        value.year,
+        value.month,
+        value.day,
+        value.hour,
+        value.minute,
+        value.second,
+      );
+
+      final normalized = normalize(dt);
+      final groupRows = <Map<String, dynamic>>[];
+      while (index < rows.length) {
+        final current = rows[index];
+        final currentDt = current['__dt'] as DateTime?;
+        if (currentDt == null) {
+          break;
+        }
+        if (normalize(currentDt) != normalized) {
+          break;
+        }
+        groupRows.add(current);
+        index++;
+      }
+
+      result.add({
+        '__isGroup': true,
+        '__dt': normalized,
+        'created_at': DateFormat(
+          'dd/MM/yyyy HH:mm:ss',
+        ).format(groupRows.first['__dt'] as DateTime),
+      });
+
+      final pauseRows = <Map<String, dynamic>>[];
+      final otherRows = <Map<String, dynamic>>[];
+      for (final item in groupRows) {
+        final event = item['evento']?.toString();
+        if (event == 'pausa_jornada') {
+          pauseRows.add(item);
+        } else {
+          otherRows.add(item);
+        }
+      }
+
+      result
+        ..addAll(pauseRows)
+        ..addAll(otherRows);
     }
     return result;
   }
@@ -108,6 +175,311 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
     _partCtrl.dispose();
     _opCtrl.dispose();
     super.dispose();
+  }
+
+  void _ensureColumnState(Map<String, String> headerMap) {
+    final allowedKeys = headerMap.keys.toList(growable: false);
+    final allowedSet = allowedKeys.toSet();
+    final order = _columnOrders.putIfAbsent(_tipo, () => <String>[]);
+    final hidden = _hiddenColumns.putIfAbsent(_tipo, () => <String>{});
+    order.removeWhere((key) => !allowedSet.contains(key));
+    hidden.removeWhere((key) => !allowedSet.contains(key));
+    for (final key in allowedKeys) {
+      if (!order.contains(key)) {
+        order.add(key);
+      }
+    }
+  }
+
+  void _hideColumn(String columnKey) {
+    final headerMap = _headerConfigs[_tipo] ?? const {};
+    _ensureColumnState(headerMap);
+    final hidden = _hiddenColumns[_tipo]!;
+    final order = _columnOrders[_tipo]!;
+    final visibleCount = order.where((key) => !hidden.contains(key)).length;
+    if (visibleCount <= 1) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Mantenha ao menos uma coluna visível.'),
+          duration: Duration(seconds: 2),
+        ),
+      );
+      return;
+    }
+    setState(() {
+      hidden.add(columnKey);
+    });
+  }
+
+  void _showColumn(String columnKey) {
+    final headerMap = _headerConfigs[_tipo] ?? const {};
+    _ensureColumnState(headerMap);
+    setState(() {
+      _hiddenColumns[_tipo]!.remove(columnKey);
+    });
+  }
+
+  void _reorderVisibleColumn(String columnKey, int dropIndex) {
+    final headerMap = _headerConfigs[_tipo] ?? const {};
+    _ensureColumnState(headerMap);
+    final hidden = _hiddenColumns[_tipo]!;
+    if (hidden.contains(columnKey)) {
+      return;
+    }
+    final order = _columnOrders[_tipo]!;
+    final visible = [
+      for (final key in order)
+        if (!hidden.contains(key)) key,
+    ];
+    if (visible.length < 2) {
+      return;
+    }
+    final oldIndex = visible.indexOf(columnKey);
+    if (oldIndex == -1) {
+      return;
+    }
+    if (dropIndex < 0 || dropIndex > visible.length) {
+      return;
+    }
+    var adjustedIndex = dropIndex;
+    if (adjustedIndex == oldIndex || adjustedIndex == oldIndex + 1) {
+      return;
+    }
+    final working = List<String>.from(visible);
+    final moved = working.removeAt(oldIndex);
+    if (adjustedIndex > oldIndex) {
+      adjustedIndex -= 1;
+    }
+    working.insert(adjustedIndex, moved);
+    final hiddenOrder = [
+      for (final key in order)
+        if (hidden.contains(key)) key,
+    ];
+    setState(() {
+      order
+        ..clear()
+        ..addAll(working)
+        ..addAll(hiddenOrder);
+    });
+  }
+
+  Widget _buildColumnChip(
+    BuildContext context,
+    String columnKey,
+    String label, {
+    VoidCallback? onPressed,
+    bool enableTooltip = true,
+    bool showDelete = true,
+  }) {
+    final chip = InputChip(
+      avatar: const Icon(Icons.drag_indicator, size: 18),
+      label: Text(label, overflow: TextOverflow.ellipsis),
+      visualDensity: VisualDensity.compact,
+      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+      onPressed: onPressed,
+      onDeleted: showDelete ? onPressed : null,
+      deleteIcon: showDelete
+          ? const Icon(Icons.visibility_off_outlined, size: 18)
+          : null,
+      deleteButtonTooltipMessage: showDelete ? 'Ocultar coluna' : null,
+    );
+    if (!enableTooltip) {
+      return chip;
+    }
+    final message = showDelete
+        ? 'Toque para ocultar ou arraste para reordenar'
+        : 'Arraste para reordenar';
+    return Tooltip(message: message, child: chip);
+  }
+
+  Widget _buildReorderableChip(
+    BuildContext context,
+    Map<String, String> headerMap,
+    String columnKey,
+  ) {
+    final label = headerMap[columnKey] ?? columnKey;
+    return LongPressDraggable<String>(
+      data: columnKey,
+      dragAnchorStrategy: pointerDragAnchorStrategy,
+      feedback: Material(
+        elevation: 6,
+        color: Colors.transparent,
+        child: _buildColumnChip(
+          context,
+          columnKey,
+          label,
+          enableTooltip: false,
+          showDelete: false,
+        ),
+      ),
+      childWhenDragging: Opacity(
+        opacity: 0.5,
+        child: IgnorePointer(
+          child: _buildColumnChip(
+            context,
+            columnKey,
+            label,
+            enableTooltip: false,
+          ),
+        ),
+      ),
+      child: _buildColumnChip(
+        context,
+        columnKey,
+        label,
+        onPressed: () => _hideColumn(columnKey),
+      ),
+    );
+  }
+
+  Widget _buildInsertionTarget(BuildContext context, int index) {
+    final theme = Theme.of(context);
+    return DragTarget<String>(
+      onWillAcceptWithDetails: (details) {
+        final order = _columnOrders[_tipo];
+        if (order == null || !order.contains(details.data)) {
+          return false;
+        }
+        final hidden = _hiddenColumns[_tipo];
+        if (hidden != null && hidden.contains(details.data)) {
+          return false;
+        }
+        return true;
+      },
+      onAcceptWithDetails: (details) {
+        _reorderVisibleColumn(details.data, index);
+      },
+      builder: (context, candidate, rejected) {
+        final isActive = candidate.isNotEmpty;
+        return AnimatedContainer(
+          duration: const Duration(milliseconds: 120),
+          width: 14,
+          height: 42,
+          margin: const EdgeInsets.symmetric(horizontal: 2, vertical: 4),
+          decoration: BoxDecoration(
+            color: isActive
+                ? theme.colorScheme.primary.withValues(alpha: 0.18)
+                : theme.colorScheme.surfaceContainerHighest.withValues(
+                    alpha: 0.08,
+                  ),
+            borderRadius: BorderRadius.circular(6),
+            border: Border.all(
+              color: isActive
+                  ? theme.colorScheme.primary
+                  : theme.colorScheme.outline.withValues(alpha: 0.35),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildHeaderLabel(
+    String columnKey,
+    String label,
+    VoidCallback onHide,
+  ) {
+    return Tooltip(
+      message: 'Toque para ocultar',
+      child: InkWell(
+        onTap: onHide,
+        borderRadius: BorderRadius.circular(6),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Flexible(
+                child: Text(
+                  label,
+                  style: const TextStyle(fontSize: 12),
+                  overflow: TextOverflow.ellipsis,
+                  maxLines: 1,
+                ),
+              ),
+              const SizedBox(width: 4),
+              const Icon(Icons.visibility_off_outlined, size: 16),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildColumnManager(
+    BuildContext context,
+    Map<String, String> headerMap,
+    List<String> visibleColumns,
+    List<String> hiddenColumns,
+  ) {
+    if (headerMap.isEmpty) {
+      return const SizedBox.shrink();
+    }
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (hiddenColumns.isNotEmpty) ...[
+          Text('Colunas ocultas', style: theme.textTheme.labelMedium),
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: hiddenColumns.map((key) {
+              final label = headerMap[key] ?? key;
+              return Tooltip(
+                message: 'Mostrar coluna',
+                child: ActionChip(
+                  avatar: const Icon(Icons.visibility_outlined, size: 18),
+                  label: Text(label),
+                  onPressed: () => _showColumn(key),
+                ),
+              );
+            }).toList(),
+          ),
+          const SizedBox(height: 12),
+        ],
+        Text('Colunas visíveis', style: theme.textTheme.labelMedium),
+        const SizedBox(height: 8),
+        Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          crossAxisAlignment: WrapCrossAlignment.center,
+          children: [
+            for (var i = 0; i < visibleColumns.length; i++)
+              Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  _buildInsertionTarget(context, i),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 2),
+                    child: KeyedSubtree(
+                      key: ValueKey('visible_${visibleColumns[i]}'),
+                      child: _buildReorderableChip(
+                        context,
+                        headerMap,
+                        visibleColumns[i],
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            if (visibleColumns.isNotEmpty)
+              Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  _buildInsertionTarget(context, visibleColumns.length),
+                ],
+              ),
+          ],
+        ),
+        const SizedBox(height: 6),
+        Text(
+          'Toque para ocultar e arraste os chips, soltando nas áreas destacadas para reordenar.',
+          style: theme.textTheme.bodySmall,
+        ),
+      ],
+    );
   }
 
   void _buscar() {
@@ -439,95 +811,108 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
               if (dados.isEmpty) {
                 return const Text('Nenhum dado encontrado.');
               }
-              final headerMap = _tipo == 'preparador'
-                  ? const {
-                      'os': 'OS',
-                      're_liberacao': 'RE Liberação',
-                      're_finalizacao': 'RE Finalização',
-                      'partnumber': 'Partnumber',
-                      'maquina': 'Máquina',
-                      'faixa_texto': 'Faixa',
-                      'created_at': 'Horário Inicial',
-                      'medicao': 'Medição Inicial',
-                      'medicao_final': 'Medição Final',
-                      'created_at_final': 'Horário Final',
-                    }
-                  : const {
-                      'os': 'OS',
-                      're_operador': 'RE',
-                      'created_at': 'Início',
-                      'retorno_at': 'Retorno',
-                      'partnumber': 'Partnumber',
-                      'maquina': 'Máquina',
-                      'titulo': 'Título',
-                      'instrumento': 'Instrumento',
-                      'faixa_texto': 'Faixa',
-                      'status': 'Status',
-                      'motivo': 'Motivo',
-                    };
-              final headers = headerMap.keys.toList();
-              return LayoutBuilder(
-                builder: (context, constraints) {
-                  final theme = Theme.of(context);
-                  final groupColor = theme.colorScheme.surfaceVariant
-                      .withOpacity(0.25);
-                  final pauseColor = Colors.orange.withOpacity(0.12);
-                  return SingleChildScrollView(
-                    scrollDirection: Axis.horizontal,
-                    child: ConstrainedBox(
-                      constraints: BoxConstraints(
-                        minWidth: constraints.maxWidth,
-                      ),
-                      child: DataTable(
-                        columnSpacing: 12,
-                        horizontalMargin: 12,
-                        columns: headers
-                            .map(
-                              (h) => DataColumn(
-                                label: Text(
-                                  headerMap[h] ?? h,
-                                  style: const TextStyle(fontSize: 12),
-                                ),
-                              ),
-                            )
-                            .toList(),
-                        rows: dados.map((r) {
-                          final isGroup = r['__isGroup'] == true;
-                          final isPause = r['evento'] == 'pausa_jornada';
-                          return DataRow(
-                            color: MaterialStateProperty.resolveWith<Color?>((
-                              states,
-                            ) {
-                              if (isGroup) return groupColor;
-                              if (isPause) return pauseColor;
-                              return null;
-                            }),
-                            cells: headers.map((h) {
-                              if (isGroup) {
-                                final text = h == 'created_at'
-                                    ? 'Horário: ${r['created_at'] ?? ''}'
-                                    : '';
-                                final style = theme.textTheme.labelLarge
-                                    ?.copyWith(fontWeight: FontWeight.bold);
-                                return DataCell(Text(text, style: style));
-                              }
-                              final value = r[h];
-                              final display = value == null
-                                  ? ''
-                                  : value.toString();
-                              return DataCell(
-                                Text(
-                                  display,
-                                  style: const TextStyle(fontSize: 12),
-                                ),
+              final headerMap = _headerConfigs[_tipo] ?? const {};
+              _ensureColumnState(headerMap);
+              final hiddenSet = _hiddenColumns[_tipo] ?? <String>{};
+              final order = _columnOrders[_tipo] ?? <String>[];
+              final visibleColumns = [
+                for (final key in order)
+                  if (!hiddenSet.contains(key)) key,
+              ];
+              final hiddenColumns = [
+                for (final key in order)
+                  if (hiddenSet.contains(key)) key,
+              ];
+              final manager = _buildColumnManager(
+                context,
+                headerMap,
+                visibleColumns,
+                hiddenColumns,
+              );
+              if (visibleColumns.isEmpty) {
+                return Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    manager,
+                    const SizedBox(height: 12),
+                    const Text('Selecione ao menos uma coluna para exibir.'),
+                  ],
+                );
+              }
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  manager,
+                  const SizedBox(height: 12),
+                  LayoutBuilder(
+                    builder: (context, constraints) {
+                      final theme = Theme.of(context);
+                      final groupColor = theme.colorScheme.surfaceVariant
+                          .withOpacity(0.25);
+                      final pauseColor = Colors.orange.withOpacity(0.12);
+                      final firstColumnKey = visibleColumns.isNotEmpty
+                          ? visibleColumns.first
+                          : null;
+                      return SingleChildScrollView(
+                        scrollDirection: Axis.horizontal,
+                        child: ConstrainedBox(
+                          constraints: BoxConstraints(
+                            minWidth: constraints.maxWidth,
+                          ),
+                          child: DataTable(
+                            columnSpacing: 12,
+                            horizontalMargin: 12,
+                            columns: visibleColumns
+                                .map(
+                                  (h) => DataColumn(
+                                    label: _buildHeaderLabel(
+                                      h,
+                                      headerMap[h] ?? h,
+                                      () => _hideColumn(h),
+                                    ),
+                                  ),
+                                )
+                                .toList(),
+                            rows: dados.map((r) {
+                              final isGroup = r['__isGroup'] == true;
+                              final isPause = r['evento'] == 'pausa_jornada';
+                              return DataRow(
+                                color:
+                                    MaterialStateProperty.resolveWith<Color?>((
+                                      states,
+                                    ) {
+                                      if (isGroup) return groupColor;
+                                      if (isPause) return pauseColor;
+                                      return null;
+                                    }),
+                                cells: visibleColumns.map((h) {
+                                  if (isGroup) {
+                                    final text = h == firstColumnKey
+                                        ? 'Horário: ${r['created_at'] ?? ''}'
+                                        : '';
+                                    final style = theme.textTheme.labelLarge
+                                        ?.copyWith(fontWeight: FontWeight.bold);
+                                    return DataCell(Text(text, style: style));
+                                  }
+                                  final value = r[h];
+                                  final display = value == null
+                                      ? ''
+                                      : value.toString();
+                                  return DataCell(
+                                    Text(
+                                      display,
+                                      style: const TextStyle(fontSize: 12),
+                                    ),
+                                  );
+                                }).toList(),
                               );
                             }).toList(),
-                          );
-                        }).toList(),
-                      ),
-                    ),
-                  );
-                },
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+                ],
               );
             },
           ),


### PR DESCRIPTION
## Summary
- rework the personnel report column reordering logic so the drop index is applied after removing the dragged column and hidden columns stay in place
- add dedicated insertion targets that highlight while dragging to make it possible to reorder columns in any position and update the helper copy accordingly

## Testing
- flutter analyze
- flutter test

------
https://chatgpt.com/codex/tasks/task_e_68d2c3a859f08331ada619f5e037149c