### PR TITLE
Prevent personnel report group headers from stretching columns

### DIFF
--- a/lib/screens/dashboard/components/personnel_report_chart.dart
+++ b/lib/screens/dashboard/components/personnel_report_chart.dart
@@ -22,6 +22,16 @@ class _TableMetrics {
   final double totalWidth;
 }
 
+class _FilterDialogResult {
+  const _FilterDialogResult({
+    this.selectedValues = const <String>{},
+    this.clearFilter = false,
+  });
+
+  final Set<String> selectedValues;
+  final bool clearFilter;
+}
+
 class _PersonnelReportChartState extends State<PersonnelReportChart> {
   final _osCtrl = TextEditingController();
   final _partCtrl = TextEditingController();
@@ -41,6 +51,10 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
   final Map<String, Map<String, double>> _columnWidthOverrides = {
     'operador': <String, double>{},
     'preparador': <String, double>{},
+  };
+  final Map<String, Map<String, Set<String>>> _columnFilters = {
+    'operador': <String, Set<String>>{},
+    'preparador': <String, Set<String>>{},
   };
 
   String? _activeResizeColumn;
@@ -193,6 +207,281 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
     return result;
   }
 
+  String _normalizeFilterValue(dynamic value) {
+    final raw = value?.toString();
+    if (raw == null) return '';
+    return raw.trim();
+  }
+
+  String _describeFilterValue(String value) {
+    return value.isEmpty ? '(Vazio)' : value;
+  }
+
+  String _formatFilterPreview(Set<String> values) {
+    if (values.isEmpty) return '';
+    const maxPreview = 2;
+    final sorted = values.map(_describeFilterValue).toList()
+      ..sort((a, b) => a.toLowerCase().compareTo(b.toLowerCase()));
+    if (sorted.length <= maxPreview) {
+      return sorted.join(', ');
+    }
+    final remaining = sorted.length - maxPreview;
+    return '${sorted.take(maxPreview).join(', ')} +$remaining';
+  }
+
+  bool _isColumnFiltered(String columnKey) {
+    final filters = _columnFilters[_tipo];
+    if (filters == null) return false;
+    final values = filters[columnKey];
+    return values != null && values.isNotEmpty;
+  }
+
+  void _clearFilter(String columnKey) {
+    final filters = _columnFilters[_tipo];
+    if (filters == null) return;
+    if (!filters.containsKey(columnKey)) return;
+    setState(() {
+      filters.remove(columnKey);
+    });
+  }
+
+  void _clearAllFilters() {
+    final filters = _columnFilters[_tipo];
+    if (filters == null || filters.isEmpty) return;
+    setState(() {
+      filters.clear();
+    });
+  }
+
+  List<Map<String, dynamic>> _applyFiltersToRows(
+    List<Map<String, dynamic>> rows,
+    Map<String, Set<String>> filters,
+  ) {
+    if (rows.isEmpty || filters.isEmpty) {
+      return List<Map<String, dynamic>>.from(rows);
+    }
+
+    final normalizedFilters = <String, Set<String>>{};
+    filters.forEach((key, value) {
+      if (value.isNotEmpty) {
+        normalizedFilters[key] = value;
+      }
+    });
+
+    if (normalizedFilters.isEmpty) {
+      return List<Map<String, dynamic>>.from(rows);
+    }
+
+    final result = <Map<String, dynamic>>[];
+    Map<String, dynamic>? activeGroup;
+    var groupRows = <Map<String, dynamic>>[];
+
+    void flushGroup() {
+      if (activeGroup != null) {
+        if (groupRows.isNotEmpty) {
+          result.add(activeGroup!);
+          result.addAll(groupRows);
+        }
+        activeGroup = null;
+        groupRows = <Map<String, dynamic>>[];
+      }
+    }
+
+    for (final row in rows) {
+      if (row['__isGroup'] == true) {
+        flushGroup();
+        activeGroup = row;
+        continue;
+      }
+
+      var include = true;
+      for (final entry in normalizedFilters.entries) {
+        final normalizedValue = _normalizeFilterValue(row[entry.key]);
+        if (!entry.value.contains(normalizedValue)) {
+          include = false;
+          break;
+        }
+      }
+
+      if (!include) {
+        continue;
+      }
+
+      if (activeGroup != null) {
+        groupRows.add(row);
+      } else {
+        result.add(row);
+      }
+    }
+
+    flushGroup();
+    return result;
+  }
+
+  List<Map<String, dynamic>> _applyActiveFilters(
+    List<Map<String, dynamic>> rows,
+  ) {
+    final filters = _columnFilters[_tipo];
+    if (filters == null || filters.isEmpty) {
+      return List<Map<String, dynamic>>.from(rows);
+    }
+    return _applyFiltersToRows(rows, filters);
+  }
+
+  Future<void> _showColumnFilterSheet(
+    BuildContext context,
+    String columnKey,
+    String label,
+    List<Map<String, dynamic>> sourceRows,
+  ) async {
+    final filters = _columnFilters[_tipo]!;
+    final otherFilters = <String, Set<String>>{};
+    filters.forEach((key, value) {
+      if (key == columnKey || value.isEmpty) return;
+      otherFilters[key] = value;
+    });
+
+    final rowsForValues = _applyFiltersToRows(sourceRows, otherFilters);
+    final values = <String>{};
+    for (final row in rowsForValues) {
+      if (row['__isGroup'] == true) {
+        continue;
+      }
+      values.add(_normalizeFilterValue(row[columnKey]));
+    }
+
+    if (values.isEmpty) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Nenhum valor disponível para filtrar em $label.'),
+        ),
+      );
+      return;
+    }
+
+    final sortedValues = values.toList()
+      ..sort((a, b) => a.toLowerCase().compareTo(b.toLowerCase()));
+    final currentSelection = filters[columnKey];
+    final initialSelection =
+        (currentSelection == null || currentSelection.isEmpty)
+        ? sortedValues.toSet()
+        : currentSelection.where(values.contains).toSet();
+
+    final result = await showDialog<_FilterDialogResult>(
+      context: context,
+      builder: (context) {
+        var tempSelected = initialSelection.isEmpty
+            ? sortedValues.toSet()
+            : Set<String>.from(initialSelection);
+        return StatefulBuilder(
+          builder: (context, setModalState) {
+            final allSelected = tempSelected.length == sortedValues.length;
+            final listHeight = math.min(320.0, 36.0 * sortedValues.length + 12);
+            return AlertDialog(
+              title: Text('Filtrar $label'),
+              content: SizedBox(
+                width: 340,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    CheckboxListTile(
+                      dense: true,
+                      value: allSelected,
+                      onChanged: (value) {
+                        setModalState(() {
+                          if (value == true) {
+                            tempSelected = sortedValues.toSet();
+                          } else {
+                            tempSelected = <String>{};
+                          }
+                        });
+                      },
+                      controlAffinity: ListTileControlAffinity.leading,
+                      title: const Text('Selecionar tudo'),
+                      contentPadding: EdgeInsets.zero,
+                    ),
+                    const Divider(height: 12),
+                    SizedBox(
+                      height: listHeight,
+                      child: Scrollbar(
+                        thumbVisibility: sortedValues.length > 8,
+                        child: ListView.builder(
+                          shrinkWrap: true,
+                          itemCount: sortedValues.length,
+                          itemBuilder: (context, index) {
+                            final value = sortedValues[index];
+                            final checked = tempSelected.contains(value);
+                            return CheckboxListTile(
+                              dense: true,
+                              value: checked,
+                              onChanged: (selected) {
+                                setModalState(() {
+                                  if (selected == true) {
+                                    tempSelected.add(value);
+                                  } else {
+                                    tempSelected.remove(value);
+                                  }
+                                });
+                              },
+                              controlAffinity: ListTileControlAffinity.leading,
+                              title: Text(_describeFilterValue(value)),
+                              contentPadding: EdgeInsets.zero,
+                            );
+                          },
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () {
+                    Navigator.of(
+                      context,
+                    ).pop(const _FilterDialogResult(clearFilter: true));
+                  },
+                  child: const Text('Limpar filtro'),
+                ),
+                TextButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: const Text('Cancelar'),
+                ),
+                FilledButton(
+                  onPressed: tempSelected.isEmpty
+                      ? null
+                      : () {
+                          Navigator.of(context).pop(
+                            _FilterDialogResult(
+                              selectedValues: Set<String>.from(tempSelected),
+                            ),
+                          );
+                        },
+                  child: const Text('Aplicar'),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    );
+
+    if (result == null || !mounted) {
+      return;
+    }
+
+    setState(() {
+      if (result.clearFilter ||
+          result.selectedValues.isEmpty ||
+          result.selectedValues.length == sortedValues.length) {
+        filters.remove(columnKey);
+      } else {
+        filters[columnKey] = Set<String>.from(result.selectedValues);
+      }
+    });
+  }
+
   @override
   void dispose() {
     _osCtrl.dispose();
@@ -210,9 +499,14 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
       _tipo,
       () => <String, double>{},
     );
+    final filters = _columnFilters.putIfAbsent(
+      _tipo,
+      () => <String, Set<String>>{},
+    );
     order.removeWhere((key) => !allowedSet.contains(key));
     hidden.removeWhere((key) => !allowedSet.contains(key));
     overrides.removeWhere((key, _) => !allowedSet.contains(key));
+    filters.removeWhere((key, _) => !allowedSet.contains(key));
     for (final key in allowedKeys) {
       if (!order.contains(key)) {
         order.add(key);
@@ -409,10 +703,7 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
     final minTotalWidth = minContentWidth + spacing;
 
     if (baseTotalWidth <= viewportWidth) {
-      return _TableMetrics(
-        columnWidths: adjusted,
-        totalWidth: math.max(baseTotalWidth, viewportWidth),
-      );
+      return _TableMetrics(columnWidths: adjusted, totalWidth: baseTotalWidth);
     }
 
     final targetTotalWidth = math.max(viewportWidth, minTotalWidth);
@@ -422,10 +713,7 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
     if (remainingReduction <= 0) {
       final newContent = adjusted.fold<double>(0, (sum, width) => sum + width);
       final newTotal = newContent + spacing;
-      return _TableMetrics(
-        columnWidths: adjusted,
-        totalWidth: math.max(newTotal, viewportWidth),
-      );
+      return _TableMetrics(columnWidths: adjusted, totalWidth: newTotal);
     }
 
     const double tolerance = 0.1;
@@ -476,10 +764,7 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
       (sum, width) => sum + width,
     );
     final finalTotalWidth = adjustedContentWidth + spacing;
-    return _TableMetrics(
-      columnWidths: adjusted,
-      totalWidth: math.max(finalTotalWidth, viewportWidth),
-    );
+    return _TableMetrics(columnWidths: adjusted, totalWidth: finalTotalWidth);
   }
 
   Widget _buildColumnChip(
@@ -602,21 +887,28 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
   }
 
   Widget _buildHeaderLabel(
+    BuildContext context,
     String columnKey,
     String label,
     VoidCallback onHide,
+    VoidCallback onFilter,
+    bool filterActive,
   ) {
-    return Tooltip(
-      message: 'Toque para ocultar',
-      child: InkWell(
-        onTap: onHide,
-        borderRadius: BorderRadius.circular(6),
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Flexible(
+    final theme = Theme.of(context);
+    final iconColor = filterActive
+        ? theme.colorScheme.primary
+        : theme.iconTheme.color?.withOpacity(0.7) ?? theme.hintColor;
+    return Row(
+      mainAxisSize: MainAxisSize.max,
+      children: [
+        Expanded(
+          child: Tooltip(
+            message: 'Toque para ocultar',
+            child: InkWell(
+              onTap: onHide,
+              borderRadius: BorderRadius.circular(6),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
                 child: Text(
                   label,
                   style: const TextStyle(fontSize: 12),
@@ -624,12 +916,29 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
                   maxLines: 1,
                 ),
               ),
-              const SizedBox(width: 4),
-              const Icon(Icons.visibility_off_outlined, size: 16),
-            ],
+            ),
           ),
         ),
-      ),
+        const SizedBox(width: 4),
+        Tooltip(
+          message: filterActive ? 'Editar filtro' : 'Filtrar coluna',
+          child: SizedBox(
+            width: 24,
+            height: 24,
+            child: IconButton(
+              padding: EdgeInsets.zero,
+              visualDensity: VisualDensity.compact,
+              constraints: const BoxConstraints.tightFor(width: 24, height: 24),
+              onPressed: onFilter,
+              icon: Icon(
+                filterActive ? Icons.filter_alt : Icons.filter_alt_outlined,
+                size: 16,
+                color: iconColor,
+              ),
+            ),
+          ),
+        ),
+      ],
     );
   }
 
@@ -770,8 +1079,59 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
         ),
         const SizedBox(height: 6),
         Text(
-          'Toque para ocultar e arraste os chips, soltando nas áreas destacadas para reordenar. Arraste os divisores no cabeçalho para ajustar a largura das colunas.',
+          'Toque para ocultar e arraste os chips, soltando nas áreas destacadas para reordenar. Arraste os divisores no cabeçalho para ajustar a largura das colunas. Use o ícone de filtro no cabeçalho para filtrar os valores.',
           style: theme.textTheme.bodySmall,
+        ),
+      ],
+    );
+  }
+
+  Widget? _buildActiveFilterSummary(
+    BuildContext context,
+    Map<String, String> headerMap,
+    List<Map<String, dynamic>> sourceRows,
+  ) {
+    final filters = _columnFilters[_tipo];
+    if (filters == null || filters.isEmpty) {
+      return null;
+    }
+    final chips = <Widget>[];
+    filters.forEach((columnKey, values) {
+      if (values.isEmpty) return;
+      final label = headerMap[columnKey] ?? columnKey;
+      final preview = _formatFilterPreview(values);
+      chips.add(
+        InputChip(
+          avatar: const Icon(Icons.filter_alt, size: 18),
+          label: Text('$label: $preview'),
+          materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+          onPressed: () =>
+              _showColumnFilterSheet(context, columnKey, label, sourceRows),
+          onDeleted: () => _clearFilter(columnKey),
+          deleteIcon: const Icon(Icons.close, size: 18),
+        ),
+      );
+    });
+
+    if (chips.isEmpty) {
+      return null;
+    }
+
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text('Filtros ativos', style: theme.textTheme.labelMedium),
+        const SizedBox(height: 6),
+        Wrap(spacing: 8, runSpacing: 8, children: chips),
+        const SizedBox(height: 8),
+        Align(
+          alignment: Alignment.centerLeft,
+          child: TextButton.icon(
+            onPressed: _clearAllFilters,
+            icon: const Icon(Icons.filter_alt_off, size: 18),
+            label: const Text('Limpar filtros'),
+          ),
         ),
       ],
     );
@@ -783,6 +1143,7 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
     List<String> visibleColumns,
     List<double> columnWidths,
     double totalWidth,
+    List<Map<String, dynamic>> sourceRows,
   ) {
     final theme = Theme.of(context);
     final background = theme.colorScheme.surfaceContainerHighest.withValues(
@@ -812,9 +1173,17 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
                     ),
                     alignment: Alignment.centerLeft,
                     child: _buildHeaderLabel(
+                      context,
                       columnKey,
                       headerMap[columnKey] ?? columnKey,
                       () => _hideColumn(columnKey),
+                      () => _showColumnFilterSheet(
+                        context,
+                        columnKey,
+                        headerMap[columnKey] ?? columnKey,
+                        sourceRows,
+                      ),
+                      _isColumnFiltered(columnKey),
                     ),
                   ),
                 ),
@@ -1261,13 +1630,40 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
                 visibleColumns,
                 hiddenColumns,
               );
+              final filterSummary = _buildActiveFilterSummary(
+                context,
+                headerMap,
+                dados,
+              );
+              final filteredRows = _applyActiveFilters(dados);
               if (visibleColumns.isEmpty) {
                 return Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     manager,
+                    if (filterSummary != null) ...[
+                      const SizedBox(height: 12),
+                      filterSummary,
+                    ],
                     const SizedBox(height: 12),
                     const Text('Selecione ao menos uma coluna para exibir.'),
+                  ],
+                );
+              }
+              if (filteredRows.isEmpty) {
+                return Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    manager,
+                    if (filterSummary != null) ...[
+                      const SizedBox(height: 12),
+                      filterSummary,
+                    ],
+                    const SizedBox(height: 12),
+                    Text(
+                      'Nenhum resultado com os filtros aplicados.',
+                      style: Theme.of(context).textTheme.bodyMedium,
+                    ),
                   ],
                 );
               }
@@ -1275,6 +1671,10 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   manager,
+                  if (filterSummary != null) ...[
+                    const SizedBox(height: 12),
+                    filterSummary,
+                  ],
                   const SizedBox(height: 12),
                   LayoutBuilder(
                     builder: (context, constraints) {
@@ -1286,7 +1686,7 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
                         context,
                         headerMap,
                         visibleColumns,
-                        dados,
+                        filteredRows,
                       );
                       final overrides =
                           _columnWidthOverrides[_tipo] ??
@@ -1333,7 +1733,19 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
                         lockedColumns: lockedIndices,
                       );
                       final adjustedColumns = fittedMetrics.columnWidths;
-                      final tableWidth = fittedMetrics.totalWidth;
+                      final adjustedContentWidth = adjustedColumns.fold<double>(
+                        0,
+                        (sum, width) => sum + width,
+                      );
+                      final naturalTableWidth =
+                          adjustedContentWidth + spacingWidth;
+                      final viewportBaseline = availableViewportWidth.isFinite
+                          ? availableViewportWidth
+                          : naturalTableWidth;
+                      final tableWidth = math.max(
+                        naturalTableWidth,
+                        viewportBaseline,
+                      );
                       final rows = <Widget>[
                         _buildTableHeaderRow(
                           context,
@@ -1341,10 +1753,11 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
                           visibleColumns,
                           adjustedColumns,
                           tableWidth,
+                          dados,
                         ),
                         const SizedBox(height: 8),
                       ];
-                      for (final row in dados) {
+                      for (final row in filteredRows) {
                         if (row['__isGroup'] == true) {
                           rows.add(
                             _buildGroupHeaderRow(

--- a/lib/screens/dashboard/components/personnel_report_chart.dart
+++ b/lib/screens/dashboard/components/personnel_report_chart.dart
@@ -1020,7 +1020,13 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
           bottom: _cellVerticalPadding,
         );
 
-        return SizedBox.expand(
+        final resolvedHeight = constraints.maxHeight.isFinite &&
+                constraints.maxHeight > 0
+            ? constraints.maxHeight
+            : _headerRowMinHeight;
+        return SizedBox(
+          width: contentWidth,
+          height: resolvedHeight,
           child: Stack(
             fit: StackFit.expand,
             children: [

--- a/lib/screens/dashboard/components/personnel_report_chart.dart
+++ b/lib/screens/dashboard/components/personnel_report_chart.dart
@@ -1302,27 +1302,30 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
     final spacingCount = math.max(0, visibleColumns.length - 1);
     final spacingWidth = columnSpacing * spacingCount;
     final resolvedWidths = List<double>.from(columnWidths);
-    var intrinsicWidth = spacingWidth;
-    for (final width in resolvedWidths) {
-      intrinsicWidth += width;
-    }
-    var containerWidth = math.max(totalWidth, intrinsicWidth);
-    if (resolvedWidths.isNotEmpty) {
-      final diff = containerWidth - intrinsicWidth;
-      if (diff.abs() > 0.5) {
-        final lastIndex = resolvedWidths.length - 1;
-        final adjusted = (resolvedWidths[lastIndex] + diff).clamp(
-          0.0,
-          double.infinity,
-        );
-        resolvedWidths[lastIndex] = adjusted;
-        intrinsicWidth = spacingWidth;
-        for (final width in resolvedWidths) {
-          intrinsicWidth += width;
-        }
-        containerWidth = math.max(totalWidth, intrinsicWidth);
+
+    double computeContentWidth() {
+      var sum = spacingWidth;
+      for (final width in resolvedWidths) {
+        sum += width;
       }
+      return sum;
     }
+
+    var contentWidth = computeContentWidth();
+    var containerWidth = math.max(totalWidth, contentWidth);
+
+    if (resolvedWidths.isNotEmpty && contentWidth - containerWidth > 0.5) {
+      final overflow = contentWidth - containerWidth;
+      final lastIndex = resolvedWidths.length - 1;
+      resolvedWidths[lastIndex] = math.max(
+        0.0,
+        resolvedWidths[lastIndex] - overflow,
+      );
+      contentWidth = computeContentWidth();
+      containerWidth = math.max(totalWidth, contentWidth);
+    }
+
+    final fillerWidth = containerWidth - contentWidth;
 
     final cells = <Widget>[];
     for (var index = 0; index < visibleColumns.length; index++) {
@@ -1370,6 +1373,9 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
       if (index != visibleColumns.length - 1) {
         cells.add(SizedBox(width: columnSpacing));
       }
+    }
+    if (fillerWidth > 0.5) {
+      cells.add(SizedBox(width: fillerWidth));
     }
     return Container(
       width: containerWidth,
@@ -1424,27 +1430,30 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
     final spacingCount = math.max(0, visibleColumns.length - 1);
     final spacingWidth = columnSpacing * spacingCount;
     final resolvedWidths = List<double>.from(columnWidths);
-    var intrinsicWidth = spacingWidth;
-    for (final width in resolvedWidths) {
-      intrinsicWidth += width;
-    }
-    var containerWidth = math.max(totalWidth, intrinsicWidth);
-    if (resolvedWidths.isNotEmpty) {
-      final diff = containerWidth - intrinsicWidth;
-      if (diff.abs() > 0.5) {
-        final lastIndex = resolvedWidths.length - 1;
-        final adjusted = (resolvedWidths[lastIndex] + diff).clamp(
-          0.0,
-          double.infinity,
-        );
-        resolvedWidths[lastIndex] = adjusted;
-        intrinsicWidth = spacingWidth;
-        for (final width in resolvedWidths) {
-          intrinsicWidth += width;
-        }
-        containerWidth = math.max(totalWidth, intrinsicWidth);
+
+    double computeContentWidth() {
+      var sum = spacingWidth;
+      for (final width in resolvedWidths) {
+        sum += width;
       }
+      return sum;
     }
+
+    var contentWidth = computeContentWidth();
+    var containerWidth = math.max(totalWidth, contentWidth);
+
+    if (resolvedWidths.isNotEmpty && contentWidth - containerWidth > 0.5) {
+      final overflow = contentWidth - containerWidth;
+      final lastIndex = resolvedWidths.length - 1;
+      resolvedWidths[lastIndex] = math.max(
+        0.0,
+        resolvedWidths[lastIndex] - overflow,
+      );
+      contentWidth = computeContentWidth();
+      containerWidth = math.max(totalWidth, contentWidth);
+    }
+
+    final fillerWidth = containerWidth - contentWidth;
 
     final cells = <Widget>[];
     for (var index = 0; index < visibleColumns.length; index++) {
@@ -1470,6 +1479,9 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
       if (index != visibleColumns.length - 1) {
         cells.add(SizedBox(width: columnSpacing));
       }
+    }
+    if (fillerWidth > 0.5) {
+      cells.add(SizedBox(width: fillerWidth));
     }
     return Container(
       width: containerWidth,

--- a/lib/screens/dashboard/components/personnel_report_chart.dart
+++ b/lib/screens/dashboard/components/personnel_report_chart.dart
@@ -38,13 +38,20 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
     'operador': <String>[],
     'preparador': <String>[],
   };
+  final Map<String, Map<String, double>> _columnWidthOverrides = {
+    'operador': <String, double>{},
+    'preparador': <String, double>{},
+  };
+
+  String? _activeResizeColumn;
 
   static const double _columnSpacing = 12;
   static const double _cellHorizontalPadding = 12;
   static const double _cellVerticalPadding = 10;
   static const double _horizontalMargin = 12;
-  static const double _minColumnWidth = 56;
-  static const double _maxColumnWidth = 320;
+  static const double _minColumnWidth = 40;
+  static const double _maxColumnWidth = 480;
+  static const double _resizeHandleHitWidth = 16;
 
   static const Map<String, Map<String, String>> _headerConfigs = {
     'preparador': {
@@ -198,8 +205,13 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
     final allowedSet = allowedKeys.toSet();
     final order = _columnOrders.putIfAbsent(_tipo, () => <String>[]);
     final hidden = _hiddenColumns.putIfAbsent(_tipo, () => <String>{});
+    final overrides = _columnWidthOverrides.putIfAbsent(
+      _tipo,
+      () => <String, double>{},
+    );
     order.removeWhere((key) => !allowedSet.contains(key));
     hidden.removeWhere((key) => !allowedSet.contains(key));
+    overrides.removeWhere((key, _) => !allowedSet.contains(key));
     for (final key in allowedKeys) {
       if (!order.contains(key)) {
         order.add(key);
@@ -232,6 +244,42 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
     _ensureColumnState(headerMap);
     setState(() {
       _hiddenColumns[_tipo]!.remove(columnKey);
+    });
+  }
+
+  void _setColumnWidthOverride(String columnKey, double width) {
+    final overrides = _columnWidthOverrides[_tipo];
+    if (overrides == null) {
+      return;
+    }
+    final clamped = width.clamp(_minColumnWidth, _maxColumnWidth).toDouble();
+    final previous = overrides[columnKey];
+    if (previous != null && (previous - clamped).abs() <= 0.1) {
+      return;
+    }
+    setState(() {
+      overrides[columnKey] = clamped;
+    });
+  }
+
+  void _removeColumnWidthOverride(String columnKey) {
+    final overrides = _columnWidthOverrides[_tipo];
+    if (overrides == null) {
+      return;
+    }
+    if (!overrides.containsKey(columnKey)) {
+      if (_activeResizeColumn == columnKey) {
+        setState(() {
+          _activeResizeColumn = null;
+        });
+      }
+      return;
+    }
+    setState(() {
+      overrides.remove(columnKey);
+      if (_activeResizeColumn == columnKey) {
+        _activeResizeColumn = null;
+      }
     });
   }
 
@@ -340,8 +388,9 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
   _TableMetrics _fitColumnsToViewport(
     _TableMetrics metrics,
     int columnCount,
-    double viewportWidth,
-  ) {
+    double viewportWidth, {
+    Set<int> lockedColumns = const <int>{},
+  }) {
     if (columnCount <= 0 || metrics.columnWidths.isEmpty) {
       return const _TableMetrics(columnWidths: <double>[], totalWidth: 0);
     }
@@ -359,10 +408,10 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
     final minTotalWidth = minContentWidth + spacing;
 
     if (baseTotalWidth <= viewportWidth) {
-      if (adjusted.isNotEmpty) {
-        adjusted[adjusted.length - 1] += viewportWidth - baseTotalWidth;
-      }
-      return _TableMetrics(columnWidths: adjusted, totalWidth: viewportWidth);
+      return _TableMetrics(
+        columnWidths: adjusted,
+        totalWidth: math.max(baseTotalWidth, viewportWidth),
+      );
     }
 
     final targetTotalWidth = math.max(viewportWidth, minTotalWidth);
@@ -370,21 +419,22 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
     var remainingReduction = contentWidth - targetContentWidth;
 
     if (remainingReduction <= 0) {
-      if (adjusted.isNotEmpty) {
-        adjusted[adjusted.length - 1] += targetContentWidth - contentWidth;
-      }
       final newContent = adjusted.fold<double>(0, (sum, width) => sum + width);
+      final newTotal = newContent + spacing;
       return _TableMetrics(
         columnWidths: adjusted,
-        totalWidth: newContent + spacing,
+        totalWidth: math.max(newTotal, viewportWidth),
       );
     }
 
     const double tolerance = 0.1;
     while (remainingReduction > tolerance) {
       double adjustableSum = 0;
-      for (final width in adjusted) {
-        final available = width - _minColumnWidth;
+      for (var i = 0; i < adjusted.length; i++) {
+        if (lockedColumns.contains(i)) {
+          continue;
+        }
+        final available = adjusted[i] - _minColumnWidth;
         if (available > 0) {
           adjustableSum += available;
         }
@@ -402,6 +452,9 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
 
       var reducedThisPass = 0.0;
       for (var i = 0; i < adjusted.length; i++) {
+        if (lockedColumns.contains(i)) {
+          continue;
+        }
         final available = adjusted[i] - _minColumnWidth;
         if (available <= 0) continue;
         final share = remainingReduction * (available / adjustableSum);
@@ -421,18 +474,10 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
       0,
       (sum, width) => sum + width,
     );
-    final diff = targetContentWidth - adjustedContentWidth;
-    if (diff > tolerance && adjusted.isNotEmpty) {
-      adjusted[adjusted.length - 1] += diff;
-    }
-
-    final finalContentWidth = adjusted.fold<double>(
-      0,
-      (sum, width) => sum + width,
-    );
+    final finalTotalWidth = adjustedContentWidth + spacing;
     return _TableMetrics(
       columnWidths: adjusted,
-      totalWidth: finalContentWidth + spacing,
+      totalWidth: math.max(finalTotalWidth, viewportWidth),
     );
   }
 
@@ -587,6 +632,74 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
     );
   }
 
+  Widget _buildResizeHandle(
+    BuildContext context,
+    String columnKey,
+    double currentWidth,
+  ) {
+    final theme = Theme.of(context);
+    final isActive = _activeResizeColumn == columnKey;
+    final indicatorColor = isActive
+        ? theme.colorScheme.primary
+        : theme.dividerColor.withOpacity(0.6);
+    final overrides = _columnWidthOverrides[_tipo];
+    return Tooltip(
+      message:
+          'Arraste para redimensionar. Toque duas vezes para restaurar o tamanho automático.',
+      child: MouseRegion(
+        cursor: SystemMouseCursors.resizeColumn,
+        child: GestureDetector(
+          behavior: HitTestBehavior.translucent,
+          onHorizontalDragStart: (_) {
+            if (_activeResizeColumn != columnKey) {
+              setState(() {
+                _activeResizeColumn = columnKey;
+              });
+            }
+          },
+          onHorizontalDragUpdate: (details) {
+            final baseWidth = overrides?[columnKey] ?? currentWidth;
+            final nextWidth = (baseWidth + details.delta.dx).clamp(
+              _minColumnWidth,
+              _maxColumnWidth,
+            );
+            _setColumnWidthOverride(columnKey, nextWidth.toDouble());
+          },
+          onHorizontalDragEnd: (_) {
+            if (_activeResizeColumn == columnKey) {
+              setState(() {
+                _activeResizeColumn = null;
+              });
+            }
+          },
+          onHorizontalDragCancel: () {
+            if (_activeResizeColumn == columnKey) {
+              setState(() {
+                _activeResizeColumn = null;
+              });
+            }
+          },
+          onDoubleTap: () {
+            _removeColumnWidthOverride(columnKey);
+          },
+          child: SizedBox(
+            width: _resizeHandleHitWidth,
+            child: Center(
+              child: Container(
+                width: 2,
+                margin: const EdgeInsets.symmetric(vertical: 6),
+                decoration: BoxDecoration(
+                  color: indicatorColor,
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
   Widget _buildColumnManager(
     BuildContext context,
     Map<String, String> headerMap,
@@ -656,7 +769,7 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
         ),
         const SizedBox(height: 6),
         Text(
-          'Toque para ocultar e arraste os chips, soltando nas áreas destacadas para reordenar.',
+          'Toque para ocultar e arraste os chips, soltando nas áreas destacadas para reordenar. Arraste os divisores no cabeçalho para ajustar a largura das colunas.',
           style: theme.textTheme.bodySmall,
         ),
       ],
@@ -678,18 +791,36 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
     final cells = <Widget>[];
     for (var index = 0; index < visibleColumns.length; index++) {
       final columnKey = visibleColumns[index];
+      final width = columnWidths[index];
       cells.add(
-        Container(
-          width: columnWidths[index],
-          padding: const EdgeInsets.symmetric(
-            horizontal: _cellHorizontalPadding,
-            vertical: _cellVerticalPadding,
-          ),
-          alignment: Alignment.centerLeft,
-          child: _buildHeaderLabel(
-            columnKey,
-            headerMap[columnKey] ?? columnKey,
-            () => _hideColumn(columnKey),
+        SizedBox(
+          width: width,
+          child: Stack(
+            clipBehavior: Clip.none,
+            children: [
+              Positioned.fill(
+                child: Container(
+                  padding: EdgeInsetsDirectional.only(
+                    start: _cellHorizontalPadding,
+                    end: _cellHorizontalPadding + (_resizeHandleHitWidth / 2),
+                    top: _cellVerticalPadding,
+                    bottom: _cellVerticalPadding,
+                  ),
+                  alignment: Alignment.centerLeft,
+                  child: _buildHeaderLabel(
+                    columnKey,
+                    headerMap[columnKey] ?? columnKey,
+                    () => _hideColumn(columnKey),
+                  ),
+                ),
+              ),
+              Positioned(
+                top: 0,
+                bottom: 0,
+                right: 0,
+                child: _buildResizeHandle(context, columnKey, width),
+              ),
+            ],
           ),
         ),
       );
@@ -1157,12 +1288,38 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
                         visibleColumns,
                         dados,
                       );
+                      final overrides =
+                          _columnWidthOverrides[_tipo] ??
+                          const <String, double>{};
+                      final lockedIndices = <int>{};
+                      final overrideAdjusted = List<double>.from(
+                        metrics.columnWidths,
+                      );
+                      double overrideContentWidth = 0;
+                      for (var i = 0; i < overrideAdjusted.length; i++) {
+                        final overrideWidth = overrides[visibleColumns[i]];
+                        if (overrideWidth != null) {
+                          final clamped = overrideWidth
+                              .clamp(_minColumnWidth, _maxColumnWidth)
+                              .toDouble();
+                          overrideAdjusted[i] = clamped;
+                          lockedIndices.add(i);
+                        }
+                        overrideContentWidth += overrideAdjusted[i];
+                      }
+                      final spacingWidth =
+                          _columnSpacing *
+                          math.max(0, visibleColumns.length - 1);
+                      final manualMetrics = _TableMetrics(
+                        columnWidths: overrideAdjusted,
+                        totalWidth: overrideContentWidth + spacingWidth,
+                      );
                       final mediaWidth = MediaQuery.maybeOf(
                         context,
                       )?.size.width;
                       final rawViewportWidth = constraints.maxWidth.isFinite
                           ? constraints.maxWidth
-                          : (mediaWidth ?? metrics.totalWidth);
+                          : (mediaWidth ?? manualMetrics.totalWidth);
                       final availableViewportWidth = rawViewportWidth.isFinite
                           ? math.max(
                               0.0,
@@ -1170,9 +1327,10 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
                             )
                           : rawViewportWidth;
                       final fittedMetrics = _fitColumnsToViewport(
-                        metrics,
+                        manualMetrics,
                         visibleColumns.length,
                         availableViewportWidth,
+                        lockedColumns: lockedIndices,
                       );
                       final adjustedColumns = fittedMetrics.columnWidths;
                       final tableWidth = fittedMetrics.totalWidth;

--- a/lib/screens/dashboard/components/personnel_report_chart.dart
+++ b/lib/screens/dashboard/components/personnel_report_chart.dart
@@ -1370,13 +1370,6 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
       }
     }
 
-    final effectiveWidth = contentWidth > targetWidth
-        ? contentWidth
-        : targetWidth;
-    final fillerWidth = effectiveWidth - contentWidth > tolerance
-        ? effectiveWidth - contentWidth
-        : 0.0;
-
     final cells = <Widget>[];
     for (var index = 0; index < visibleColumns.length; index++) {
       final columnKey = visibleColumns[index];
@@ -1425,17 +1418,23 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
         cells.add(SizedBox(width: math.max(0, gapWidth)));
       }
     }
-    if (fillerWidth > tolerance) {
-      cells.add(SizedBox(width: fillerWidth));
-    }
+    final safeContentWidth = math.max(0.0, contentWidth);
+    final contentRow = Row(mainAxisSize: MainAxisSize.min, children: cells);
+    final containerWidth = math.max(targetWidth, safeContentWidth);
     return Container(
-      width: effectiveWidth,
+      width: containerWidth,
       decoration: BoxDecoration(
         color: background,
         borderRadius: BorderRadius.circular(8),
         border: Border.all(color: borderColor),
       ),
-      child: Row(mainAxisSize: MainAxisSize.min, children: cells),
+      child: Align(
+        alignment: AlignmentDirectional.centerStart,
+        child: SizedBox(
+          width: safeContentWidth,
+          child: contentRow,
+        ),
+      ),
     );
   }
 
@@ -1551,13 +1550,6 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
       }
     }
 
-    final effectiveWidth = contentWidth > targetWidth
-        ? contentWidth
-        : targetWidth;
-    final fillerWidth = effectiveWidth - contentWidth > tolerance
-        ? effectiveWidth - contentWidth
-        : 0.0;
-
     final cells = <Widget>[];
     for (var index = 0; index < visibleColumns.length; index++) {
       final columnKey = visibleColumns[index];
@@ -1586,18 +1578,24 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
         cells.add(SizedBox(width: math.max(0, gapWidth)));
       }
     }
-    if (fillerWidth > tolerance) {
-      cells.add(SizedBox(width: fillerWidth));
-    }
+    final safeContentWidth = math.max(0.0, contentWidth);
+    final contentRow = Row(mainAxisSize: MainAxisSize.min, children: cells);
+    final containerWidth = math.max(targetWidth, safeContentWidth);
     return Container(
-      width: effectiveWidth,
+      width: containerWidth,
       decoration: BoxDecoration(
         color: background,
         border: Border(
           bottom: BorderSide(color: theme.dividerColor.withOpacity(0.1)),
         ),
       ),
-      child: Row(mainAxisSize: MainAxisSize.min, children: cells),
+      child: Align(
+        alignment: AlignmentDirectional.centerStart,
+        child: SizedBox(
+          width: safeContentWidth,
+          child: contentRow,
+        ),
+      ),
     );
   }
 

--- a/lib/screens/dashboard/components/personnel_report_chart.dart
+++ b/lib/screens/dashboard/components/personnel_report_chart.dart
@@ -16,10 +16,15 @@ class PersonnelReportChart extends StatefulWidget {
 }
 
 class _TableMetrics {
-  const _TableMetrics({required this.columnWidths, required this.totalWidth});
+  const _TableMetrics({
+    required this.columnWidths,
+    required this.totalWidth,
+    required this.columnSpacing,
+  });
 
   final List<double> columnWidths;
   final double totalWidth;
+  final double columnSpacing;
 }
 
 class _FilterDialogResult {
@@ -30,6 +35,142 @@ class _FilterDialogResult {
 
   final Set<String> selectedValues;
   final bool clearFilter;
+}
+
+class _ColumnFilterDialog extends StatefulWidget {
+  const _ColumnFilterDialog({
+    required this.label,
+    required this.values,
+    required this.initialSelection,
+    required this.describeValue,
+  });
+
+  final String label;
+  final List<String> values;
+  final Set<String> initialSelection;
+  final String Function(String) describeValue;
+
+  @override
+  State<_ColumnFilterDialog> createState() => _ColumnFilterDialogState();
+}
+
+class _ColumnFilterDialogState extends State<_ColumnFilterDialog> {
+  late Set<String> _tempSelected;
+  late final ScrollController _scrollController;
+
+  @override
+  void initState() {
+    super.initState();
+    final baseSelection = widget.initialSelection.isEmpty
+        ? widget.values.toSet()
+        : Set<String>.from(widget.initialSelection);
+    baseSelection.retainAll(widget.values);
+    if (baseSelection.isEmpty && widget.values.isNotEmpty) {
+      _tempSelected = widget.values.toSet();
+    } else {
+      _tempSelected = baseSelection;
+    }
+    _scrollController = ScrollController();
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final allSelected =
+        widget.values.isNotEmpty &&
+        _tempSelected.length == widget.values.length;
+    final listHeight = math.min(320.0, 36.0 * widget.values.length + 12);
+    return AlertDialog(
+      title: Text('Filtrar ${widget.label}'),
+      content: SizedBox(
+        width: 340,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            CheckboxListTile(
+              dense: true,
+              value: allSelected,
+              onChanged: (value) {
+                setState(() {
+                  if (value == true) {
+                    _tempSelected = widget.values.toSet();
+                  } else {
+                    _tempSelected = <String>{};
+                  }
+                });
+              },
+              controlAffinity: ListTileControlAffinity.leading,
+              title: const Text('Selecionar tudo'),
+              contentPadding: EdgeInsets.zero,
+            ),
+            const Divider(height: 12),
+            SizedBox(
+              height: listHeight,
+              child: Scrollbar(
+                controller: _scrollController,
+                thumbVisibility: widget.values.length > 8,
+                child: ListView.builder(
+                  controller: _scrollController,
+                  itemCount: widget.values.length,
+                  itemBuilder: (context, index) {
+                    final value = widget.values[index];
+                    final checked = _tempSelected.contains(value);
+                    return CheckboxListTile(
+                      dense: true,
+                      value: checked,
+                      onChanged: (selected) {
+                        setState(() {
+                          if (selected == true) {
+                            _tempSelected.add(value);
+                          } else {
+                            _tempSelected.remove(value);
+                          }
+                        });
+                      },
+                      controlAffinity: ListTileControlAffinity.leading,
+                      title: Text(widget.describeValue(value)),
+                      contentPadding: EdgeInsets.zero,
+                    );
+                  },
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () {
+            Navigator.of(
+              context,
+            ).pop(const _FilterDialogResult(clearFilter: true));
+          },
+          child: const Text('Limpar filtro'),
+        ),
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancelar'),
+        ),
+        FilledButton(
+          onPressed: _tempSelected.isEmpty
+              ? null
+              : () {
+                  Navigator.of(context).pop(
+                    _FilterDialogResult(
+                      selectedValues: Set<String>.from(_tempSelected),
+                    ),
+                  );
+                },
+          child: const Text('Aplicar'),
+        ),
+      ],
+    );
+  }
 }
 
 class _PersonnelReportChartState extends State<PersonnelReportChart> {
@@ -58,8 +199,10 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
   };
 
   String? _activeResizeColumn;
+  final ScrollController _tableScrollController = ScrollController();
 
   static const double _columnSpacing = 12;
+  static const double _minColumnSpacing = 6;
   static const double _cellHorizontalPadding = 12;
   static const double _cellVerticalPadding = 10;
   static const double _headerRowMinHeight = 44;
@@ -371,98 +514,11 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
     final result = await showDialog<_FilterDialogResult>(
       context: context,
       builder: (context) {
-        var tempSelected = initialSelection.isEmpty
-            ? sortedValues.toSet()
-            : Set<String>.from(initialSelection);
-        return StatefulBuilder(
-          builder: (context, setModalState) {
-            final allSelected = tempSelected.length == sortedValues.length;
-            final listHeight = math.min(320.0, 36.0 * sortedValues.length + 12);
-            return AlertDialog(
-              title: Text('Filtrar $label'),
-              content: SizedBox(
-                width: 340,
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    CheckboxListTile(
-                      dense: true,
-                      value: allSelected,
-                      onChanged: (value) {
-                        setModalState(() {
-                          if (value == true) {
-                            tempSelected = sortedValues.toSet();
-                          } else {
-                            tempSelected = <String>{};
-                          }
-                        });
-                      },
-                      controlAffinity: ListTileControlAffinity.leading,
-                      title: const Text('Selecionar tudo'),
-                      contentPadding: EdgeInsets.zero,
-                    ),
-                    const Divider(height: 12),
-                    SizedBox(
-                      height: listHeight,
-                      child: Scrollbar(
-                        thumbVisibility: sortedValues.length > 8,
-                        child: ListView.builder(
-                          shrinkWrap: true,
-                          itemCount: sortedValues.length,
-                          itemBuilder: (context, index) {
-                            final value = sortedValues[index];
-                            final checked = tempSelected.contains(value);
-                            return CheckboxListTile(
-                              dense: true,
-                              value: checked,
-                              onChanged: (selected) {
-                                setModalState(() {
-                                  if (selected == true) {
-                                    tempSelected.add(value);
-                                  } else {
-                                    tempSelected.remove(value);
-                                  }
-                                });
-                              },
-                              controlAffinity: ListTileControlAffinity.leading,
-                              title: Text(_describeFilterValue(value)),
-                              contentPadding: EdgeInsets.zero,
-                            );
-                          },
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-              actions: [
-                TextButton(
-                  onPressed: () {
-                    Navigator.of(
-                      context,
-                    ).pop(const _FilterDialogResult(clearFilter: true));
-                  },
-                  child: const Text('Limpar filtro'),
-                ),
-                TextButton(
-                  onPressed: () => Navigator.of(context).pop(),
-                  child: const Text('Cancelar'),
-                ),
-                FilledButton(
-                  onPressed: tempSelected.isEmpty
-                      ? null
-                      : () {
-                          Navigator.of(context).pop(
-                            _FilterDialogResult(
-                              selectedValues: Set<String>.from(tempSelected),
-                            ),
-                          );
-                        },
-                  child: const Text('Aplicar'),
-                ),
-              ],
-            );
-          },
+        return _ColumnFilterDialog(
+          label: label,
+          values: sortedValues,
+          initialSelection: initialSelection,
+          describeValue: _describeFilterValue,
         );
       },
     );
@@ -487,6 +543,7 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
     _osCtrl.dispose();
     _partCtrl.dispose();
     _opCtrl.dispose();
+    _tableScrollController.dispose();
     super.dispose();
   }
 
@@ -672,12 +729,18 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
       widths.add(width);
     }
 
-    final spacing = _columnSpacing * math.max(0, visibleColumns.length - 1);
+    final spacingCount = math.max(0, visibleColumns.length - 1);
+    final spacing = _columnSpacing * spacingCount;
     final totalWidth = widths.fold<double>(
       spacing,
       (value, element) => value + element,
     );
-    return _TableMetrics(columnWidths: widths, totalWidth: totalWidth);
+    final appliedSpacing = spacingCount == 0 ? 0.0 : _columnSpacing;
+    return _TableMetrics(
+      columnWidths: widths,
+      totalWidth: totalWidth,
+      columnSpacing: appliedSpacing,
+    );
   }
 
   _TableMetrics _fitColumnsToViewport(
@@ -687,84 +750,103 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
     Set<int> lockedColumns = const <int>{},
   }) {
     if (columnCount <= 0 || metrics.columnWidths.isEmpty) {
-      return const _TableMetrics(columnWidths: <double>[], totalWidth: 0);
+      return _TableMetrics(
+        columnWidths: List<double>.from(metrics.columnWidths),
+        totalWidth: metrics.totalWidth,
+        columnSpacing: metrics.columnSpacing,
+      );
     }
 
-    final spacing = _columnSpacing * math.max(0, columnCount - 1);
+    final spacingCount = math.max(0, columnCount - 1);
     final adjusted = List<double>.from(metrics.columnWidths);
-    final contentWidth = adjusted.fold<double>(0, (sum, width) => sum + width);
-    final baseTotalWidth = contentWidth + spacing;
+    final baseSpacing = spacingCount == 0 ? 0.0 : metrics.columnSpacing;
+    var spacingWidth = baseSpacing * spacingCount;
+    var contentWidth = adjusted.fold<double>(0, (sum, width) => sum + width);
+    var totalWidth = contentWidth + spacingWidth;
 
     if (!viewportWidth.isFinite || viewportWidth <= 0) {
-      return _TableMetrics(columnWidths: adjusted, totalWidth: baseTotalWidth);
+      final spacingValue = spacingCount == 0 ? 0.0 : baseSpacing;
+      return _TableMetrics(
+        columnWidths: adjusted,
+        totalWidth: totalWidth,
+        columnSpacing: spacingValue,
+      );
     }
 
+    final minSpacingWidth = spacingCount * _minColumnSpacing;
     final minContentWidth = columnCount * _minColumnWidth;
-    final minTotalWidth = minContentWidth + spacing;
-
-    if (baseTotalWidth <= viewportWidth) {
-      return _TableMetrics(columnWidths: adjusted, totalWidth: baseTotalWidth);
-    }
-
-    final targetTotalWidth = math.max(viewportWidth, minTotalWidth);
-    final targetContentWidth = targetTotalWidth - spacing;
-    var remainingReduction = contentWidth - targetContentWidth;
+    final absoluteMinTotalWidth = minContentWidth + minSpacingWidth;
+    final targetTotalWidth = math.max(viewportWidth, absoluteMinTotalWidth);
+    var remainingReduction = totalWidth - targetTotalWidth;
 
     if (remainingReduction <= 0) {
-      final newContent = adjusted.fold<double>(0, (sum, width) => sum + width);
-      final newTotal = newContent + spacing;
-      return _TableMetrics(columnWidths: adjusted, totalWidth: newTotal);
+      final spacingValue = spacingCount == 0 ? 0.0 : baseSpacing;
+      return _TableMetrics(
+        columnWidths: adjusted,
+        totalWidth: totalWidth,
+        columnSpacing: spacingValue,
+      );
+    }
+
+    if (spacingCount > 0 && spacingWidth > minSpacingWidth) {
+      final spacingReduction = math.min(
+        remainingReduction,
+        spacingWidth - minSpacingWidth,
+      );
+      if (spacingReduction > 0) {
+        spacingWidth -= spacingReduction;
+        remainingReduction -= spacingReduction;
+      }
     }
 
     const double tolerance = 0.1;
-    while (remainingReduction > tolerance) {
-      double adjustableSum = 0;
-      for (var i = 0; i < adjusted.length; i++) {
-        if (lockedColumns.contains(i)) {
-          continue;
+    if (remainingReduction > tolerance) {
+      while (remainingReduction > tolerance) {
+        double adjustableSum = 0;
+        for (var i = 0; i < adjusted.length; i++) {
+          if (lockedColumns.contains(i)) {
+            continue;
+          }
+          final available = adjusted[i] - _minColumnWidth;
+          if (available > 0) {
+            adjustableSum += available;
+          }
         }
-        final available = adjusted[i] - _minColumnWidth;
-        if (available > 0) {
-          adjustableSum += available;
+        if (adjustableSum <= tolerance) {
+          break;
         }
-      }
-      if (adjustableSum <= 0) {
-        final actualContent = adjusted.fold<double>(
-          0,
-          (sum, width) => sum + width,
-        );
-        return _TableMetrics(
-          columnWidths: adjusted,
-          totalWidth: actualContent + spacing,
-        );
-      }
 
-      var reducedThisPass = 0.0;
-      for (var i = 0; i < adjusted.length; i++) {
-        if (lockedColumns.contains(i)) {
-          continue;
+        var reducedThisPass = 0.0;
+        for (var i = 0; i < adjusted.length; i++) {
+          if (lockedColumns.contains(i)) {
+            continue;
+          }
+          final available = adjusted[i] - _minColumnWidth;
+          if (available <= 0) continue;
+          final share = remainingReduction * (available / adjustableSum);
+          final reduction = math.min(available, share);
+          if (reduction <= 0) continue;
+          adjusted[i] -= reduction;
+          reducedThisPass += reduction;
         }
-        final available = adjusted[i] - _minColumnWidth;
-        if (available <= 0) continue;
-        final share = remainingReduction * (available / adjustableSum);
-        final reduction = math.min(available, share);
-        if (reduction <= 0) continue;
-        adjusted[i] -= reduction;
-        reducedThisPass += reduction;
-      }
 
-      if (reducedThisPass <= 0) {
-        break;
+        if (reducedThisPass <= tolerance) {
+          break;
+        }
+        remainingReduction -= reducedThisPass;
       }
-      remainingReduction -= reducedThisPass;
     }
 
-    final adjustedContentWidth = adjusted.fold<double>(
-      0,
-      (sum, width) => sum + width,
+    contentWidth = adjusted.fold<double>(0, (sum, width) => sum + width);
+    totalWidth = contentWidth + spacingWidth;
+    final spacingValue = spacingCount == 0
+        ? 0.0
+        : math.max(_minColumnSpacing, spacingWidth / spacingCount);
+    return _TableMetrics(
+      columnWidths: adjusted,
+      totalWidth: totalWidth,
+      columnSpacing: spacingValue,
     );
-    final finalTotalWidth = adjustedContentWidth + spacing;
-    return _TableMetrics(columnWidths: adjusted, totalWidth: finalTotalWidth);
   }
 
   Widget _buildColumnChip(
@@ -1143,6 +1225,7 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
     List<String> visibleColumns,
     List<double> columnWidths,
     double totalWidth,
+    double columnSpacing,
     List<Map<String, dynamic>> sourceRows,
   ) {
     final theme = Theme.of(context);
@@ -1194,7 +1277,7 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
         ),
       );
       if (index != visibleColumns.length - 1) {
-        cells.add(const SizedBox(width: _columnSpacing));
+        cells.add(SizedBox(width: columnSpacing));
       }
     }
     return Container(
@@ -1241,6 +1324,7 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
     List<String> visibleColumns,
     List<double> columnWidths,
     double totalWidth,
+    double columnSpacing,
     Color pauseColor,
   ) {
     final theme = Theme.of(context);
@@ -1268,7 +1352,7 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
         ),
       );
       if (index != visibleColumns.length - 1) {
-        cells.add(const SizedBox(width: _columnSpacing));
+        cells.add(SizedBox(width: columnSpacing));
       }
     }
     return Container(
@@ -1707,12 +1791,18 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
                         }
                         overrideContentWidth += overrideAdjusted[i];
                       }
-                      final spacingWidth =
-                          _columnSpacing *
-                          math.max(0, visibleColumns.length - 1);
+                      final spacingCount = math.max(
+                        0,
+                        visibleColumns.length - 1,
+                      );
+                      final baseSpacing = spacingCount == 0
+                          ? 0.0
+                          : metrics.columnSpacing;
+                      final manualSpacingWidth = baseSpacing * spacingCount;
                       final manualMetrics = _TableMetrics(
                         columnWidths: overrideAdjusted,
-                        totalWidth: overrideContentWidth + spacingWidth,
+                        totalWidth: overrideContentWidth + manualSpacingWidth,
+                        columnSpacing: baseSpacing,
                       );
                       final mediaWidth = MediaQuery.maybeOf(
                         context,
@@ -1733,12 +1823,10 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
                         lockedColumns: lockedIndices,
                       );
                       final adjustedColumns = fittedMetrics.columnWidths;
-                      final adjustedContentWidth = adjustedColumns.fold<double>(
-                        0,
-                        (sum, width) => sum + width,
-                      );
-                      final naturalTableWidth =
-                          adjustedContentWidth + spacingWidth;
+                      final columnSpacing = spacingCount == 0
+                          ? 0.0
+                          : fittedMetrics.columnSpacing;
+                      final naturalTableWidth = fittedMetrics.totalWidth;
                       final viewportBaseline = availableViewportWidth.isFinite
                           ? availableViewportWidth
                           : naturalTableWidth;
@@ -1753,6 +1841,7 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
                           visibleColumns,
                           adjustedColumns,
                           tableWidth,
+                          columnSpacing,
                           dados,
                         ),
                         const SizedBox(height: 8),
@@ -1775,12 +1864,16 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
                               visibleColumns,
                               adjustedColumns,
                               tableWidth,
+                              columnSpacing,
                               pauseColor,
                             ),
                           );
                         }
                       }
-                      return SingleChildScrollView(
+                      final needsHorizontalScroll =
+                          naturalTableWidth - viewportBaseline > 0.5;
+                      final tableView = SingleChildScrollView(
+                        controller: _tableScrollController,
                         scrollDirection: Axis.horizontal,
                         child: Padding(
                           padding: const EdgeInsets.symmetric(
@@ -1794,6 +1887,14 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
                             ),
                           ),
                         ),
+                      );
+                      return Scrollbar(
+                        controller: _tableScrollController,
+                        thumbVisibility: needsHorizontalScroll,
+                        trackVisibility: needsHorizontalScroll,
+                        notificationPredicate: (notification) =>
+                            notification.metrics.axis == Axis.horizontal,
+                        child: tableView,
                       );
                     },
                   ),

--- a/lib/screens/dashboard/components/personnel_report_chart.dart
+++ b/lib/screens/dashboard/components/personnel_report_chart.dart
@@ -1299,10 +1299,35 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
       alpha: 0.4,
     );
     final borderColor = theme.dividerColor.withOpacity(0.18);
+    final spacingCount = math.max(0, visibleColumns.length - 1);
+    final spacingWidth = columnSpacing * spacingCount;
+    final resolvedWidths = List<double>.from(columnWidths);
+    var intrinsicWidth = spacingWidth;
+    for (final width in resolvedWidths) {
+      intrinsicWidth += width;
+    }
+    var containerWidth = math.max(totalWidth, intrinsicWidth);
+    if (resolvedWidths.isNotEmpty) {
+      final diff = containerWidth - intrinsicWidth;
+      if (diff.abs() > 0.5) {
+        final lastIndex = resolvedWidths.length - 1;
+        final adjusted = (resolvedWidths[lastIndex] + diff).clamp(
+          0.0,
+          double.infinity,
+        );
+        resolvedWidths[lastIndex] = adjusted;
+        intrinsicWidth = spacingWidth;
+        for (final width in resolvedWidths) {
+          intrinsicWidth += width;
+        }
+        containerWidth = math.max(totalWidth, intrinsicWidth);
+      }
+    }
+
     final cells = <Widget>[];
     for (var index = 0; index < visibleColumns.length; index++) {
       final columnKey = visibleColumns[index];
-      final width = columnWidths[index];
+      final width = resolvedWidths[index];
       cells.add(
         SizedBox(
           width: width,
@@ -1347,7 +1372,7 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
       }
     }
     return Container(
-      width: totalWidth,
+      width: containerWidth,
       decoration: BoxDecoration(
         color: background,
         borderRadius: BorderRadius.circular(8),
@@ -1396,6 +1421,31 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
     final theme = Theme.of(context);
     final isPause = row['evento'] == 'pausa_jornada';
     final background = isPause ? pauseColor : null;
+    final spacingCount = math.max(0, visibleColumns.length - 1);
+    final spacingWidth = columnSpacing * spacingCount;
+    final resolvedWidths = List<double>.from(columnWidths);
+    var intrinsicWidth = spacingWidth;
+    for (final width in resolvedWidths) {
+      intrinsicWidth += width;
+    }
+    var containerWidth = math.max(totalWidth, intrinsicWidth);
+    if (resolvedWidths.isNotEmpty) {
+      final diff = containerWidth - intrinsicWidth;
+      if (diff.abs() > 0.5) {
+        final lastIndex = resolvedWidths.length - 1;
+        final adjusted = (resolvedWidths[lastIndex] + diff).clamp(
+          0.0,
+          double.infinity,
+        );
+        resolvedWidths[lastIndex] = adjusted;
+        intrinsicWidth = spacingWidth;
+        for (final width in resolvedWidths) {
+          intrinsicWidth += width;
+        }
+        containerWidth = math.max(totalWidth, intrinsicWidth);
+      }
+    }
+
     final cells = <Widget>[];
     for (var index = 0; index < visibleColumns.length; index++) {
       final columnKey = visibleColumns[index];
@@ -1403,7 +1453,7 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
       final text = value == null ? '' : value.toString();
       cells.add(
         Container(
-          width: columnWidths[index],
+          width: resolvedWidths[index],
           padding: const EdgeInsets.symmetric(
             horizontal: _cellHorizontalPadding,
             vertical: _cellVerticalPadding,
@@ -1422,7 +1472,7 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
       }
     }
     return Container(
-      width: totalWidth,
+      width: containerWidth,
       decoration: BoxDecoration(
         color: background,
         border: Border(
@@ -1892,7 +1942,11 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
                       final columnSpacing = spacingCount == 0
                           ? 0.0
                           : fittedMetrics.columnSpacing;
-                      final naturalTableWidth = fittedMetrics.totalWidth;
+                      final spacingWidth = columnSpacing * spacingCount;
+                      final naturalTableWidth = adjustedColumns.fold<double>(
+                        spacingWidth,
+                        (sum, width) => sum + width,
+                      );
                       final viewportBaseline = availableViewportWidth.isFinite
                           ? availableViewportWidth
                           : naturalTableWidth;

--- a/lib/screens/dashboard/components/personnel_report_chart.dart
+++ b/lib/screens/dashboard/components/personnel_report_chart.dart
@@ -1370,8 +1370,11 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
       }
     }
 
-    final fillerWidth = targetWidth - contentWidth > tolerance
-        ? targetWidth - contentWidth
+    final effectiveWidth = contentWidth > targetWidth
+        ? contentWidth
+        : targetWidth;
+    final fillerWidth = effectiveWidth - contentWidth > tolerance
+        ? effectiveWidth - contentWidth
         : 0.0;
 
     final cells = <Widget>[];
@@ -1426,7 +1429,7 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
       cells.add(SizedBox(width: fillerWidth));
     }
     return Container(
-      width: targetWidth,
+      width: effectiveWidth,
       decoration: BoxDecoration(
         color: background,
         borderRadius: BorderRadius.circular(8),
@@ -1548,8 +1551,11 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
       }
     }
 
-    final fillerWidth = targetWidth - contentWidth > tolerance
-        ? targetWidth - contentWidth
+    final effectiveWidth = contentWidth > targetWidth
+        ? contentWidth
+        : targetWidth;
+    final fillerWidth = effectiveWidth - contentWidth > tolerance
+        ? effectiveWidth - contentWidth
         : 0.0;
 
     final cells = <Widget>[];
@@ -1584,7 +1590,7 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
       cells.add(SizedBox(width: fillerWidth));
     }
     return Container(
-      width: targetWidth,
+      width: effectiveWidth,
       decoration: BoxDecoration(
         color: background,
         border: Border(

--- a/lib/screens/dashboard/components/personnel_report_chart.dart
+++ b/lib/screens/dashboard/components/personnel_report_chart.dart
@@ -1312,20 +1312,37 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
     }
 
     var contentWidth = computeContentWidth();
-    var containerWidth = math.max(totalWidth, contentWidth);
+    final targetWidth = totalWidth;
+    const tolerance = 0.5;
 
-    if (resolvedWidths.isNotEmpty && contentWidth - containerWidth > 0.5) {
-      final overflow = contentWidth - containerWidth;
-      final lastIndex = resolvedWidths.length - 1;
-      resolvedWidths[lastIndex] = math.max(
-        0.0,
-        resolvedWidths[lastIndex] - overflow,
-      );
+    if (resolvedWidths.isNotEmpty && contentWidth - targetWidth > tolerance) {
+      var overflow = contentWidth - targetWidth;
+      for (var index = resolvedWidths.length - 1;
+          index >= 0 && overflow > tolerance;
+          index--) {
+        final available = resolvedWidths[index] - _minColumnWidth;
+        if (available <= 0) {
+          continue;
+        }
+        final reduction = math.min(available, overflow);
+        resolvedWidths[index] -= reduction;
+        overflow -= reduction;
+      }
+
+      if (overflow > tolerance) {
+        final lastIndex = resolvedWidths.length - 1;
+        resolvedWidths[lastIndex] = math.max(
+          0.0,
+          resolvedWidths[lastIndex] - overflow,
+        );
+      }
+
       contentWidth = computeContentWidth();
-      containerWidth = math.max(totalWidth, contentWidth);
     }
 
-    final fillerWidth = containerWidth - contentWidth;
+    final fillerWidth = targetWidth - contentWidth > tolerance
+        ? targetWidth - contentWidth
+        : 0.0;
 
     final cells = <Widget>[];
     for (var index = 0; index < visibleColumns.length; index++) {
@@ -1378,7 +1395,7 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
       cells.add(SizedBox(width: fillerWidth));
     }
     return Container(
-      width: containerWidth,
+      width: targetWidth,
       decoration: BoxDecoration(
         color: background,
         borderRadius: BorderRadius.circular(8),
@@ -1440,20 +1457,37 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
     }
 
     var contentWidth = computeContentWidth();
-    var containerWidth = math.max(totalWidth, contentWidth);
+    final targetWidth = totalWidth;
+    const tolerance = 0.5;
 
-    if (resolvedWidths.isNotEmpty && contentWidth - containerWidth > 0.5) {
-      final overflow = contentWidth - containerWidth;
-      final lastIndex = resolvedWidths.length - 1;
-      resolvedWidths[lastIndex] = math.max(
-        0.0,
-        resolvedWidths[lastIndex] - overflow,
-      );
+    if (resolvedWidths.isNotEmpty && contentWidth - targetWidth > tolerance) {
+      var overflow = contentWidth - targetWidth;
+      for (var index = resolvedWidths.length - 1;
+          index >= 0 && overflow > tolerance;
+          index--) {
+        final available = resolvedWidths[index] - _minColumnWidth;
+        if (available <= 0) {
+          continue;
+        }
+        final reduction = math.min(available, overflow);
+        resolvedWidths[index] -= reduction;
+        overflow -= reduction;
+      }
+
+      if (overflow > tolerance) {
+        final lastIndex = resolvedWidths.length - 1;
+        resolvedWidths[lastIndex] = math.max(
+          0.0,
+          resolvedWidths[lastIndex] - overflow,
+        );
+      }
+
       contentWidth = computeContentWidth();
-      containerWidth = math.max(totalWidth, contentWidth);
     }
 
-    final fillerWidth = containerWidth - contentWidth;
+    final fillerWidth = targetWidth - contentWidth > tolerance
+        ? targetWidth - contentWidth
+        : 0.0;
 
     final cells = <Widget>[];
     for (var index = 0; index < visibleColumns.length; index++) {
@@ -1484,7 +1518,7 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
       cells.add(SizedBox(width: fillerWidth));
     }
     return Container(
-      width: containerWidth,
+      width: targetWidth,
       decoration: BoxDecoration(
         color: background,
         border: Border(

--- a/lib/screens/dashboard/components/personnel_report_chart.dart
+++ b/lib/screens/dashboard/components/personnel_report_chart.dart
@@ -1300,13 +1300,18 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
     );
     final borderColor = theme.dividerColor.withOpacity(0.18);
     final spacingCount = math.max(0, visibleColumns.length - 1);
-    final spacingWidth = columnSpacing * spacingCount;
+    final gapWidths = spacingCount > 0
+        ? List<double>.filled(spacingCount, columnSpacing)
+        : const <double>[];
     final resolvedWidths = List<double>.from(columnWidths);
 
     double computeContentWidth() {
-      var sum = spacingWidth;
+      var sum = 0.0;
       for (final width in resolvedWidths) {
         sum += width;
+      }
+      for (final gap in gapWidths) {
+        sum += gap;
       }
       return sum;
     }
@@ -1317,27 +1322,47 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
 
     if (resolvedWidths.isNotEmpty && contentWidth - targetWidth > tolerance) {
       var overflow = contentWidth - targetWidth;
-      for (var index = resolvedWidths.length - 1;
-          index >= 0 && overflow > tolerance;
-          index--) {
-        final available = resolvedWidths[index] - _minColumnWidth;
-        if (available <= 0) {
-          continue;
+
+      if (gapWidths.isNotEmpty) {
+        for (var index = gapWidths.length - 1;
+            index >= 0 && overflow > tolerance;
+            index--) {
+          final available = gapWidths[index];
+          if (available <= 0) {
+            continue;
+          }
+          final reduction = math.min(available, overflow);
+          gapWidths[index] -= reduction;
+          overflow -= reduction;
         }
-        final reduction = math.min(available, overflow);
-        resolvedWidths[index] -= reduction;
-        overflow -= reduction;
+        contentWidth = computeContentWidth();
+        overflow = contentWidth - targetWidth;
       }
 
       if (overflow > tolerance) {
+        for (var index = resolvedWidths.length - 1;
+            index >= 0 && overflow > tolerance;
+            index--) {
+          final available = resolvedWidths[index] - _minColumnWidth;
+          if (available <= 0) {
+            continue;
+          }
+          final reduction = math.min(available, overflow);
+          resolvedWidths[index] -= reduction;
+          overflow -= reduction;
+        }
+        contentWidth = computeContentWidth();
+        overflow = contentWidth - targetWidth;
+      }
+
+      if (overflow > tolerance && resolvedWidths.isNotEmpty) {
         final lastIndex = resolvedWidths.length - 1;
         resolvedWidths[lastIndex] = math.max(
           0.0,
           resolvedWidths[lastIndex] - overflow,
         );
+        contentWidth = computeContentWidth();
       }
-
-      contentWidth = computeContentWidth();
     }
 
     final fillerWidth = targetWidth - contentWidth > tolerance
@@ -1388,7 +1413,8 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
         ),
       );
       if (index != visibleColumns.length - 1) {
-        cells.add(SizedBox(width: columnSpacing));
+        final gapWidth = gapWidths.isNotEmpty ? gapWidths[index] : columnSpacing;
+        cells.add(SizedBox(width: math.max(0, gapWidth)));
       }
     }
     if (fillerWidth > 0.5) {
@@ -1445,13 +1471,18 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
     final isPause = row['evento'] == 'pausa_jornada';
     final background = isPause ? pauseColor : null;
     final spacingCount = math.max(0, visibleColumns.length - 1);
-    final spacingWidth = columnSpacing * spacingCount;
+    final gapWidths = spacingCount > 0
+        ? List<double>.filled(spacingCount, columnSpacing)
+        : const <double>[];
     final resolvedWidths = List<double>.from(columnWidths);
 
     double computeContentWidth() {
-      var sum = spacingWidth;
+      var sum = 0.0;
       for (final width in resolvedWidths) {
         sum += width;
+      }
+      for (final gap in gapWidths) {
+        sum += gap;
       }
       return sum;
     }
@@ -1462,27 +1493,47 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
 
     if (resolvedWidths.isNotEmpty && contentWidth - targetWidth > tolerance) {
       var overflow = contentWidth - targetWidth;
-      for (var index = resolvedWidths.length - 1;
-          index >= 0 && overflow > tolerance;
-          index--) {
-        final available = resolvedWidths[index] - _minColumnWidth;
-        if (available <= 0) {
-          continue;
+
+      if (gapWidths.isNotEmpty) {
+        for (var index = gapWidths.length - 1;
+            index >= 0 && overflow > tolerance;
+            index--) {
+          final available = gapWidths[index];
+          if (available <= 0) {
+            continue;
+          }
+          final reduction = math.min(available, overflow);
+          gapWidths[index] -= reduction;
+          overflow -= reduction;
         }
-        final reduction = math.min(available, overflow);
-        resolvedWidths[index] -= reduction;
-        overflow -= reduction;
+        contentWidth = computeContentWidth();
+        overflow = contentWidth - targetWidth;
       }
 
       if (overflow > tolerance) {
+        for (var index = resolvedWidths.length - 1;
+            index >= 0 && overflow > tolerance;
+            index--) {
+          final available = resolvedWidths[index] - _minColumnWidth;
+          if (available <= 0) {
+            continue;
+          }
+          final reduction = math.min(available, overflow);
+          resolvedWidths[index] -= reduction;
+          overflow -= reduction;
+        }
+        contentWidth = computeContentWidth();
+        overflow = contentWidth - targetWidth;
+      }
+
+      if (overflow > tolerance && resolvedWidths.isNotEmpty) {
         final lastIndex = resolvedWidths.length - 1;
         resolvedWidths[lastIndex] = math.max(
           0.0,
           resolvedWidths[lastIndex] - overflow,
         );
+        contentWidth = computeContentWidth();
       }
-
-      contentWidth = computeContentWidth();
     }
 
     final fillerWidth = targetWidth - contentWidth > tolerance
@@ -1511,7 +1562,8 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
         ),
       );
       if (index != visibleColumns.length - 1) {
-        cells.add(SizedBox(width: columnSpacing));
+        final gapWidth = gapWidths.isNotEmpty ? gapWidths[index] : columnSpacing;
+        cells.add(SizedBox(width: math.max(0, gapWidth)));
       }
     }
     if (fillerWidth > 0.5) {

--- a/lib/screens/dashboard/components/personnel_report_chart.dart
+++ b/lib/screens/dashboard/components/personnel_report_chart.dart
@@ -21,6 +21,42 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
   String _tipo = 'operador';
   String _modo = 'os';
   Future<List<Map<String, dynamic>>>? _future;
+  final Map<String, Set<String>> _hiddenColumns = {
+    'operador': <String>{},
+    'preparador': <String>{},
+  };
+  final Map<String, List<String>> _columnOrders = {
+    'operador': <String>[],
+    'preparador': <String>[],
+  };
+
+  static const Map<String, Map<String, String>> _headerConfigs = {
+    'preparador': {
+      'os': 'OS',
+      're_liberacao': 'RE Liberação',
+      're_finalizacao': 'RE Finalização',
+      'partnumber': 'Partnumber',
+      'maquina': 'Máquina',
+      'faixa_texto': 'Faixa',
+      'created_at': 'Horário Inicial',
+      'medicao': 'Medição Inicial',
+      'medicao_final': 'Medição Final',
+      'created_at_final': 'Horário Final',
+    },
+    'operador': {
+      'os': 'OS',
+      're_operador': 'RE',
+      'created_at': 'Início',
+      'retorno_at': 'Retorno',
+      'partnumber': 'Partnumber',
+      'maquina': 'Máquina',
+      'titulo': 'Título',
+      'instrumento': 'Instrumento',
+      'faixa_texto': 'Faixa',
+      'status': 'Status',
+      'motivo': 'Motivo',
+    },
+  };
 
   DateTime? _parseDateTime(dynamic value) {
     final raw = value?.toString().trim();
@@ -73,31 +109,62 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
     List<Map<String, dynamic>> rows,
   ) {
     final result = <Map<String, dynamic>>[];
-    DateTime? lastGroup;
-    for (final row in rows) {
+    var index = 0;
+    while (index < rows.length) {
+      final row = rows[index];
       final dt = row['__dt'] as DateTime?;
-      if (dt != null) {
-        final normalized = DateTime(
-          dt.year,
-          dt.month,
-          dt.day,
-          dt.hour,
-          dt.minute,
-          dt.second,
-        );
-        if (lastGroup == null || normalized != lastGroup) {
-          final label = DateFormat('dd/MM/yyyy HH:mm:ss').format(dt);
-          result.add({
-            '__isGroup': true,
-            '__dt': normalized,
-            'created_at': label,
-          });
-          lastGroup = normalized;
-        }
-      } else {
-        lastGroup = null;
+      if (dt == null) {
+        result.add(row);
+        index++;
+        continue;
       }
-      result.add(row);
+
+      DateTime normalize(DateTime value) => DateTime(
+        value.year,
+        value.month,
+        value.day,
+        value.hour,
+        value.minute,
+        value.second,
+      );
+
+      final normalized = normalize(dt);
+      final groupRows = <Map<String, dynamic>>[];
+      while (index < rows.length) {
+        final current = rows[index];
+        final currentDt = current['__dt'] as DateTime?;
+        if (currentDt == null) {
+          break;
+        }
+        if (normalize(currentDt) != normalized) {
+          break;
+        }
+        groupRows.add(current);
+        index++;
+      }
+
+      result.add({
+        '__isGroup': true,
+        '__dt': normalized,
+        'created_at': DateFormat(
+          'dd/MM/yyyy HH:mm:ss',
+        ).format(groupRows.first['__dt'] as DateTime),
+      });
+
+      final pauseRows = <Map<String, dynamic>>[];
+      final otherRows = <Map<String, dynamic>>[];
+      for (final item in groupRows) {
+        final event = item['evento']?.toString();
+        if (event == 'pausa_jornada') {
+          pauseRows.add(item);
+        } else {
+          otherRows.add(item);
+        }
+      }
+
+      result
+        ..addAll(pauseRows)
+        ..addAll(otherRows);
     }
     return result;
   }
@@ -108,6 +175,322 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
     _partCtrl.dispose();
     _opCtrl.dispose();
     super.dispose();
+  }
+
+  void _ensureColumnState(Map<String, String> headerMap) {
+    final allowedKeys = headerMap.keys.toList(growable: false);
+    final allowedSet = allowedKeys.toSet();
+    final order = _columnOrders.putIfAbsent(_tipo, () => <String>[]);
+    final hidden = _hiddenColumns.putIfAbsent(_tipo, () => <String>{});
+    order.removeWhere((key) => !allowedSet.contains(key));
+    hidden.removeWhere((key) => !allowedSet.contains(key));
+    for (final key in allowedKeys) {
+      if (!order.contains(key)) {
+        order.add(key);
+      }
+    }
+  }
+
+  void _hideColumn(String columnKey) {
+    final headerMap = _headerConfigs[_tipo] ?? const {};
+    _ensureColumnState(headerMap);
+    final hidden = _hiddenColumns[_tipo]!;
+    final order = _columnOrders[_tipo]!;
+    final visibleCount = order.where((key) => !hidden.contains(key)).length;
+    if (visibleCount <= 1) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Mantenha ao menos uma coluna visível.'),
+          duration: Duration(seconds: 2),
+        ),
+      );
+      return;
+    }
+    setState(() {
+      hidden.add(columnKey);
+    });
+  }
+
+  void _showColumn(String columnKey) {
+    final headerMap = _headerConfigs[_tipo] ?? const {};
+    _ensureColumnState(headerMap);
+    setState(() {
+      _hiddenColumns[_tipo]!.remove(columnKey);
+    });
+  }
+
+  void _reorderVisibleColumn(String columnKey, int dropIndex) {
+    final headerMap = _headerConfigs[_tipo] ?? const {};
+    _ensureColumnState(headerMap);
+    final hidden = _hiddenColumns[_tipo]!;
+    if (hidden.contains(columnKey)) {
+      return;
+    }
+    final order = _columnOrders[_tipo]!;
+    final visible = [
+      for (final key in order)
+        if (!hidden.contains(key)) key,
+    ];
+    if (visible.length < 2) {
+      return;
+    }
+    final oldIndex = visible.indexOf(columnKey);
+    if (oldIndex == -1) {
+      return;
+    }
+    if (dropIndex < 0 || dropIndex > visible.length) {
+      return;
+    }
+    var adjustedIndex = dropIndex;
+    if (adjustedIndex == oldIndex || adjustedIndex == oldIndex + 1) {
+      return;
+    }
+    final working = List<String>.from(visible);
+    final moved = working.removeAt(oldIndex);
+    if (adjustedIndex > oldIndex) {
+      adjustedIndex -= 1;
+    }
+    working.insert(adjustedIndex, moved);
+    final hiddenOrder = [
+      for (final key in order)
+        if (hidden.contains(key)) key,
+    ];
+    setState(() {
+      order
+        ..clear()
+        ..addAll(working)
+        ..addAll(hiddenOrder);
+    });
+  }
+
+  Widget _buildColumnChip(
+    BuildContext context,
+    String columnKey,
+    String label, {
+    VoidCallback? onPressed,
+    bool enableTooltip = true,
+    bool showDelete = true,
+  }) {
+    final chip = InputChip(
+      avatar: const Icon(Icons.drag_indicator, size: 18),
+      label: Text(label, overflow: TextOverflow.ellipsis),
+      visualDensity: VisualDensity.compact,
+      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+      onPressed: onPressed,
+      onDeleted: showDelete ? onPressed : null,
+      deleteIcon: showDelete
+          ? const Icon(Icons.visibility_off_outlined, size: 18)
+          : null,
+      deleteButtonTooltipMessage: showDelete ? 'Ocultar coluna' : null,
+    );
+    if (!enableTooltip) {
+      return chip;
+    }
+    final message = showDelete
+        ? 'Toque para ocultar ou arraste para reordenar'
+        : 'Arraste para reordenar';
+    return Tooltip(message: message, child: chip);
+  }
+
+  Widget _buildReorderableChip(
+    BuildContext context,
+    Map<String, String> headerMap,
+    String columnKey,
+  ) {
+    final label = headerMap[columnKey] ?? columnKey;
+    Widget wrapPointer(Widget child) {
+      return MouseRegion(
+        cursor: SystemMouseCursors.grab,
+        child: child,
+      );
+    }
+
+    return Draggable<String>(
+      data: columnKey,
+      dragAnchorStrategy: pointerDragAnchorStrategy,
+      feedback: Material(
+        elevation: 6,
+        color: Colors.transparent,
+        child: _buildColumnChip(
+          context,
+          columnKey,
+          label,
+          enableTooltip: false,
+          showDelete: false,
+        ),
+      ),
+      childWhenDragging: wrapPointer(
+        Opacity(
+          opacity: 0.5,
+          child: IgnorePointer(
+            child: _buildColumnChip(
+              context,
+              columnKey,
+              label,
+              enableTooltip: false,
+            ),
+          ),
+        ),
+      ),
+      child: wrapPointer(
+        _buildColumnChip(
+          context,
+          columnKey,
+          label,
+          onPressed: () => _hideColumn(columnKey),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildInsertionTarget(BuildContext context, int index) {
+    final theme = Theme.of(context);
+    return DragTarget<String>(
+      onWillAcceptWithDetails: (details) {
+        final order = _columnOrders[_tipo];
+        if (order == null || !order.contains(details.data)) {
+          return false;
+        }
+        final hidden = _hiddenColumns[_tipo];
+        if (hidden != null && hidden.contains(details.data)) {
+          return false;
+        }
+        return true;
+      },
+      onAcceptWithDetails: (details) {
+        _reorderVisibleColumn(details.data, index);
+      },
+      builder: (context, candidate, rejected) {
+        final isActive = candidate.isNotEmpty;
+        return AnimatedContainer(
+          duration: const Duration(milliseconds: 120),
+          width: 14,
+          height: 42,
+          margin: const EdgeInsets.symmetric(horizontal: 2, vertical: 4),
+          decoration: BoxDecoration(
+            color: isActive
+                ? theme.colorScheme.primary.withValues(alpha: 0.18)
+                : theme.colorScheme.surfaceContainerHighest.withValues(
+                    alpha: 0.08,
+                  ),
+            borderRadius: BorderRadius.circular(6),
+            border: Border.all(
+              color: isActive
+                  ? theme.colorScheme.primary
+                  : theme.colorScheme.outline.withValues(alpha: 0.35),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildHeaderLabel(
+    String columnKey,
+    String label,
+    VoidCallback onHide,
+  ) {
+    return Tooltip(
+      message: 'Toque para ocultar',
+      child: InkWell(
+        onTap: onHide,
+        borderRadius: BorderRadius.circular(6),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Flexible(
+                child: Text(
+                  label,
+                  style: const TextStyle(fontSize: 12),
+                  overflow: TextOverflow.ellipsis,
+                  maxLines: 1,
+                ),
+              ),
+              const SizedBox(width: 4),
+              const Icon(Icons.visibility_off_outlined, size: 16),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildColumnManager(
+    BuildContext context,
+    Map<String, String> headerMap,
+    List<String> visibleColumns,
+    List<String> hiddenColumns,
+  ) {
+    if (headerMap.isEmpty) {
+      return const SizedBox.shrink();
+    }
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (hiddenColumns.isNotEmpty) ...[
+          Text('Colunas ocultas', style: theme.textTheme.labelMedium),
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: hiddenColumns.map((key) {
+              final label = headerMap[key] ?? key;
+              return Tooltip(
+                message: 'Mostrar coluna',
+                child: ActionChip(
+                  avatar: const Icon(Icons.visibility_outlined, size: 18),
+                  label: Text(label),
+                  onPressed: () => _showColumn(key),
+                ),
+              );
+            }).toList(),
+          ),
+          const SizedBox(height: 12),
+        ],
+        Text('Colunas visíveis', style: theme.textTheme.labelMedium),
+        const SizedBox(height: 8),
+        Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          crossAxisAlignment: WrapCrossAlignment.center,
+          children: [
+            for (var i = 0; i < visibleColumns.length; i++)
+              Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  _buildInsertionTarget(context, i),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 2),
+                    child: KeyedSubtree(
+                      key: ValueKey('visible_${visibleColumns[i]}'),
+                      child: _buildReorderableChip(
+                        context,
+                        headerMap,
+                        visibleColumns[i],
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            if (visibleColumns.isNotEmpty)
+              Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  _buildInsertionTarget(context, visibleColumns.length),
+                ],
+              ),
+          ],
+        ),
+        const SizedBox(height: 6),
+        Text(
+          'Toque para ocultar e arraste os chips, soltando nas áreas destacadas para reordenar.',
+          style: theme.textTheme.bodySmall,
+        ),
+      ],
+    );
   }
 
   void _buscar() {
@@ -439,95 +822,127 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
               if (dados.isEmpty) {
                 return const Text('Nenhum dado encontrado.');
               }
-              final headerMap = _tipo == 'preparador'
-                  ? const {
-                      'os': 'OS',
-                      're_liberacao': 'RE Liberação',
-                      're_finalizacao': 'RE Finalização',
-                      'partnumber': 'Partnumber',
-                      'maquina': 'Máquina',
-                      'faixa_texto': 'Faixa',
-                      'created_at': 'Horário Inicial',
-                      'medicao': 'Medição Inicial',
-                      'medicao_final': 'Medição Final',
-                      'created_at_final': 'Horário Final',
-                    }
-                  : const {
-                      'os': 'OS',
-                      're_operador': 'RE',
-                      'created_at': 'Início',
-                      'retorno_at': 'Retorno',
-                      'partnumber': 'Partnumber',
-                      'maquina': 'Máquina',
-                      'titulo': 'Título',
-                      'instrumento': 'Instrumento',
-                      'faixa_texto': 'Faixa',
-                      'status': 'Status',
-                      'motivo': 'Motivo',
-                    };
-              final headers = headerMap.keys.toList();
-              return LayoutBuilder(
-                builder: (context, constraints) {
-                  final theme = Theme.of(context);
-                  final groupColor = theme.colorScheme.surfaceVariant
-                      .withOpacity(0.25);
-                  final pauseColor = Colors.orange.withOpacity(0.12);
-                  return SingleChildScrollView(
-                    scrollDirection: Axis.horizontal,
-                    child: ConstrainedBox(
-                      constraints: BoxConstraints(
-                        minWidth: constraints.maxWidth,
-                      ),
-                      child: DataTable(
-                        columnSpacing: 12,
-                        horizontalMargin: 12,
-                        columns: headers
-                            .map(
-                              (h) => DataColumn(
-                                label: Text(
-                                  headerMap[h] ?? h,
-                                  style: const TextStyle(fontSize: 12),
-                                ),
-                              ),
-                            )
-                            .toList(),
-                        rows: dados.map((r) {
-                          final isGroup = r['__isGroup'] == true;
-                          final isPause = r['evento'] == 'pausa_jornada';
-                          return DataRow(
-                            color: MaterialStateProperty.resolveWith<Color?>((
-                              states,
-                            ) {
-                              if (isGroup) return groupColor;
-                              if (isPause) return pauseColor;
-                              return null;
-                            }),
-                            cells: headers.map((h) {
-                              if (isGroup) {
-                                final text = h == 'created_at'
-                                    ? 'Horário: ${r['created_at'] ?? ''}'
-                                    : '';
-                                final style = theme.textTheme.labelLarge
-                                    ?.copyWith(fontWeight: FontWeight.bold);
-                                return DataCell(Text(text, style: style));
-                              }
-                              final value = r[h];
-                              final display = value == null
-                                  ? ''
-                                  : value.toString();
-                              return DataCell(
-                                Text(
-                                  display,
-                                  style: const TextStyle(fontSize: 12),
-                                ),
+              final headerMap = _headerConfigs[_tipo] ?? const {};
+              _ensureColumnState(headerMap);
+              final hiddenSet = _hiddenColumns[_tipo] ?? <String>{};
+              final order = _columnOrders[_tipo] ?? <String>[];
+              final visibleColumns = [
+                for (final key in order)
+                  if (!hiddenSet.contains(key)) key,
+              ];
+              final hiddenColumns = [
+                for (final key in order)
+                  if (hiddenSet.contains(key)) key,
+              ];
+              final manager = _buildColumnManager(
+                context,
+                headerMap,
+                visibleColumns,
+                hiddenColumns,
+              );
+              if (visibleColumns.isEmpty) {
+                return Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    manager,
+                    const SizedBox(height: 12),
+                    const Text('Selecione ao menos uma coluna para exibir.'),
+                  ],
+                );
+              }
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  manager,
+                  const SizedBox(height: 12),
+                  LayoutBuilder(
+                    builder: (context, constraints) {
+                      final theme = Theme.of(context);
+                      final groupColor = theme.colorScheme.surfaceVariant
+                          .withOpacity(0.25);
+                      final pauseColor = Colors.orange.withOpacity(0.12);
+                      final firstColumnKey = visibleColumns.isNotEmpty
+                          ? visibleColumns.first
+                          : null;
+                      return SingleChildScrollView(
+                        scrollDirection: Axis.horizontal,
+                        child: ConstrainedBox(
+                          constraints: BoxConstraints(
+                            minWidth: constraints.maxWidth,
+                          ),
+                          child: DataTable(
+                            columnSpacing: 12,
+                            horizontalMargin: 12,
+                            columns: visibleColumns
+                                .map(
+                                  (h) => DataColumn(
+                                    label: _buildHeaderLabel(
+                                      h,
+                                      headerMap[h] ?? h,
+                                      () => _hideColumn(h),
+                                    ),
+                                  ),
+                                )
+                                .toList(),
+                            rows: dados.map((r) {
+                              final isGroup = r['__isGroup'] == true;
+                              final isPause = r['evento'] == 'pausa_jornada';
+                              return DataRow(
+                                color:
+                                    MaterialStateProperty.resolveWith<Color?>((
+                                      states,
+                                    ) {
+                                      if (isGroup) return groupColor;
+                                      if (isPause) return pauseColor;
+                                      return null;
+                                    }),
+                                cells: visibleColumns.map((h) {
+                                  if (isGroup) {
+                                    if (h != firstColumnKey) {
+                                      return const DataCell(SizedBox.shrink());
+                                    }
+                                    final text = 'Horário: ${r['created_at'] ?? ''}';
+                                    final style = theme.textTheme.labelLarge
+                                        ?.copyWith(fontWeight: FontWeight.bold);
+                                    return DataCell(
+                                      ConstrainedBox(
+                                        constraints: const BoxConstraints(
+                                          minHeight: 40,
+                                          minWidth: 0,
+                                        ),
+                                        child: OverflowBox(
+                                          minWidth: 0,
+                                          maxWidth: double.infinity,
+                                          alignment: Alignment.centerLeft,
+                                          child: Padding(
+                                            padding: const EdgeInsets.symmetric(
+                                              horizontal: 4,
+                                            ),
+                                            child: Text(text, style: style),
+                                          ),
+                                        ),
+                                      ),
+                                    );
+                                  }
+                                  final value = r[h];
+                                  final display = value == null
+                                      ? ''
+                                      : value.toString();
+                                  return DataCell(
+                                    Text(
+                                      display,
+                                      style: const TextStyle(fontSize: 12),
+                                    ),
+                                  );
+                                }).toList(),
                               );
                             }).toList(),
-                          );
-                        }).toList(),
-                      ),
-                    ),
-                  );
-                },
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+                ],
               );
             },
           ),

--- a/lib/screens/dashboard/components/personnel_report_chart.dart
+++ b/lib/screens/dashboard/components/personnel_report_chart.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 
 import '../../../constants.dart';
@@ -11,6 +13,13 @@ class PersonnelReportChart extends StatefulWidget {
 
   @override
   State<PersonnelReportChart> createState() => _PersonnelReportChartState();
+}
+
+class _TableMetrics {
+  const _TableMetrics({required this.columnWidths, required this.totalWidth});
+
+  final List<double> columnWidths;
+  final double totalWidth;
 }
 
 class _PersonnelReportChartState extends State<PersonnelReportChart> {
@@ -29,6 +38,13 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
     'operador': <String>[],
     'preparador': <String>[],
   };
+
+  static const double _columnSpacing = 12;
+  static const double _cellHorizontalPadding = 12;
+  static const double _cellVerticalPadding = 10;
+  static const double _horizontalMargin = 12;
+  static const double _minColumnWidth = 56;
+  static const double _maxColumnWidth = 320;
 
   static const Map<String, Map<String, String>> _headerConfigs = {
     'preparador': {
@@ -263,6 +279,64 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
     });
   }
 
+  _TableMetrics _computeTableMetrics(
+    BuildContext context,
+    Map<String, String> headerMap,
+    List<String> visibleColumns,
+    List<Map<String, dynamic>> rows,
+  ) {
+    final direction = Directionality.of(context);
+    final theme = Theme.of(context);
+    final headerStyle =
+        theme.textTheme.labelMedium?.copyWith(fontWeight: FontWeight.w600) ??
+        const TextStyle(fontSize: 12, fontWeight: FontWeight.w600);
+    const dataStyle = TextStyle(fontSize: 12);
+    final painter = TextPainter(
+      textDirection: direction,
+      maxLines: 1,
+      ellipsis: '…',
+    );
+
+    double measure(String text, TextStyle style) {
+      if (text.isEmpty) {
+        return 0;
+      }
+      painter
+        ..text = TextSpan(text: text, style: style)
+        ..layout(maxWidth: double.infinity);
+      return painter.width;
+    }
+
+    final widths = <double>[];
+    for (final columnKey in visibleColumns) {
+      double maxWidth = 0;
+      maxWidth = math.max(
+        maxWidth,
+        measure(headerMap[columnKey] ?? columnKey, headerStyle),
+      );
+      for (final row in rows) {
+        if (row['__isGroup'] == true) {
+          continue;
+        }
+        final value = row[columnKey];
+        if (value == null) {
+          continue;
+        }
+        maxWidth = math.max(maxWidth, measure(value.toString(), dataStyle));
+      }
+      final padded = maxWidth + (_cellHorizontalPadding * 2);
+      final width = padded.clamp(_minColumnWidth, _maxColumnWidth).toDouble();
+      widths.add(width);
+    }
+
+    final spacing = _columnSpacing * math.max(0, visibleColumns.length - 1);
+    final totalWidth = widths.fold<double>(
+      spacing,
+      (value, element) => value + element,
+    );
+    return _TableMetrics(columnWidths: widths, totalWidth: totalWidth);
+  }
+
   Widget _buildColumnChip(
     BuildContext context,
     String columnKey,
@@ -299,10 +373,7 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
   ) {
     final label = headerMap[columnKey] ?? columnKey;
     Widget wrapPointer(Widget child) {
-      return MouseRegion(
-        cursor: SystemMouseCursors.grab,
-        child: child,
-      );
+      return MouseRegion(cursor: SystemMouseCursors.grab, child: child);
     }
 
     return Draggable<String>(
@@ -490,6 +561,126 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
           style: theme.textTheme.bodySmall,
         ),
       ],
+    );
+  }
+
+  Widget _buildTableHeaderRow(
+    BuildContext context,
+    Map<String, String> headerMap,
+    List<String> visibleColumns,
+    List<double> columnWidths,
+    double totalWidth,
+  ) {
+    final theme = Theme.of(context);
+    final background = theme.colorScheme.surfaceContainerHighest.withValues(
+      alpha: 0.4,
+    );
+    final borderColor = theme.dividerColor.withOpacity(0.18);
+    final cells = <Widget>[];
+    for (var index = 0; index < visibleColumns.length; index++) {
+      final columnKey = visibleColumns[index];
+      cells.add(
+        Container(
+          width: columnWidths[index],
+          padding: const EdgeInsets.symmetric(
+            horizontal: _cellHorizontalPadding,
+            vertical: _cellVerticalPadding,
+          ),
+          alignment: Alignment.centerLeft,
+          child: _buildHeaderLabel(
+            columnKey,
+            headerMap[columnKey] ?? columnKey,
+            () => _hideColumn(columnKey),
+          ),
+        ),
+      );
+      if (index != visibleColumns.length - 1) {
+        cells.add(const SizedBox(width: _columnSpacing));
+      }
+    }
+    return Container(
+      width: totalWidth,
+      decoration: BoxDecoration(
+        color: background,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: borderColor),
+      ),
+      child: Row(mainAxisSize: MainAxisSize.min, children: cells),
+    );
+  }
+
+  Widget _buildGroupHeaderRow(
+    BuildContext context,
+    Map<String, dynamic> row,
+    double totalWidth,
+    Color groupColor,
+  ) {
+    final theme = Theme.of(context);
+    final textStyle = theme.textTheme.labelLarge?.copyWith(
+      fontWeight: FontWeight.bold,
+    );
+    final createdAt = row['created_at']?.toString() ?? '';
+    final text = createdAt.isEmpty ? 'Horário' : 'Horário: $createdAt';
+    return Container(
+      width: totalWidth,
+      margin: const EdgeInsets.only(top: 12, bottom: 6),
+      padding: const EdgeInsets.symmetric(
+        horizontal: _cellHorizontalPadding,
+        vertical: 8,
+      ),
+      decoration: BoxDecoration(
+        color: groupColor,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Text(text, style: textStyle),
+    );
+  }
+
+  Widget _buildDataRowWidget(
+    BuildContext context,
+    Map<String, dynamic> row,
+    List<String> visibleColumns,
+    List<double> columnWidths,
+    double totalWidth,
+    Color pauseColor,
+  ) {
+    final theme = Theme.of(context);
+    final isPause = row['evento'] == 'pausa_jornada';
+    final background = isPause ? pauseColor : null;
+    final cells = <Widget>[];
+    for (var index = 0; index < visibleColumns.length; index++) {
+      final columnKey = visibleColumns[index];
+      final value = row[columnKey];
+      final text = value == null ? '' : value.toString();
+      cells.add(
+        Container(
+          width: columnWidths[index],
+          padding: const EdgeInsets.symmetric(
+            horizontal: _cellHorizontalPadding,
+            vertical: _cellVerticalPadding,
+          ),
+          alignment: Alignment.centerLeft,
+          child: Text(
+            text,
+            style: const TextStyle(fontSize: 12),
+            overflow: TextOverflow.ellipsis,
+            maxLines: 1,
+          ),
+        ),
+      );
+      if (index != visibleColumns.length - 1) {
+        cells.add(const SizedBox(width: _columnSpacing));
+      }
+    }
+    return Container(
+      width: totalWidth,
+      decoration: BoxDecoration(
+        color: background,
+        border: Border(
+          bottom: BorderSide(color: theme.dividerColor.withOpacity(0.1)),
+        ),
+      ),
+      child: Row(mainAxisSize: MainAxisSize.min, children: cells),
     );
   }
 
@@ -861,82 +1052,70 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
                       final groupColor = theme.colorScheme.surfaceVariant
                           .withOpacity(0.25);
                       final pauseColor = Colors.orange.withOpacity(0.12);
-                      final firstColumnKey = visibleColumns.isNotEmpty
-                          ? visibleColumns.first
-                          : null;
+                      final metrics = _computeTableMetrics(
+                        context,
+                        headerMap,
+                        visibleColumns,
+                        dados,
+                      );
+                      final baseWidth = metrics.totalWidth;
+                      final availableWidth = math.max(
+                        baseWidth,
+                        constraints.maxWidth - (_horizontalMargin * 2),
+                      );
+                      final adjustedColumns = List<double>.from(
+                        metrics.columnWidths,
+                      );
+                      if (adjustedColumns.isNotEmpty &&
+                          availableWidth > baseWidth) {
+                        adjustedColumns[adjustedColumns.length - 1] +=
+                            availableWidth - baseWidth;
+                      }
+                      final rows = <Widget>[
+                        _buildTableHeaderRow(
+                          context,
+                          headerMap,
+                          visibleColumns,
+                          adjustedColumns,
+                          availableWidth,
+                        ),
+                        const SizedBox(height: 8),
+                      ];
+                      for (final row in dados) {
+                        if (row['__isGroup'] == true) {
+                          rows.add(
+                            _buildGroupHeaderRow(
+                              context,
+                              row,
+                              availableWidth,
+                              groupColor,
+                            ),
+                          );
+                        } else {
+                          rows.add(
+                            _buildDataRowWidget(
+                              context,
+                              row,
+                              visibleColumns,
+                              adjustedColumns,
+                              availableWidth,
+                              pauseColor,
+                            ),
+                          );
+                        }
+                      }
                       return SingleChildScrollView(
                         scrollDirection: Axis.horizontal,
-                        child: ConstrainedBox(
-                          constraints: BoxConstraints(
-                            minWidth: constraints.maxWidth,
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: _horizontalMargin,
                           ),
-                          child: DataTable(
-                            columnSpacing: 12,
-                            horizontalMargin: 12,
-                            columns: visibleColumns
-                                .map(
-                                  (h) => DataColumn(
-                                    label: _buildHeaderLabel(
-                                      h,
-                                      headerMap[h] ?? h,
-                                      () => _hideColumn(h),
-                                    ),
-                                  ),
-                                )
-                                .toList(),
-                            rows: dados.map((r) {
-                              final isGroup = r['__isGroup'] == true;
-                              final isPause = r['evento'] == 'pausa_jornada';
-                              return DataRow(
-                                color:
-                                    MaterialStateProperty.resolveWith<Color?>((
-                                      states,
-                                    ) {
-                                      if (isGroup) return groupColor;
-                                      if (isPause) return pauseColor;
-                                      return null;
-                                    }),
-                                cells: visibleColumns.map((h) {
-                                  if (isGroup) {
-                                    if (h != firstColumnKey) {
-                                      return const DataCell(SizedBox.shrink());
-                                    }
-                                    final text = 'Horário: ${r['created_at'] ?? ''}';
-                                    final style = theme.textTheme.labelLarge
-                                        ?.copyWith(fontWeight: FontWeight.bold);
-                                    return DataCell(
-                                      ConstrainedBox(
-                                        constraints: const BoxConstraints(
-                                          minHeight: 40,
-                                          minWidth: 0,
-                                        ),
-                                        child: OverflowBox(
-                                          minWidth: 0,
-                                          maxWidth: double.infinity,
-                                          alignment: Alignment.centerLeft,
-                                          child: Padding(
-                                            padding: const EdgeInsets.symmetric(
-                                              horizontal: 4,
-                                            ),
-                                            child: Text(text, style: style),
-                                          ),
-                                        ),
-                                      ),
-                                    );
-                                  }
-                                  final value = r[h];
-                                  final display = value == null
-                                      ? ''
-                                      : value.toString();
-                                  return DataCell(
-                                    Text(
-                                      display,
-                                      style: const TextStyle(fontSize: 12),
-                                    ),
-                                  );
-                                }).toList(),
-                              );
-                            }).toList(),
+                          child: SizedBox(
+                            width: availableWidth,
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: rows,
+                            ),
                           ),
                         ),
                       );

--- a/lib/screens/dashboard/components/personnel_report_chart.dart
+++ b/lib/screens/dashboard/components/personnel_report_chart.dart
@@ -795,14 +795,15 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
       cells.add(
         SizedBox(
           width: width,
-          child: Stack(
-            clipBehavior: Clip.none,
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              Positioned.fill(
+              Expanded(
                 child: Container(
                   padding: EdgeInsetsDirectional.only(
                     start: _cellHorizontalPadding,
-                    end: _cellHorizontalPadding + (_resizeHandleHitWidth / 2),
+                    end: _cellHorizontalPadding,
                     top: _cellVerticalPadding,
                     bottom: _cellVerticalPadding,
                   ),
@@ -814,10 +815,8 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
                   ),
                 ),
               ),
-              Positioned(
-                top: 0,
-                bottom: 0,
-                right: 0,
+              Align(
+                alignment: Alignment.centerRight,
                 child: _buildResizeHandle(context, columnKey, width),
               ),
             ],

--- a/lib/screens/dashboard/components/personnel_report_chart.dart
+++ b/lib/screens/dashboard/components/personnel_report_chart.dart
@@ -980,47 +980,105 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
     final iconColor = filterActive
         ? theme.colorScheme.primary
         : theme.iconTheme.color?.withOpacity(0.7) ?? theme.hintColor;
-    return Row(
-      mainAxisSize: MainAxisSize.max,
-      children: [
-        Expanded(
-          child: Tooltip(
-            message: 'Toque para ocultar',
-            child: InkWell(
-              onTap: onHide,
-              borderRadius: BorderRadius.circular(6),
-              child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
-                child: Text(
-                  label,
-                  style: const TextStyle(fontSize: 12),
-                  overflow: TextOverflow.ellipsis,
-                  maxLines: 1,
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final contentWidth = constraints.maxWidth;
+        if (!contentWidth.isFinite || contentWidth <= 0) {
+          return const SizedBox.shrink();
+        }
+        var iconTapSize = contentWidth >= 72
+            ? 32.0
+            : contentWidth >= 54
+                ? 28.0
+                : contentWidth >= 40
+                    ? 24.0
+                    : contentWidth >= 30
+                        ? 20.0
+                        : contentWidth * 0.7;
+        iconTapSize = iconTapSize.clamp(18.0, contentWidth);
+        final availableForLabel = math.max(0.0, contentWidth - iconTapSize);
+        final startPadding = math.min(
+          _cellHorizontalPadding,
+          math.max(2.0, availableForLabel * 0.35),
+        );
+        final gap = math.max(2.0, math.min(6.0, startPadding));
+        var endPadding = iconTapSize + gap;
+        final maxEndPadding = math.max(0.0, contentWidth - startPadding);
+        if (endPadding > maxEndPadding) {
+          endPadding = maxEndPadding;
+        }
+        final labelPadding = EdgeInsetsDirectional.only(
+          start: startPadding,
+          end: endPadding,
+          top: _cellVerticalPadding,
+          bottom: _cellVerticalPadding,
+        );
+        final iconPadding = EdgeInsetsDirectional.only(
+          end: math.max(2.0, math.min(startPadding, _cellHorizontalPadding)),
+          top: _cellVerticalPadding,
+          bottom: _cellVerticalPadding,
+        );
+
+        return SizedBox.expand(
+          child: Stack(
+            fit: StackFit.expand,
+            children: [
+              Positioned.fill(
+                child: Padding(
+                  padding: labelPadding,
+                  child: Tooltip(
+                    message: 'Toque para ocultar',
+                    child: InkWell(
+                      onTap: onHide,
+                      borderRadius: BorderRadius.circular(6),
+                      child: Align(
+                        alignment: AlignmentDirectional.centerStart,
+                        child: Text(
+                          label,
+                          style: const TextStyle(fontSize: 12),
+                          overflow: TextOverflow.ellipsis,
+                          maxLines: 1,
+                        ),
+                      ),
+                    ),
+                  ),
                 ),
               ),
-            ),
-          ),
-        ),
-        const SizedBox(width: 4),
-        Tooltip(
-          message: filterActive ? 'Editar filtro' : 'Filtrar coluna',
-          child: SizedBox(
-            width: 24,
-            height: 24,
-            child: IconButton(
-              padding: EdgeInsets.zero,
-              visualDensity: VisualDensity.compact,
-              constraints: const BoxConstraints.tightFor(width: 24, height: 24),
-              onPressed: onFilter,
-              icon: Icon(
-                filterActive ? Icons.filter_alt : Icons.filter_alt_outlined,
-                size: 16,
-                color: iconColor,
+              Align(
+                alignment: AlignmentDirectional.centerEnd,
+                child: Padding(
+                  padding: iconPadding,
+                  child: Tooltip(
+                    message:
+                        filterActive ? 'Editar filtro' : 'Filtrar coluna',
+                    child: SizedBox(
+                      width: iconTapSize,
+                      height: iconTapSize,
+                      child: Material(
+                        type: MaterialType.transparency,
+                        child: InkWell(
+                          onTap: onFilter,
+                          borderRadius:
+                              BorderRadius.circular(iconTapSize / 2),
+                          child: Center(
+                            child: Icon(
+                              filterActive
+                                  ? Icons.filter_alt
+                                  : Icons.filter_alt_outlined,
+                              size: iconTapSize <= 20 ? 14 : 16,
+                              color: iconColor,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
               ),
-            ),
+            ],
           ),
-        ),
-      ],
+        );
+      },
     );
   }
 

--- a/lib/screens/dashboard/components/personnel_report_chart.dart
+++ b/lib/screens/dashboard/components/personnel_report_chart.dart
@@ -990,12 +990,12 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
         var iconTapSize = contentWidth >= 72
             ? 32.0
             : contentWidth >= 54
-                ? 28.0
-                : contentWidth >= 40
-                    ? 24.0
-                    : contentWidth >= 30
-                        ? 20.0
-                        : contentWidth * 0.7;
+            ? 28.0
+            : contentWidth >= 40
+            ? 24.0
+            : contentWidth >= 30
+            ? 20.0
+            : contentWidth * 0.7;
         final minTapSize = math.min(18.0, contentWidth);
         iconTapSize = iconTapSize.clamp(minTapSize, contentWidth);
         final availableForLabel = math.max(0.0, contentWidth - iconTapSize);
@@ -1021,8 +1021,8 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
           bottom: _cellVerticalPadding,
         );
 
-        final resolvedHeight = constraints.maxHeight.isFinite &&
-                constraints.maxHeight > 0
+        final resolvedHeight =
+            constraints.maxHeight.isFinite && constraints.maxHeight > 0
             ? constraints.maxHeight
             : _headerRowMinHeight;
         return SizedBox(
@@ -1057,8 +1057,7 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
                 child: Padding(
                   padding: iconPadding,
                   child: Tooltip(
-                    message:
-                        filterActive ? 'Editar filtro' : 'Filtrar coluna',
+                    message: filterActive ? 'Editar filtro' : 'Filtrar coluna',
                     child: SizedBox(
                       width: iconTapSize,
                       height: iconTapSize,
@@ -1066,8 +1065,7 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
                         type: MaterialType.transparency,
                         child: InkWell(
                           onTap: onFilter,
-                          borderRadius:
-                              BorderRadius.circular(iconTapSize / 2),
+                          borderRadius: BorderRadius.circular(iconTapSize / 2),
                           child: Center(
                             child: Icon(
                               filterActive
@@ -1324,9 +1322,11 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
       var overflow = contentWidth - targetWidth;
 
       if (gapWidths.isNotEmpty) {
-        for (var index = gapWidths.length - 1;
-            index >= 0 && overflow > tolerance;
-            index--) {
+        for (
+          var index = gapWidths.length - 1;
+          index >= 0 && overflow > tolerance;
+          index--
+        ) {
           final available = gapWidths[index];
           if (available <= 0) {
             continue;
@@ -1340,9 +1340,11 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
       }
 
       if (overflow > tolerance) {
-        for (var index = resolvedWidths.length - 1;
-            index >= 0 && overflow > tolerance;
-            index--) {
+        for (
+          var index = resolvedWidths.length - 1;
+          index >= 0 && overflow > tolerance;
+          index--
+        ) {
           final available = resolvedWidths[index] - _minColumnWidth;
           if (available <= 0) {
             continue;
@@ -1378,42 +1380,42 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
           width: width,
           child: Container(
             constraints: const BoxConstraints(minHeight: _headerRowMinHeight),
-            child: Row(
-              mainAxisSize: MainAxisSize.max,
-              crossAxisAlignment: CrossAxisAlignment.center,
+            child: Stack(
+              fit: StackFit.expand,
+              clipBehavior: Clip.none,
               children: [
-                Expanded(
-                  child: Container(
-                    padding: EdgeInsetsDirectional.only(
-                      start: _cellHorizontalPadding,
-                      end: _cellHorizontalPadding,
-                      top: _cellVerticalPadding,
-                      bottom: _cellVerticalPadding,
-                    ),
-                    alignment: Alignment.centerLeft,
-                    child: _buildHeaderLabel(
+                Padding(
+                  padding: const EdgeInsetsDirectional.only(
+                    start: _cellHorizontalPadding,
+                    end: _cellHorizontalPadding + _resizeHandleHitWidth,
+                  ),
+                  child: _buildHeaderLabel(
+                    context,
+                    columnKey,
+                    headerMap[columnKey] ?? columnKey,
+                    () => _hideColumn(columnKey),
+                    () => _showColumnFilterSheet(
                       context,
                       columnKey,
                       headerMap[columnKey] ?? columnKey,
-                      () => _hideColumn(columnKey),
-                      () => _showColumnFilterSheet(
-                        context,
-                        columnKey,
-                        headerMap[columnKey] ?? columnKey,
-                        sourceRows,
-                      ),
-                      _isColumnFiltered(columnKey),
+                      sourceRows,
                     ),
+                    _isColumnFiltered(columnKey),
                   ),
                 ),
-                _buildResizeHandle(context, columnKey, width),
+                Align(
+                  alignment: AlignmentDirectional.centerEnd,
+                  child: _buildResizeHandle(context, columnKey, width),
+                ),
               ],
             ),
           ),
         ),
       );
       if (index != visibleColumns.length - 1) {
-        final gapWidth = gapWidths.isNotEmpty ? gapWidths[index] : columnSpacing;
+        final gapWidth = gapWidths.isNotEmpty
+            ? gapWidths[index]
+            : columnSpacing;
         cells.add(SizedBox(width: math.max(0, gapWidth)));
       }
     }
@@ -1495,9 +1497,11 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
       var overflow = contentWidth - targetWidth;
 
       if (gapWidths.isNotEmpty) {
-        for (var index = gapWidths.length - 1;
-            index >= 0 && overflow > tolerance;
-            index--) {
+        for (
+          var index = gapWidths.length - 1;
+          index >= 0 && overflow > tolerance;
+          index--
+        ) {
           final available = gapWidths[index];
           if (available <= 0) {
             continue;
@@ -1511,9 +1515,11 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
       }
 
       if (overflow > tolerance) {
-        for (var index = resolvedWidths.length - 1;
-            index >= 0 && overflow > tolerance;
-            index--) {
+        for (
+          var index = resolvedWidths.length - 1;
+          index >= 0 && overflow > tolerance;
+          index--
+        ) {
           final available = resolvedWidths[index] - _minColumnWidth;
           if (available <= 0) {
             continue;
@@ -1562,7 +1568,9 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
         ),
       );
       if (index != visibleColumns.length - 1) {
-        final gapWidth = gapWidths.isNotEmpty ? gapWidths[index] : columnSpacing;
+        final gapWidth = gapWidths.isNotEmpty
+            ? gapWidths[index]
+            : columnSpacing;
         cells.add(SizedBox(width: math.max(0, gapWidth)));
       }
     }

--- a/lib/screens/dashboard/components/personnel_report_chart.dart
+++ b/lib/screens/dashboard/components/personnel_report_chart.dart
@@ -838,10 +838,11 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
     }
 
     contentWidth = adjusted.fold<double>(0, (sum, width) => sum + width);
-    totalWidth = contentWidth + spacingWidth;
     final spacingValue = spacingCount == 0
         ? 0.0
         : math.max(_minColumnSpacing, spacingWidth / spacingCount);
+    final adjustedSpacingWidth = spacingCount * spacingValue;
+    totalWidth = contentWidth + adjustedSpacingWidth;
     return _TableMetrics(
       columnWidths: adjusted,
       totalWidth: totalWidth,

--- a/lib/screens/dashboard/components/personnel_report_chart.dart
+++ b/lib/screens/dashboard/components/personnel_report_chart.dart
@@ -337,6 +337,105 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
     return _TableMetrics(columnWidths: widths, totalWidth: totalWidth);
   }
 
+  _TableMetrics _fitColumnsToViewport(
+    _TableMetrics metrics,
+    int columnCount,
+    double viewportWidth,
+  ) {
+    if (columnCount <= 0 || metrics.columnWidths.isEmpty) {
+      return const _TableMetrics(columnWidths: <double>[], totalWidth: 0);
+    }
+
+    final spacing = _columnSpacing * math.max(0, columnCount - 1);
+    final adjusted = List<double>.from(metrics.columnWidths);
+    final contentWidth = adjusted.fold<double>(0, (sum, width) => sum + width);
+    final baseTotalWidth = contentWidth + spacing;
+
+    if (!viewportWidth.isFinite || viewportWidth <= 0) {
+      return _TableMetrics(columnWidths: adjusted, totalWidth: baseTotalWidth);
+    }
+
+    final minContentWidth = columnCount * _minColumnWidth;
+    final minTotalWidth = minContentWidth + spacing;
+
+    if (baseTotalWidth <= viewportWidth) {
+      if (adjusted.isNotEmpty) {
+        adjusted[adjusted.length - 1] += viewportWidth - baseTotalWidth;
+      }
+      return _TableMetrics(columnWidths: adjusted, totalWidth: viewportWidth);
+    }
+
+    final targetTotalWidth = math.max(viewportWidth, minTotalWidth);
+    final targetContentWidth = targetTotalWidth - spacing;
+    var remainingReduction = contentWidth - targetContentWidth;
+
+    if (remainingReduction <= 0) {
+      if (adjusted.isNotEmpty) {
+        adjusted[adjusted.length - 1] += targetContentWidth - contentWidth;
+      }
+      final newContent = adjusted.fold<double>(0, (sum, width) => sum + width);
+      return _TableMetrics(
+        columnWidths: adjusted,
+        totalWidth: newContent + spacing,
+      );
+    }
+
+    const double tolerance = 0.1;
+    while (remainingReduction > tolerance) {
+      double adjustableSum = 0;
+      for (final width in adjusted) {
+        final available = width - _minColumnWidth;
+        if (available > 0) {
+          adjustableSum += available;
+        }
+      }
+      if (adjustableSum <= 0) {
+        final actualContent = adjusted.fold<double>(
+          0,
+          (sum, width) => sum + width,
+        );
+        return _TableMetrics(
+          columnWidths: adjusted,
+          totalWidth: actualContent + spacing,
+        );
+      }
+
+      var reducedThisPass = 0.0;
+      for (var i = 0; i < adjusted.length; i++) {
+        final available = adjusted[i] - _minColumnWidth;
+        if (available <= 0) continue;
+        final share = remainingReduction * (available / adjustableSum);
+        final reduction = math.min(available, share);
+        if (reduction <= 0) continue;
+        adjusted[i] -= reduction;
+        reducedThisPass += reduction;
+      }
+
+      if (reducedThisPass <= 0) {
+        break;
+      }
+      remainingReduction -= reducedThisPass;
+    }
+
+    final adjustedContentWidth = adjusted.fold<double>(
+      0,
+      (sum, width) => sum + width,
+    );
+    final diff = targetContentWidth - adjustedContentWidth;
+    if (diff > tolerance && adjusted.isNotEmpty) {
+      adjusted[adjusted.length - 1] += diff;
+    }
+
+    final finalContentWidth = adjusted.fold<double>(
+      0,
+      (sum, width) => sum + width,
+    );
+    return _TableMetrics(
+      columnWidths: adjusted,
+      totalWidth: finalContentWidth + spacing,
+    );
+  }
+
   Widget _buildColumnChip(
     BuildContext context,
     String columnKey,
@@ -1058,26 +1157,32 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
                         visibleColumns,
                         dados,
                       );
-                      final baseWidth = metrics.totalWidth;
-                      final availableWidth = math.max(
-                        baseWidth,
-                        constraints.maxWidth - (_horizontalMargin * 2),
+                      final mediaWidth = MediaQuery.maybeOf(
+                        context,
+                      )?.size.width;
+                      final rawViewportWidth = constraints.maxWidth.isFinite
+                          ? constraints.maxWidth
+                          : (mediaWidth ?? metrics.totalWidth);
+                      final availableViewportWidth = rawViewportWidth.isFinite
+                          ? math.max(
+                              0.0,
+                              rawViewportWidth - (_horizontalMargin * 2),
+                            )
+                          : rawViewportWidth;
+                      final fittedMetrics = _fitColumnsToViewport(
+                        metrics,
+                        visibleColumns.length,
+                        availableViewportWidth,
                       );
-                      final adjustedColumns = List<double>.from(
-                        metrics.columnWidths,
-                      );
-                      if (adjustedColumns.isNotEmpty &&
-                          availableWidth > baseWidth) {
-                        adjustedColumns[adjustedColumns.length - 1] +=
-                            availableWidth - baseWidth;
-                      }
+                      final adjustedColumns = fittedMetrics.columnWidths;
+                      final tableWidth = fittedMetrics.totalWidth;
                       final rows = <Widget>[
                         _buildTableHeaderRow(
                           context,
                           headerMap,
                           visibleColumns,
                           adjustedColumns,
-                          availableWidth,
+                          tableWidth,
                         ),
                         const SizedBox(height: 8),
                       ];
@@ -1087,7 +1192,7 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
                             _buildGroupHeaderRow(
                               context,
                               row,
-                              availableWidth,
+                              tableWidth,
                               groupColor,
                             ),
                           );
@@ -1098,7 +1203,7 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
                               row,
                               visibleColumns,
                               adjustedColumns,
-                              availableWidth,
+                              tableWidth,
                               pauseColor,
                             ),
                           );
@@ -1111,7 +1216,7 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
                             horizontal: _horizontalMargin,
                           ),
                           child: SizedBox(
-                            width: availableWidth,
+                            width: tableWidth,
                             child: Column(
                               crossAxisAlignment: CrossAxisAlignment.start,
                               children: rows,

--- a/lib/screens/dashboard/components/personnel_report_chart.dart
+++ b/lib/screens/dashboard/components/personnel_report_chart.dart
@@ -1378,8 +1378,8 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
       cells.add(
         SizedBox(
           width: width,
-          child: Container(
-            constraints: const BoxConstraints(minHeight: _headerRowMinHeight),
+          child: SizedBox(
+            height: _headerRowMinHeight,
             child: Stack(
               fit: StackFit.expand,
               clipBehavior: Clip.none,

--- a/lib/screens/dashboard/components/personnel_report_chart.dart
+++ b/lib/screens/dashboard/components/personnel_report_chart.dart
@@ -995,7 +995,8 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
                     : contentWidth >= 30
                         ? 20.0
                         : contentWidth * 0.7;
-        iconTapSize = iconTapSize.clamp(18.0, contentWidth);
+        final minTapSize = math.min(18.0, contentWidth);
+        iconTapSize = iconTapSize.clamp(minTapSize, contentWidth);
         final availableForLabel = math.max(0.0, contentWidth - iconTapSize);
         final startPadding = math.min(
           _cellHorizontalPadding,

--- a/lib/screens/dashboard/components/personnel_report_chart.dart
+++ b/lib/screens/dashboard/components/personnel_report_chart.dart
@@ -1316,7 +1316,7 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
 
     var contentWidth = computeContentWidth();
     final targetWidth = totalWidth;
-    const tolerance = 0.5;
+    const tolerance = 0.001;
 
     if (resolvedWidths.isNotEmpty && contentWidth - targetWidth > tolerance) {
       var overflow = contentWidth - targetWidth;
@@ -1357,13 +1357,16 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
         overflow = contentWidth - targetWidth;
       }
 
-      if (overflow > tolerance && resolvedWidths.isNotEmpty) {
-        final lastIndex = resolvedWidths.length - 1;
-        resolvedWidths[lastIndex] = math.max(
-          0.0,
-          resolvedWidths[lastIndex] - overflow,
-        );
-        contentWidth = computeContentWidth();
+      if (resolvedWidths.isNotEmpty) {
+        final overflowAfterAdjust = contentWidth - targetWidth;
+        if (overflowAfterAdjust > tolerance) {
+          final lastIndex = resolvedWidths.length - 1;
+          resolvedWidths[lastIndex] = math.max(
+            0.0,
+            resolvedWidths[lastIndex] - overflowAfterAdjust,
+          );
+          contentWidth = computeContentWidth();
+        }
       }
     }
 
@@ -1419,7 +1422,7 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
         cells.add(SizedBox(width: math.max(0, gapWidth)));
       }
     }
-    if (fillerWidth > 0.5) {
+    if (fillerWidth > tolerance) {
       cells.add(SizedBox(width: fillerWidth));
     }
     return Container(
@@ -1491,7 +1494,7 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
 
     var contentWidth = computeContentWidth();
     final targetWidth = totalWidth;
-    const tolerance = 0.5;
+    const tolerance = 0.001;
 
     if (resolvedWidths.isNotEmpty && contentWidth - targetWidth > tolerance) {
       var overflow = contentWidth - targetWidth;
@@ -1532,13 +1535,16 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
         overflow = contentWidth - targetWidth;
       }
 
-      if (overflow > tolerance && resolvedWidths.isNotEmpty) {
-        final lastIndex = resolvedWidths.length - 1;
-        resolvedWidths[lastIndex] = math.max(
-          0.0,
-          resolvedWidths[lastIndex] - overflow,
-        );
-        contentWidth = computeContentWidth();
+      if (resolvedWidths.isNotEmpty) {
+        final overflowAfterAdjust = contentWidth - targetWidth;
+        if (overflowAfterAdjust > tolerance) {
+          final lastIndex = resolvedWidths.length - 1;
+          resolvedWidths[lastIndex] = math.max(
+            0.0,
+            resolvedWidths[lastIndex] - overflowAfterAdjust,
+          );
+          contentWidth = computeContentWidth();
+        }
       }
     }
 
@@ -1574,7 +1580,7 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
         cells.add(SizedBox(width: math.max(0, gapWidth)));
       }
     }
-    if (fillerWidth > 0.5) {
+    if (fillerWidth > tolerance) {
       cells.add(SizedBox(width: fillerWidth));
     }
     return Container(

--- a/lib/screens/dashboard/components/personnel_report_chart.dart
+++ b/lib/screens/dashboard/components/personnel_report_chart.dart
@@ -48,6 +48,7 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
   static const double _columnSpacing = 12;
   static const double _cellHorizontalPadding = 12;
   static const double _cellVerticalPadding = 10;
+  static const double _headerRowMinHeight = 44;
   static const double _horizontalMargin = 12;
   static const double _minColumnWidth = 40;
   static const double _maxColumnWidth = 480;
@@ -795,31 +796,31 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
       cells.add(
         SizedBox(
           width: width,
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              Expanded(
-                child: Container(
-                  padding: EdgeInsetsDirectional.only(
-                    start: _cellHorizontalPadding,
-                    end: _cellHorizontalPadding,
-                    top: _cellVerticalPadding,
-                    bottom: _cellVerticalPadding,
-                  ),
-                  alignment: Alignment.centerLeft,
-                  child: _buildHeaderLabel(
-                    columnKey,
-                    headerMap[columnKey] ?? columnKey,
-                    () => _hideColumn(columnKey),
+          child: Container(
+            constraints: const BoxConstraints(minHeight: _headerRowMinHeight),
+            child: Row(
+              mainAxisSize: MainAxisSize.max,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                Expanded(
+                  child: Container(
+                    padding: EdgeInsetsDirectional.only(
+                      start: _cellHorizontalPadding,
+                      end: _cellHorizontalPadding,
+                      top: _cellVerticalPadding,
+                      bottom: _cellVerticalPadding,
+                    ),
+                    alignment: Alignment.centerLeft,
+                    child: _buildHeaderLabel(
+                      columnKey,
+                      headerMap[columnKey] ?? columnKey,
+                      () => _hideColumn(columnKey),
+                    ),
                   ),
                 ),
-              ),
-              Align(
-                alignment: Alignment.centerRight,
-                child: _buildResizeHandle(context, columnKey, width),
-              ),
-            ],
+                _buildResizeHandle(context, columnKey, width),
+              ],
+            ),
           ),
         ),
       );

--- a/lib/screens/dashboard/components/personnel_report_chart.dart
+++ b/lib/screens/dashboard/components/personnel_report_chart.dart
@@ -743,6 +743,28 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
     );
   }
 
+  List<int> _buildColumnFlexes(List<double> widths) {
+    if (widths.isEmpty) {
+      return const <int>[];
+    }
+    final positiveWidths = widths.map((width) => math.max(0.0, width)).toList();
+    final total = positiveWidths.fold<double>(0, (sum, width) => sum + width);
+    if (total <= 0) {
+      return List<int>.filled(widths.length, 1);
+    }
+    final scale = 1000 / total;
+    final flexes = <int>[];
+    for (final width in positiveWidths) {
+      final flex = math.max(1, (width * scale).round());
+      flexes.add(flex);
+    }
+    final sumFlex = flexes.fold<int>(0, (sum, value) => sum + value);
+    if (sumFlex <= 0) {
+      return List<int>.filled(widths.length, 1);
+    }
+    return flexes;
+  }
+
   _TableMetrics _fitColumnsToViewport(
     _TableMetrics metrics,
     int columnCount,
@@ -1288,6 +1310,7 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
     Map<String, String> headerMap,
     List<String> visibleColumns,
     List<double> columnWidths,
+    List<int> columnFlexes,
     double totalWidth,
     double columnSpacing,
     List<Map<String, dynamic>> sourceRows,
@@ -1298,140 +1321,92 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
     );
     final borderColor = theme.dividerColor.withOpacity(0.18);
     final spacingCount = math.max(0, visibleColumns.length - 1);
-    final gapWidths = spacingCount > 0
-        ? List<double>.filled(spacingCount, columnSpacing)
-        : const <double>[];
+    final totalSpacing = spacingCount * columnSpacing;
     final resolvedWidths = List<double>.from(columnWidths);
-
-    double computeContentWidth() {
-      var sum = 0.0;
-      for (final width in resolvedWidths) {
-        sum += width;
-      }
-      for (final gap in gapWidths) {
-        sum += gap;
-      }
-      return sum;
-    }
-
-    var contentWidth = computeContentWidth();
-    final targetWidth = totalWidth;
-    const tolerance = 0.001;
-
-    if (resolvedWidths.isNotEmpty && contentWidth - targetWidth > tolerance) {
-      var overflow = contentWidth - targetWidth;
-
-      if (gapWidths.isNotEmpty) {
-        for (
-          var index = gapWidths.length - 1;
-          index >= 0 && overflow > tolerance;
-          index--
-        ) {
-          final available = gapWidths[index];
-          if (available <= 0) {
-            continue;
-          }
-          final reduction = math.min(available, overflow);
-          gapWidths[index] -= reduction;
-          overflow -= reduction;
-        }
-        contentWidth = computeContentWidth();
-        overflow = contentWidth - targetWidth;
-      }
-
-      if (overflow > tolerance) {
-        for (
-          var index = resolvedWidths.length - 1;
-          index >= 0 && overflow > tolerance;
-          index--
-        ) {
-          final available = resolvedWidths[index] - _minColumnWidth;
-          if (available <= 0) {
-            continue;
-          }
-          final reduction = math.min(available, overflow);
-          resolvedWidths[index] -= reduction;
-          overflow -= reduction;
-        }
-        contentWidth = computeContentWidth();
-        overflow = contentWidth - targetWidth;
-      }
-
-      if (resolvedWidths.isNotEmpty) {
-        final overflowAfterAdjust = contentWidth - targetWidth;
-        if (overflowAfterAdjust > tolerance) {
-          final lastIndex = resolvedWidths.length - 1;
-          resolvedWidths[lastIndex] = math.max(
-            0.0,
-            resolvedWidths[lastIndex] - overflowAfterAdjust,
-          );
-          contentWidth = computeContentWidth();
-        }
-      }
-    }
+    final flexes = columnFlexes.isEmpty
+        ? _buildColumnFlexes(resolvedWidths)
+        : columnFlexes;
 
     final cells = <Widget>[];
     for (var index = 0; index < visibleColumns.length; index++) {
       final columnKey = visibleColumns[index];
-      final width = resolvedWidths[index];
+      final fallbackWidth = resolvedWidths[index];
+      final flex = index < flexes.length ? math.max(1, flexes[index]) : 1;
       cells.add(
-        SizedBox(
-          width: width,
-          child: SizedBox(
-            height: _headerRowMinHeight,
-            child: Stack(
-              fit: StackFit.expand,
-              clipBehavior: Clip.none,
-              children: [
-                Padding(
-                  padding: const EdgeInsetsDirectional.only(
-                    start: _cellHorizontalPadding,
-                    end: _cellHorizontalPadding + _resizeHandleHitWidth,
-                  ),
-                  child: _buildHeaderLabel(
-                    context,
-                    columnKey,
-                    headerMap[columnKey] ?? columnKey,
-                    () => _hideColumn(columnKey),
-                    () => _showColumnFilterSheet(
-                      context,
-                      columnKey,
-                      headerMap[columnKey] ?? columnKey,
-                      sourceRows,
-                    ),
-                    _isColumnFiltered(columnKey),
-                  ),
-                ),
-                Align(
-                  alignment: AlignmentDirectional.centerEnd,
-                  child: _buildResizeHandle(context, columnKey, width),
-                ),
-              ],
+        Flexible(
+          fit: FlexFit.tight,
+          flex: flex,
+          child: ConstrainedBox(
+            constraints: BoxConstraints(minWidth: _minColumnWidth),
+            child: SizedBox(
+              height: _headerRowMinHeight,
+              child: LayoutBuilder(
+                builder: (context, cellConstraints) {
+                  final maxWidth = cellConstraints.maxWidth.isFinite
+                      ? cellConstraints.maxWidth
+                      : math.max(_minColumnWidth, fallbackWidth);
+                  return Stack(
+                    fit: StackFit.expand,
+                    clipBehavior: Clip.none,
+                    children: [
+                      Padding(
+                        padding: const EdgeInsetsDirectional.only(
+                          start: _cellHorizontalPadding,
+                          end:
+                              _cellHorizontalPadding + _resizeHandleHitWidth,
+                        ),
+                        child: _buildHeaderLabel(
+                          context,
+                          columnKey,
+                          headerMap[columnKey] ?? columnKey,
+                          () => _hideColumn(columnKey),
+                          () => _showColumnFilterSheet(
+                            context,
+                            columnKey,
+                            headerMap[columnKey] ?? columnKey,
+                            sourceRows,
+                          ),
+                          _isColumnFiltered(columnKey),
+                        ),
+                      ),
+                      Align(
+                        alignment: AlignmentDirectional.centerEnd,
+                        child:
+                            _buildResizeHandle(context, columnKey, maxWidth),
+                      ),
+                    ],
+                  );
+                },
+              ),
             ),
           ),
         ),
       );
       if (index != visibleColumns.length - 1) {
-        final gapWidth = gapWidths.isNotEmpty
-            ? gapWidths[index]
-            : columnSpacing;
-        cells.add(SizedBox(width: math.max(0, gapWidth)));
+        cells.add(SizedBox(width: math.max(0, columnSpacing)));
       }
     }
-    final safeContentWidth = math.max(0.0, contentWidth);
-    final contentRow = Row(mainAxisSize: MainAxisSize.min, children: cells);
-    final containerWidth = math.max(targetWidth, safeContentWidth);
+
+    final effectiveWidth = math.max(
+      totalWidth,
+      resolvedWidths.fold<double>(0, (sum, width) => sum + width) + totalSpacing,
+    );
+    final contentRow = Row(
+      mainAxisSize: MainAxisSize.max,
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: cells,
+    );
     return Container(
-      width: containerWidth,
+      width: effectiveWidth,
       decoration: BoxDecoration(
         color: background,
         borderRadius: BorderRadius.circular(8),
         border: Border.all(color: borderColor),
       ),
-      child: Align(
-        alignment: AlignmentDirectional.centerStart,
+      child: Padding(
+        padding: EdgeInsets.zero,
         child: SizedBox(
-          width: safeContentWidth,
+          width: effectiveWidth,
           child: contentRow,
         ),
       ),
@@ -1470,6 +1445,7 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
     Map<String, dynamic> row,
     List<String> visibleColumns,
     List<double> columnWidths,
+    List<int> columnFlexes,
     double totalWidth,
     double columnSpacing,
     Color pauseColor,
@@ -1478,123 +1454,66 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
     final isPause = row['evento'] == 'pausa_jornada';
     final background = isPause ? pauseColor : null;
     final spacingCount = math.max(0, visibleColumns.length - 1);
-    final gapWidths = spacingCount > 0
-        ? List<double>.filled(spacingCount, columnSpacing)
-        : const <double>[];
-    final resolvedWidths = List<double>.from(columnWidths);
-
-    double computeContentWidth() {
-      var sum = 0.0;
-      for (final width in resolvedWidths) {
-        sum += width;
-      }
-      for (final gap in gapWidths) {
-        sum += gap;
-      }
-      return sum;
-    }
-
-    var contentWidth = computeContentWidth();
-    final targetWidth = totalWidth;
-    const tolerance = 0.001;
-
-    if (resolvedWidths.isNotEmpty && contentWidth - targetWidth > tolerance) {
-      var overflow = contentWidth - targetWidth;
-
-      if (gapWidths.isNotEmpty) {
-        for (
-          var index = gapWidths.length - 1;
-          index >= 0 && overflow > tolerance;
-          index--
-        ) {
-          final available = gapWidths[index];
-          if (available <= 0) {
-            continue;
-          }
-          final reduction = math.min(available, overflow);
-          gapWidths[index] -= reduction;
-          overflow -= reduction;
-        }
-        contentWidth = computeContentWidth();
-        overflow = contentWidth - targetWidth;
-      }
-
-      if (overflow > tolerance) {
-        for (
-          var index = resolvedWidths.length - 1;
-          index >= 0 && overflow > tolerance;
-          index--
-        ) {
-          final available = resolvedWidths[index] - _minColumnWidth;
-          if (available <= 0) {
-            continue;
-          }
-          final reduction = math.min(available, overflow);
-          resolvedWidths[index] -= reduction;
-          overflow -= reduction;
-        }
-        contentWidth = computeContentWidth();
-        overflow = contentWidth - targetWidth;
-      }
-
-      if (resolvedWidths.isNotEmpty) {
-        final overflowAfterAdjust = contentWidth - targetWidth;
-        if (overflowAfterAdjust > tolerance) {
-          final lastIndex = resolvedWidths.length - 1;
-          resolvedWidths[lastIndex] = math.max(
-            0.0,
-            resolvedWidths[lastIndex] - overflowAfterAdjust,
-          );
-          contentWidth = computeContentWidth();
-        }
-      }
-    }
+    final totalSpacing = spacingCount * columnSpacing;
+    final flexes = columnFlexes.isEmpty
+        ? _buildColumnFlexes(columnWidths)
+        : columnFlexes;
 
     final cells = <Widget>[];
     for (var index = 0; index < visibleColumns.length; index++) {
       final columnKey = visibleColumns[index];
+      final flex = index < flexes.length ? math.max(1, flexes[index]) : 1;
       final value = row[columnKey];
       final text = value == null ? '' : value.toString();
       cells.add(
-        Container(
-          width: resolvedWidths[index],
-          padding: const EdgeInsets.symmetric(
-            horizontal: _cellHorizontalPadding,
-            vertical: _cellVerticalPadding,
-          ),
-          alignment: Alignment.centerLeft,
-          child: Text(
-            text,
-            style: const TextStyle(fontSize: 12),
-            overflow: TextOverflow.ellipsis,
-            maxLines: 1,
+        Flexible(
+          fit: FlexFit.tight,
+          flex: flex,
+          child: ConstrainedBox(
+            constraints: BoxConstraints(minWidth: _minColumnWidth),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: _cellHorizontalPadding,
+                vertical: _cellVerticalPadding,
+              ),
+              child: Align(
+                alignment: AlignmentDirectional.centerStart,
+                child: Text(
+                  text,
+                  style: const TextStyle(fontSize: 12),
+                  overflow: TextOverflow.ellipsis,
+                  maxLines: 1,
+                ),
+              ),
+            ),
           ),
         ),
       );
       if (index != visibleColumns.length - 1) {
-        final gapWidth = gapWidths.isNotEmpty
-            ? gapWidths[index]
-            : columnSpacing;
-        cells.add(SizedBox(width: math.max(0, gapWidth)));
+        cells.add(SizedBox(width: math.max(0, columnSpacing)));
       }
     }
-    final safeContentWidth = math.max(0.0, contentWidth);
-    final contentRow = Row(mainAxisSize: MainAxisSize.min, children: cells);
-    final containerWidth = math.max(targetWidth, safeContentWidth);
+
+    final effectiveWidth = math.max(
+      totalWidth,
+      columnWidths.fold<double>(0, (sum, width) => sum + width) + totalSpacing,
+    );
+    final contentRow = Row(
+      mainAxisSize: MainAxisSize.max,
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: cells,
+    );
     return Container(
-      width: containerWidth,
+      width: effectiveWidth,
       decoration: BoxDecoration(
         color: background,
         border: Border(
           bottom: BorderSide(color: theme.dividerColor.withOpacity(0.1)),
         ),
       ),
-      child: Align(
-        alignment: AlignmentDirectional.centerStart,
-        child: SizedBox(
-          width: safeContentWidth,
-          child: contentRow,
-        ),
+      child: SizedBox(
+        width: effectiveWidth,
+        child: contentRow,
       ),
     );
   }
@@ -2055,6 +1974,7 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
                         lockedColumns: lockedIndices,
                       );
                       final adjustedColumns = fittedMetrics.columnWidths;
+                      final columnFlexes = _buildColumnFlexes(adjustedColumns);
                       final columnSpacing = spacingCount == 0
                           ? 0.0
                           : fittedMetrics.columnSpacing;
@@ -2076,6 +1996,7 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
                           headerMap,
                           visibleColumns,
                           adjustedColumns,
+                          columnFlexes,
                           tableWidth,
                           columnSpacing,
                           dados,
@@ -2099,6 +2020,7 @@ class _PersonnelReportChartState extends State<PersonnelReportChart> {
                               row,
                               visibleColumns,
                               adjustedColumns,
+                              columnFlexes,
                               tableWidth,
                               columnSpacing,
                               pauseColor,


### PR DESCRIPTION
## Summary
- let the personnel report group header text overflow the first cell so it behaves like a title instead of widening the RE column
- keep the other cells blank when rendering a group row to preserve the column alignment of the data rows

## Testing
- flutter analyze
- flutter test

------
https://chatgpt.com/codex/tasks/task_e_68d2c3a859f08331ada619f5e037149c