### PR TITLE
feat: alertar falta de amostragem recente

### DIFF
--- a/lib/features/operador/presentation/operador_page.dart
+++ b/lib/features/operador/presentation/operador_page.dart
@@ -1,6 +1,7 @@
 // lib/features/operador/presentation/operador_page.dart
-import 'dart:io';
+import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 import 'package:flutter/services.dart';
 
 import 'package:flutter/material.dart';
@@ -176,6 +177,12 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
   late final VoidCallback _osSyncListener;
   late final VoidCallback _partSyncListener;
   late final VoidCallback _opSyncListener;
+  Timer? _amostragemMonitorTimer;
+  SharedSearchFormState? _activeAmostragemFlow;
+  bool _amostragemCheckInProgress = false;
+  bool _amostragemReminderDialogOpen = false;
+  DateTime? _lastAmostragem;
+  DateTime? _lastReminderShownAt;
 
   @override
   void initState() {
@@ -203,6 +210,175 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
     _partCtrl.addListener(_partSyncListener);
     _opCtrl.addListener(_opSyncListener);
     _carregarMaquinas();
+
+    ref.listen<SharedSearchFormState>(
+      sharedSearchFormProvider,
+      (previous, next) {
+        _handleFlowStateChange(previous, next);
+      },
+    );
+    _handleFlowStateChange(null, shared);
+  }
+
+  void _handleFlowStateChange(
+    SharedSearchFormState? previous,
+    SharedSearchFormState next,
+  ) {
+    if (!next.isActive ||
+        next.effectiveProcess != SearchFlowProcess.amostragem) {
+      _activeAmostragemFlow = null;
+      _cancelAmostragemMonitor();
+      return;
+    }
+
+    final wasActive = previous != null &&
+        previous.isActive &&
+        previous.effectiveProcess == SearchFlowProcess.amostragem;
+
+    final previousFlow = _activeAmostragemFlow;
+    _activeAmostragemFlow = next;
+    if (!wasActive || previousFlow == null || !next.matches(previousFlow)) {
+      _resetAmostragemReminderState();
+    }
+    _ensureAmostragemMonitorRunning();
+  }
+
+  void _resetAmostragemReminderState() {
+    _lastAmostragem = null;
+    _lastReminderShownAt = null;
+  }
+
+  void _ensureAmostragemMonitorRunning() {
+    if (_amostragemMonitorTimer != null) {
+      return;
+    }
+    unawaited(_checkAmostragemRecente());
+    _amostragemMonitorTimer = Timer.periodic(
+      const Duration(minutes: 1),
+      (_) => unawaited(_checkAmostragemRecente()),
+    );
+  }
+
+  void _cancelAmostragemMonitor() {
+    _amostragemMonitorTimer?.cancel();
+    _amostragemMonitorTimer = null;
+    _amostragemCheckInProgress = false;
+  }
+
+  Future<void> _checkAmostragemRecente() async {
+    if (_amostragemCheckInProgress) return;
+    final flow = _activeAmostragemFlow;
+    if (flow == null ||
+        !flow.isActive ||
+        flow.effectiveProcess != SearchFlowProcess.amostragem) {
+      return;
+    }
+
+    final os = flow.os.trim();
+    if (os.isEmpty) return;
+
+    final part = flow.partNumber.trim();
+    final op = flow.operacao.trim();
+    final query = <String, dynamic>{
+      'os': os,
+      if (part.isNotEmpty) 'partnumber': part,
+      if (op.isNotEmpty) 'operacao': op,
+    };
+
+    _amostragemCheckInProgress = true;
+    try {
+      final uri = buildApiUri('/operador/amostragens', query);
+      final resp = await http
+          .get(uri)
+          .timeout(const Duration(seconds: 15));
+      if (resp.statusCode == 200) {
+        DateTime? ultimaAmostragem;
+        try {
+          final data = jsonDecode(resp.body);
+          if (data is List && data.isNotEmpty) {
+            final first = data.first;
+            if (first is Map && first['created_at'] != null) {
+              final raw = first['created_at'].toString();
+              ultimaAmostragem = DateTime.tryParse(raw)?.toLocal();
+              if (ultimaAmostragem == null) {
+                ultimaAmostragem = DateTime.tryParse(raw.replaceFirst(' ', 'T'))
+                    ?.toLocal();
+              }
+            }
+          }
+        } catch (_) {}
+        _handleAmostragemRecente(flow, ultimaAmostragem);
+      }
+    } catch (_) {
+      // Ignora falhas momentâneas; nova checagem ocorrerá em seguida.
+    } finally {
+      _amostragemCheckInProgress = false;
+    }
+  }
+
+  void _handleAmostragemRecente(
+    SharedSearchFormState flow,
+    DateTime? ultimaAmostragem,
+  ) {
+    if (!mounted) return;
+    if (ultimaAmostragem != null) {
+      _lastAmostragem = ultimaAmostragem;
+    }
+
+    final now = DateTime.now();
+    final last = _lastAmostragem;
+    final bool precisaAlertar;
+    if (last == null) {
+      precisaAlertar = true;
+    } else {
+      final diff = now.difference(last);
+      precisaAlertar = diff >= const Duration(minutes: 20);
+      if (!precisaAlertar) {
+        _lastReminderShownAt = null;
+      }
+    }
+
+    if (precisaAlertar && _shouldShowAmostragemReminder(now)) {
+      _showAmostragemReminder(flow);
+    }
+  }
+
+  bool _shouldShowAmostragemReminder(DateTime now) {
+    if (_amostragemReminderDialogOpen) return false;
+    final lastReminder = _lastReminderShownAt;
+    if (lastReminder == null) return true;
+    return now.difference(lastReminder) >= const Duration(minutes: 5);
+  }
+
+  Future<void> _showAmostragemReminder(SharedSearchFormState flow) async {
+    if (!mounted || _amostragemReminderDialogOpen) return;
+    _amostragemReminderDialogOpen = true;
+    _lastReminderShownAt = DateTime.now();
+    final os = flow.os.trim();
+    final mensagemBase =
+        'Nenhuma amostragem foi registrada nos últimos 20 minutos.';
+    final mensagem = os.isEmpty
+        ? mensagemBase
+        : '$mensagemBase\nO.S. atual: $os';
+    await showDialog<void>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Atenção'),
+        content: Text(mensagem),
+        actions: [
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Entendi'),
+          ),
+        ],
+      ),
+    );
+    _amostragemReminderDialogOpen = false;
+  }
+
+  void _registrarAmostragemLocal() {
+    _lastAmostragem = DateTime.now();
+    _lastReminderShownAt = null;
   }
 
   Future<void> _carregarMaquinas() async {
@@ -290,6 +466,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
 
   @override
   void dispose() {
+    _cancelAmostragemMonitor();
     _osCtrl.removeListener(_osSyncListener);
     _partCtrl.removeListener(_partSyncListener);
     _opCtrl.removeListener(_opSyncListener);
@@ -403,6 +580,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
         ref
             .read(medidasOperadorControllerProvider.notifier)
             .aplicarSelecoesComoHistorico();
+        _registrarAmostragemLocal();
       } else {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(

--- a/lib/features/operador/presentation/operador_page.dart
+++ b/lib/features/operador/presentation/operador_page.dart
@@ -211,12 +211,6 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
     _opCtrl.addListener(_opSyncListener);
     _carregarMaquinas();
 
-    ref.listen<SharedSearchFormState>(
-      sharedSearchFormProvider,
-      (previous, next) {
-        _handleFlowStateChange(previous, next);
-      },
-    );
     _handleFlowStateChange(null, shared);
   }
 
@@ -231,7 +225,8 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
       return;
     }
 
-    final wasActive = previous != null &&
+    final wasActive =
+        previous != null &&
         previous.isActive &&
         previous.effectiveProcess == SearchFlowProcess.amostragem;
 
@@ -288,9 +283,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
     _amostragemCheckInProgress = true;
     try {
       final uri = buildApiUri('/operador/amostragens', query);
-      final resp = await http
-          .get(uri)
-          .timeout(const Duration(seconds: 15));
+      final resp = await http.get(uri).timeout(const Duration(seconds: 15));
       if (resp.statusCode == 200) {
         DateTime? ultimaAmostragem;
         try {
@@ -301,8 +294,9 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
               final raw = first['created_at'].toString();
               ultimaAmostragem = DateTime.tryParse(raw)?.toLocal();
               if (ultimaAmostragem == null) {
-                ultimaAmostragem = DateTime.tryParse(raw.replaceFirst(' ', 'T'))
-                    ?.toLocal();
+                ultimaAmostragem = DateTime.tryParse(
+                  raw.replaceFirst(' ', 'T'),
+                )?.toLocal();
               }
             }
           }
@@ -934,6 +928,13 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
 
   @override
   Widget build(BuildContext context) {
+    ref.listen<SharedSearchFormState>(sharedSearchFormProvider, (
+      previous,
+      next,
+    ) {
+      _handleFlowStateChange(previous, next);
+    });
+
     final medidasAsync = ref.watch(medidasOperadorControllerProvider);
     final medidas = medidasAsync.value ?? [];
     final flowState = ref.watch(sharedSearchFormProvider);

--- a/lib/features/operador/presentation/operador_page.dart
+++ b/lib/features/operador/presentation/operador_page.dart
@@ -321,19 +321,20 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
 
     final now = DateTime.now();
     final last = _lastAmostragem;
+    final reminderInterval = _resolveAmostragemReminderInterval(flow);
     final bool precisaAlertar;
     if (last == null) {
       precisaAlertar = true;
     } else {
       final diff = now.difference(last);
-      precisaAlertar = diff >= const Duration(minutes: 20);
+      precisaAlertar = diff >= reminderInterval;
       if (!precisaAlertar) {
         _lastReminderShownAt = null;
       }
     }
 
     if (precisaAlertar && _shouldShowAmostragemReminder(now)) {
-      _showAmostragemReminder(flow);
+      _showAmostragemReminder(flow, reminderInterval);
     }
   }
 
@@ -344,13 +345,39 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
     return now.difference(lastReminder) >= const Duration(minutes: 5);
   }
 
-  Future<void> _showAmostragemReminder(SharedSearchFormState flow) async {
+  Duration _resolveAmostragemReminderInterval(SharedSearchFormState flow) {
+    final categoria = flow.categoria?.toLowerCase().trim();
+    if (categoria == 'cnc alimentador') {
+      return const Duration(minutes: 20);
+    }
+    if (categoria == 'tornos com placa') {
+      return const Duration(minutes: 40);
+    }
+    return const Duration(hours: 2);
+  }
+
+  String _formatReminderDuration(Duration duration) {
+    final minutes = duration.inMinutes;
+    if (minutes >= 60 && minutes % 60 == 0) {
+      final hours = minutes ~/ 60;
+      final suffix = hours == 1 ? 'hora' : 'horas';
+      return '$hours $suffix';
+    }
+    final suffix = minutes == 1 ? 'minuto' : 'minutos';
+    return '$minutes $suffix';
+  }
+
+  Future<void> _showAmostragemReminder(
+    SharedSearchFormState flow,
+    Duration reminderInterval,
+  ) async {
     if (!mounted || _amostragemReminderDialogOpen) return;
     _amostragemReminderDialogOpen = true;
     _lastReminderShownAt = DateTime.now();
     final os = flow.os.trim();
+    final intervaloFormatado = _formatReminderDuration(reminderInterval);
     final mensagemBase =
-        'Nenhuma amostragem foi registrada nos últimos 20 minutos.';
+        'Nenhuma amostragem foi registrada nos últimos $intervaloFormatado.';
     final mensagem = os.isEmpty
         ? mensagemBase
         : '$mensagemBase\nO.S. atual: $os';

--- a/lib/features/operador/presentation/widgets/measurement_tile.dart
+++ b/lib/features/operador/presentation/widgets/measurement_tile.dart
@@ -20,18 +20,6 @@ class MeasurementTile extends StatefulWidget {
   State<MeasurementTile> createState() => _MeasurementTileState();
 }
 
-double? _parseManualValue(String txt) {
-  final normalized = txt.replaceAll(',', '.').trim();
-  if (normalized.isEmpty) return null;
-  return double.tryParse(normalized);
-}
-
-double? _parseAngleInput(String txt) {
-  final sanitized = txt.replaceAll(RegExp("[°º'’′\"″”]"), '').trim();
-  if (sanitized.isEmpty) return null;
-  return _parseManualValue(sanitized);
-}
-
 class _MeasurementTileState extends State<MeasurementTile> {
   TextEditingController? _manualCtrl;
   TextEditingController? _chanfroAngCtrl;


### PR DESCRIPTION
## Summary
- monitor the shared amostragem flow to periodically query the API and record the last sampling timestamp
- raise a warning dialog when no sampling is found for 20 minutes and reset the timer after each successful registration
- remove duplicated helper definitions in the measurement tile widget

## Testing
- flutter analyze
- flutter test

------
https://chatgpt.com/codex/tasks/task_e_68d518eb3668833183e3369e0722a471