### PR TITLE
Refine chanfro detection for angle hints

### DIFF
--- a/lib/features/operador/presentation/widgets/measurement_tile.dart
+++ b/lib/features/operador/presentation/widgets/measurement_tile.dart
@@ -348,6 +348,10 @@ class _MeasurementTileState extends State<MeasurementTile> {
         (angleRange.min != null || angleRange.max != null);
     if (!hasAngleRange) return false;
 
+    final hasAngleHint = RegExp(r'(\bangulo\b|\bang\.\b|graus?|[°º])')
+        .hasMatch(context);
+    if (!hasAngleHint) return false;
+
     final hasMedida = item.minimo != null || item.maximo != null;
     return hasMedida;
   }


### PR DESCRIPTION
## Summary
- ensure chanfro identification requires explicit angle hints like degree markers or the term "ângulo"
- prevent cases with only measurement ranges from showing the angle input field

## Testing
- flutter test *(fails: existing duplicate helper declarations in measurement_tile.dart)*

------
https://chatgpt.com/codex/tasks/task_e_68d51e67a5e483318461eca6e6c4075b