### PR TITLE
Limpa RE ao finalizar turno na amostragem

### DIFF
--- a/lib/features/operador/presentation/operador_page.dart
+++ b/lib/features/operador/presentation/operador_page.dart
@@ -629,6 +629,13 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text('Jornada pausada. Motivo: $motivo')),
         );
+
+        if (motivo == 'Fim do Turno') {
+          setState(() {
+            _reCtrl.clear();
+          });
+        }
+
         return true;
       } else {
         ScaffoldMessenger.of(context).showSnackBar(


### PR DESCRIPTION
## Summary
- limpa o campo de R.E. do preparador ao confirmar o motivo "Fim do Turno" na pausa de jornada

## Testing
- flutter test *(falha conhecida: duplicidade de funções em measurement_tile.dart)*

------
https://chatgpt.com/codex/tasks/task_e_68d561f5d61083318f59661b9cd50565