### PR TITLE
Add OS status overview report

### DIFF
--- a/app_db.py
+++ b/app_db.py
@@ -2,7 +2,7 @@
 from flask import Flask, request, jsonify, send_file
 from flask_cors import CORS
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple
 from collections import defaultdict
 import os
 import re
@@ -2394,6 +2394,109 @@ def relatorio_os():
     except Exception as e:
         app.logger.exception("Falha ao gerar relatório")
         return jsonify({"error": f"Falha ao gerar relatório: {e}"}), 500
+
+
+@app.route("/reports/os_status")
+def relatorio_status_os():
+    def _status_label(raw_status: Optional[str]) -> str:
+        normalized = _normalize_text(raw_status or "")
+        if normalized in {"encerrada", "finalizada", "finalizado"}:
+            return "Finalizada"
+        return "Aberta"
+
+    def _classificar_escolha(texto: str) -> Optional[str]:
+        if not texto:
+            return None
+        base = _normalize_text(_strip_side_prefix(texto))
+        if not base:
+            return None
+        if "reprov" in base:
+            if "abaix" in base:
+                return "reprovada_abaixo"
+            return "reprovada_acima"
+        if "alerta" in base:
+            if "abaix" in base:
+                return "alerta_abaixo"
+            return "alerta_acima"
+        if base in {"ok", "aprovado", "aprovada", "conforme"}:
+            return "ok"
+        return None
+
+    def _split_choices(escolha: str) -> List[str]:
+        partes = re.split(r"[|/]+", escolha)
+        return [p.strip() for p in partes if p and p.strip()]
+
+    try:
+        with _conn_db(DB_NAME) as c:
+            with c.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT os, status
+                      FROM ordem_servico
+                     ORDER BY os
+                    """,
+                )
+                registros = []
+                por_os = {}
+                for row in cur.fetchall():
+                    os_num = row.get("os")
+                    if not os_num:
+                        continue
+                    dados = {
+                        "os": os_num,
+                        "status": _status_label(row.get("status")),
+                        "reprovada_abaixo": 0,
+                        "alerta_abaixo": 0,
+                        "ok": 0,
+                        "alerta_acima": 0,
+                        "reprovada_acima": 0,
+                    }
+                    registros.append(dados)
+                    por_os[os_num] = dados
+
+                cur.execute(
+                    """
+                    SELECT a.os, i.escolha
+                      FROM operador_amostragem a
+                      JOIN operador_amostragem_item i ON i.amostragem_id = a.id
+                    """,
+                )
+                for row in cur.fetchall():
+                    os_num = row.get("os")
+                    if not os_num:
+                        continue
+                    dados = por_os.get(os_num)
+                    if dados is None:
+                        dados = {
+                            "os": os_num,
+                            "status": "Aberta",
+                            "reprovada_abaixo": 0,
+                            "alerta_abaixo": 0,
+                            "ok": 0,
+                            "alerta_acima": 0,
+                            "reprovada_acima": 0,
+                        }
+                        por_os[os_num] = dados
+                        registros.append(dados)
+                    escolha = row.get("escolha") or ""
+                    for parte in _split_choices(escolha):
+                        chave = _classificar_escolha(parte)
+                        if chave is None:
+                            continue
+                        dados[chave] = dados.get(chave, 0) + 1
+
+        def _ordenar(item):
+            os_valor = str(item.get("os", ""))
+            normalizado = _strip_leading_zeros(os_valor)
+            if normalizado.isdigit():
+                return (0, int(normalizado))
+            return (1, normalizado)
+
+        registros.sort(key=_ordenar)
+        return jsonify(registros)
+    except Exception as e:
+        app.logger.exception("Falha ao gerar resumo de status das OS")
+        return jsonify({"error": f"Falha ao gerar resumo: {e}"}), 500
 
 
 @app.route("/reports/export")

--- a/lib/features/export_relatorios/presentation/status_os_page.dart
+++ b/lib/features/export_relatorios/presentation/status_os_page.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+
+import '../../../screens/main/components/side_menu.dart';
+import 'package:admin/widgets/window_bar.dart';
+import '../../../services/report_service.dart';
+
+/// Page that lists all OS with their general status and sampling counts.
+class StatusOsPage extends StatefulWidget {
+  const StatusOsPage({super.key});
+
+  @override
+  State<StatusOsPage> createState() => _StatusOsPageState();
+}
+
+class _StatusOsPageState extends State<StatusOsPage> {
+  bool _loading = false;
+  List<Map<String, dynamic>> _rows = const <Map<String, dynamic>>[];
+
+  static const Map<String, String> _headerMap = {
+    'os': 'OS',
+    'status': 'Status',
+    'reprovada_abaixo': 'Reprovada abaixo',
+    'alerta_abaixo': 'Alerta abaixo',
+    'ok': 'OK',
+    'alerta_acima': 'Alerta acima',
+    'reprovada_acima': 'Reprovada acima',
+  };
+
+  @override
+  void initState() {
+    super.initState();
+    Future.microtask(_carregar);
+  }
+
+  Future<void> _carregar() async {
+    setState(() => _loading = true);
+    final data = await ReportService().fetchOsStatusOverview();
+    if (!mounted) return;
+    setState(() {
+      _rows = data;
+      _loading = false;
+    });
+  }
+
+  String _formatarValor(Map<String, dynamic> row, String key) {
+    final value = row[key];
+    if (value == null) return '';
+    if (value is num) return value.toInt().toString();
+    return value.toString();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final headers = _headerMap.keys.toList();
+    return Scaffold(
+      appBar: const WindowBar(title: 'Status das OS', showMenu: true),
+      drawer: const SideMenu(current: SideMenuSection.dashboard),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            FilledButton(
+              onPressed: _loading ? null : _carregar,
+              child: _loading
+                  ? const SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Text('Atualizar'),
+            ),
+            const SizedBox(height: 24),
+            Expanded(
+              child: _loading
+                  ? const Center(child: CircularProgressIndicator())
+                  : _rows.isEmpty
+                      ? const Center(child: Text('Nenhum dado'))
+                      : SingleChildScrollView(
+                          scrollDirection: Axis.horizontal,
+                          child: SingleChildScrollView(
+                            child: DataTable(
+                              columns: headers
+                                  .map(
+                                    (h) => DataColumn(
+                                      label: Text(
+                                        _headerMap[h] ?? h,
+                                        style: const TextStyle(fontSize: 12),
+                                      ),
+                                    ),
+                                  )
+                                  .toList(),
+                              rows: _rows
+                                  .map(
+                                    (row) => DataRow(
+                                      cells: headers
+                                          .map(
+                                            (h) => DataCell(
+                                              Text(
+                                                _formatarValor(row, h),
+                                                style: const TextStyle(
+                                                  fontSize: 12,
+                                                ),
+                                              ),
+                                            ),
+                                          )
+                                          .toList(),
+                                    ),
+                                  )
+                                  .toList(),
+                            ),
+                          ),
+                        ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/main/components/side_menu.dart
+++ b/lib/screens/main/components/side_menu.dart
@@ -11,6 +11,7 @@ import 'package:admin/features/cadastro_preparadores/presentation/cadastro_prepa
 import 'package:admin/features/export_relatorios/presentation/export_relatorios_page.dart';
 import 'package:admin/features/export_relatorios/presentation/visualizar_relatorios_page.dart';
 import 'package:admin/features/export_relatorios/presentation/tempo_os_page.dart';
+import 'package:admin/features/export_relatorios/presentation/status_os_page.dart';
 import 'package:admin/features/cadastro_maquinas/presentation/cadastro_maquinas_page.dart';
 import 'package:admin/features/login/login_page.dart';
 import 'package:admin/features/users/users_page.dart';
@@ -119,6 +120,11 @@ class SideMenu extends ConsumerWidget {
           title: 'Tempo por OS',
           svgSrc: 'assets/icons/menu_doc.svg',
           press: () => _navigate(context, ref, const TempoOsPage()),
+        ),
+        DrawerListTile(
+          title: 'Status das OS',
+          svgSrc: 'assets/icons/menu_doc.svg',
+          press: () => _navigate(context, ref, const StatusOsPage()),
         ),
       ]);
     }

--- a/lib/services/report_service.dart
+++ b/lib/services/report_service.dart
@@ -127,6 +127,21 @@ class ReportService {
     return null;
   }
 
+  /// Fetch an overview listing all OS with their status and sampling counts.
+  Future<List<Map<String, dynamic>>> fetchOsStatusOverview() async {
+    try {
+      final uri = Uri.parse(_baseUrl).resolve('reports/os_status');
+      final response = await _client.get(uri);
+      if (response.statusCode == 200) {
+        final data = jsonDecode(response.body);
+        if (data is List) {
+          return data.whereType<Map<String, dynamic>>().toList(growable: false);
+        }
+      }
+    } catch (_) {}
+    return [];
+  }
+
   /// Downloads the Excel report for a given OS and type.
   /// Returns `true` if the file was saved successfully.
   Future<bool> exportToExcel({required String os, required String tipo}) async {

--- a/test/report_service_test.dart
+++ b/test/report_service_test.dart
@@ -60,4 +60,15 @@ void main() {
     expect(requestedUri.queryParameters['section'], 'liberacao');
     expect(requestedUri.queryParameters['os'], '456');
   });
+
+  test('fetchOsStatusOverview hits os_status endpoint', () async {
+    late Uri requestedUri;
+    final client = MockClient((req) async {
+      requestedUri = req.url;
+      return http.Response('[]', 200);
+    });
+    final service = ReportService(client: client, baseUrl: 'http://dummy');
+    await service.fetchOsStatusOverview();
+    expect(requestedUri.path, '/reports/os_status');
+  });
 }


### PR DESCRIPTION
## Summary
- add a backend endpoint that aggregates OS status and sampling counts
- expose a Dart service method plus a UI page to visualise the OS status overview
- link the page from the side menu and cover the new service call with tests

## Testing
- flutter test test/report_service_test.dart

------
https://chatgpt.com/codex/tasks/task_e_68d5645c2abc8331a4879dfaf0ca8329