### PR TITLE
Fix OS status reset after machine release

### DIFF
--- a/app_db.py
+++ b/app_db.py
@@ -1415,6 +1415,24 @@ def resultado_preparador():
                         ),
                     )
 
+                status_geral_lower = (status_geral or "").strip().lower()
+                if status_geral_lower in (
+                        "liberada",
+                        "liberado",
+                        "ok",
+                        "aprovada",
+                        "aprovado",
+                ):
+                    cur.execute(
+                        """
+                        UPDATE ordem_servico
+                           SET status='aberta'
+                         WHERE os=%s
+                           AND LOWER(COALESCE(status,'')) IN ('', 'pausada')
+                        """,
+                        (os_num,),
+                    )
+
                 if contexto_tipo == "troca_ferramenta":
                     cur.execute(
                         """


### PR DESCRIPTION
## Summary
- ensure that recording a new liberação updates the ordem de serviço status back to `aberta`
- only reset the status when the liberação result is final so amostragem can proceed after a pause

## Testing
- python -m compileall app_db.py

------
https://chatgpt.com/codex/tasks/task_e_68d56c43772083319bf34097ed561d58