### PR TITLE
Fix OS status aggregation using amostragem counters

### DIFF
--- a/app_db.py
+++ b/app_db.py
@@ -2,7 +2,7 @@
 from flask import Flask, request, jsonify, send_file
 from flask_cors import CORS
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple
 from collections import defaultdict
 import os
 import re
@@ -2394,6 +2394,163 @@ def relatorio_os():
     except Exception as e:
         app.logger.exception("Falha ao gerar relatório")
         return jsonify({"error": f"Falha ao gerar relatório: {e}"}), 500
+
+
+@app.route("/reports/os_status")
+def relatorio_status_os():
+    def _status_label(raw_status: Optional[str]) -> str:
+        normalized = _normalize_text(raw_status or "")
+        if normalized in {"encerrada", "finalizada", "finalizado"}:
+            return "Finalizada"
+        return "Aberta"
+
+    def _classificar_status(texto: str) -> Optional[str]:
+        if not texto:
+            return None
+        base = _normalize_text(_strip_side_prefix(texto))
+        if not base:
+            return None
+        if "reprov" in base:
+            if "abaix" in base:
+                return "reprovada_abaixo"
+            if "acima" in base:
+                return "reprovada_acima"
+            return "reprovada_acima"
+        if "alerta" in base:
+            if "abaix" in base:
+                return "alerta_abaixo"
+            if "acima" in base:
+                return "alerta_acima"
+            return "alerta_acima"
+        if base in {"ok", "aprovado", "aprovada", "conforme"}:
+            return "ok"
+        return None
+
+    def _split_choices(escolha: str) -> List[str]:
+        partes = re.split(r"[|/]+", escolha)
+        return [p.strip() for p in partes if p and p.strip()]
+
+    try:
+        with _conn_db(DB_NAME) as c:
+            with c.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT codigo, categoria
+                      FROM maquinas
+                     WHERE codigo IS NOT NULL AND codigo <> ''
+                    """,
+                )
+                categorias_por_maquina = {}
+                for row in cur.fetchall():
+                    codigo = _norm(row.get("codigo"))
+                    if not codigo:
+                        continue
+                    categorias_por_maquina[codigo] = _norm(row.get("categoria"))
+
+                cur.execute(
+                    """
+                    SELECT os, status
+                      FROM ordem_servico
+                     ORDER BY os
+                    """,
+                )
+                registros = []
+                por_os = {}
+
+                def _novo_registro(os_num: str, status_label: str = "Aberta"):
+                    return {
+                        "os": os_num,
+                        "status": status_label,
+                        "reprovada_abaixo": 0,
+                        "alerta_abaixo": 0,
+                        "ok": 0,
+                        "alerta_acima": 0,
+                        "reprovada_acima": 0,
+                        "_maquinas": set(),
+                        "_categorias": set(),
+                        "_partnumbers": set(),
+                    }
+
+                for row in cur.fetchall():
+                    os_num = _norm(row.get("os"))
+                    if not os_num:
+                        continue
+                    dados = _novo_registro(os_num, _status_label(row.get("status")))
+                    registros.append(dados)
+                    por_os[os_num] = dados
+
+                cur.execute(
+                    """
+                    SELECT a.os,
+                           a.partnumber,
+                           a.maquina,
+                           i.status,
+                           i.escolha,
+                           COUNT(*) AS qtd
+                      FROM operador_amostragem a
+                      JOIN operador_amostragem_item i ON i.amostragem_id = a.id
+                     GROUP BY a.os, a.partnumber, a.maquina, i.status, i.escolha
+                    """,
+                )
+                for row in cur.fetchall():
+                    os_num = _norm(row.get("os"))
+                    if not os_num:
+                        continue
+                    dados = por_os.get(os_num)
+                    if dados is None:
+                        dados = _novo_registro(os_num)
+                        por_os[os_num] = dados
+                        registros.append(dados)
+
+                    partnumber = _norm(row.get("partnumber"))
+                    if partnumber:
+                        dados["_partnumbers"].add(partnumber)
+
+                    maquina = _norm(row.get("maquina"))
+                    if maquina:
+                        dados["_maquinas"].add(maquina)
+                        categoria = categorias_por_maquina.get(maquina)
+                        if categoria:
+                            dados["_categorias"].add(categoria)
+
+                    qtd = int(row.get("qtd") or 0)
+                    if qtd <= 0:
+                        continue
+
+                    status_bruto = row.get("status") or ""
+                    partes_status = _split_choices(status_bruto)
+                    classificados = False
+                    for parte in partes_status:
+                        chave = _classificar_status(parte)
+                        if chave is None:
+                            continue
+                        dados[chave] = dados.get(chave, 0) + qtd
+                        classificados = True
+
+                    if not classificados:
+                        escolha = row.get("escolha") or ""
+                        for parte in _split_choices(escolha):
+                            chave = _classificar_status(parte)
+                            if chave is None:
+                                continue
+                            dados[chave] = dados.get(chave, 0) + qtd
+
+        def _ordenar(item):
+            os_valor = str(item.get("os", ""))
+            normalizado = _strip_leading_zeros(os_valor)
+            if normalizado.isdigit():
+                return (0, int(normalizado))
+            return (1, normalizado)
+
+        for item in registros:
+            item["maquinas"] = sorted(item.pop("_maquinas", set()))
+            item["categorias"] = sorted(item.pop("_categorias", set()))
+            item["partnumbers"] = sorted(item.pop("_partnumbers", set()))
+        registros.sort(key=_ordenar)
+        return jsonify(registros)
+    except Exception as e:
+        app.logger.exception("Falha ao gerar resumo de status das OS")
+        return jsonify({"error": f"Falha ao gerar resumo: {e}"}), 500
 
 
 @app.route("/reports/export")

--- a/lib/features/export_relatorios/presentation/status_os_page.dart
+++ b/lib/features/export_relatorios/presentation/status_os_page.dart
@@ -1,0 +1,727 @@
+import 'dart:collection';
+
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+
+import 'package:admin/widgets/window_bar.dart';
+
+import '../../../screens/main/components/side_menu.dart';
+import '../../../services/report_service.dart';
+
+const _todos = '__all__';
+
+const Map<String, String> _headerMap = {
+  'os': 'OS',
+  'status': 'Status',
+  'reprovada_abaixo': 'Reprovada abaixo',
+  'alerta_abaixo': 'Alerta abaixo',
+  'ok': 'OK',
+  'alerta_acima': 'Alerta acima',
+  'reprovada_acima': 'Reprovada acima',
+  'maquinas': 'Máquinas',
+  'categorias': 'Categorias',
+  'partnumbers': 'Part numbers',
+};
+
+const List<String> _statusKeys = [
+  'reprovada_abaixo',
+  'alerta_abaixo',
+  'ok',
+  'alerta_acima',
+  'reprovada_acima',
+];
+
+const Map<String, Color> _statusColors = {
+  'reprovada_abaixo': Color(0xFFef5350),
+  'alerta_abaixo': Color(0xFFffb74d),
+  'ok': Color(0xFF66bb6a),
+  'alerta_acima': Color(0xFFffa726),
+  'reprovada_acima': Color(0xFFd32f2f),
+};
+
+/// Page that lists all OS with their general status and sampling counts.
+class StatusOsPage extends StatefulWidget {
+  const StatusOsPage({super.key});
+
+  @override
+  State<StatusOsPage> createState() => _StatusOsPageState();
+}
+
+class _StatusOsPageState extends State<StatusOsPage> {
+  bool _loading = false;
+  List<Map<String, dynamic>> _allRows = const <Map<String, dynamic>>[];
+  List<Map<String, dynamic>> _rows = const <Map<String, dynamic>>[];
+
+  List<String> _categorias = const <String>[];
+  List<String> _maquinas = const <String>[];
+  List<String> _partnumbers = const <String>[];
+  List<String> _osOptions = const <String>[];
+
+  String? _categoriaSelecionada;
+  String? _maquinaSelecionada;
+  String? _partnumberSelecionado;
+  String? _osSelecionada;
+
+  @override
+  void initState() {
+    super.initState();
+    Future.microtask(_carregar);
+  }
+
+  Future<void> _carregar() async {
+    setState(() => _loading = true);
+    final data = await ReportService().fetchOsStatusOverview();
+    if (!mounted) return;
+
+    final parsed = data
+        .map<Map<String, dynamic>>((raw) {
+          final mapa = Map<String, dynamic>.from(raw);
+          for (final key in _statusKeys) {
+            final valor = mapa[key];
+            if (valor is num) {
+              mapa[key] = valor.toInt();
+            } else {
+              mapa[key] = 0;
+            }
+          }
+          mapa['categorias'] = SplayTreeSet<String>.from(
+            (mapa['categorias'] as List?)?.whereType<String>() ??
+                const <String>[],
+          ).toList(growable: false);
+          mapa['maquinas'] = SplayTreeSet<String>.from(
+            (mapa['maquinas'] as List?)?.whereType<String>() ??
+                const <String>[],
+          ).toList(growable: false);
+          mapa['partnumbers'] = SplayTreeSet<String>.from(
+            (mapa['partnumbers'] as List?)?.whereType<String>() ??
+                const <String>[],
+          ).toList(growable: false);
+          mapa['status'] = (mapa['status'] ?? '').toString();
+          mapa['os'] = (mapa['os'] ?? '').toString();
+          return mapa;
+        })
+        .toList(growable: false);
+
+    final categorias = SplayTreeSet<String>();
+    final maquinas = SplayTreeSet<String>();
+    final partnumbers = SplayTreeSet<String>();
+    final ordens = SplayTreeSet<String>();
+
+    for (final row in parsed) {
+      categorias.addAll(row['categorias'].cast<String>());
+      maquinas.addAll(row['maquinas'].cast<String>());
+      partnumbers.addAll(row['partnumbers'].cast<String>());
+      ordens.add(row['os'] as String);
+    }
+
+    var categoriaSelecionada = _categoriaSelecionada;
+    if (categoriaSelecionada != null &&
+        !categorias.contains(categoriaSelecionada)) {
+      categoriaSelecionada = null;
+    }
+    var maquinaSelecionada = _maquinaSelecionada;
+    if (maquinaSelecionada != null && !maquinas.contains(maquinaSelecionada)) {
+      maquinaSelecionada = null;
+    }
+    var partnumberSelecionado = _partnumberSelecionado;
+    if (partnumberSelecionado != null &&
+        !partnumbers.contains(partnumberSelecionado)) {
+      partnumberSelecionado = null;
+    }
+    var osSelecionada = _osSelecionada;
+    if (osSelecionada != null && !ordens.contains(osSelecionada)) {
+      osSelecionada = null;
+    }
+
+    final filtrado = _filtrarLista(
+      parsed,
+      categoria: categoriaSelecionada,
+      maquina: maquinaSelecionada,
+      partnumber: partnumberSelecionado,
+      os: osSelecionada,
+    );
+
+    setState(() {
+      _allRows = parsed;
+      _rows = filtrado;
+      _categorias = categorias.toList(growable: false);
+      _maquinas = maquinas.toList(growable: false);
+      _partnumbers = partnumbers.toList(growable: false);
+      _osOptions = ordens.toList(growable: false);
+      _categoriaSelecionada = categoriaSelecionada;
+      _maquinaSelecionada = maquinaSelecionada;
+      _partnumberSelecionado = partnumberSelecionado;
+      _osSelecionada = osSelecionada;
+      _loading = false;
+    });
+  }
+
+  List<Map<String, dynamic>> _filtrarLista(
+    List<Map<String, dynamic>> base, {
+    String? categoria,
+    String? maquina,
+    String? partnumber,
+    String? os,
+  }) {
+    return base
+        .where((row) {
+          final categorias =
+              (row['categorias'] as List?)?.whereType<String>().toList() ??
+              const [];
+          final maquinas =
+              (row['maquinas'] as List?)?.whereType<String>().toList() ??
+              const [];
+          final partnumbers =
+              (row['partnumbers'] as List?)?.whereType<String>().toList() ??
+              const [];
+          final osValor = row['os']?.toString() ?? '';
+
+          if (categoria != null &&
+              categoria.isNotEmpty &&
+              !categorias.contains(categoria)) {
+            return false;
+          }
+          if (maquina != null &&
+              maquina.isNotEmpty &&
+              !maquinas.contains(maquina)) {
+            return false;
+          }
+          if (partnumber != null &&
+              partnumber.isNotEmpty &&
+              !partnumbers.contains(partnumber)) {
+            return false;
+          }
+          if (os != null && os.isNotEmpty && osValor != os) {
+            return false;
+          }
+          return true;
+        })
+        .toList(growable: false);
+  }
+
+  void _atualizarFiltro(void Function() atualizar) {
+    setState(() {
+      atualizar();
+      _rows = _filtrarLista(
+        _allRows,
+        categoria: _categoriaSelecionada,
+        maquina: _maquinaSelecionada,
+        partnumber: _partnumberSelecionado,
+        os: _osSelecionada,
+      );
+    });
+  }
+
+  Map<String, int> _contagemOsPorStatus() {
+    final totais = <String, int>{'Aberta': 0, 'Finalizada': 0};
+    for (final row in _rows) {
+      final status = (row['status'] ?? '').toString();
+      if (totais.containsKey(status)) {
+        totais[status] = (totais[status] ?? 0) + 1;
+      }
+    }
+    return totais;
+  }
+
+  Map<String, int> _totaisPorStatus(String status) {
+    final totais = {for (final key in _statusKeys) key: 0};
+    for (final row in _rows) {
+      if ((row['status'] ?? '') != status) {
+        continue;
+      }
+      for (final key in _statusKeys) {
+        final valor = row[key];
+        if (valor is num) {
+          totais[key] = (totais[key] ?? 0) + valor.toInt();
+        }
+      }
+    }
+    return totais;
+  }
+
+  String _formatarValor(Map<String, dynamic> row, String key) {
+    final value = row[key];
+    if (value == null) return '';
+    if (value is List) {
+      return value.whereType<String>().join(', ');
+    }
+    if (value is num) return value.toInt().toString();
+    return value.toString();
+  }
+
+  Widget _buildDropdown({
+    required String label,
+    required List<String> opcoes,
+    required String? valor,
+    required ValueChanged<String?> onChanged,
+  }) {
+    final items = <DropdownMenuItem<String>>[
+      const DropdownMenuItem<String>(value: _todos, child: Text('Todos')),
+      ...opcoes.map(
+        (opcao) => DropdownMenuItem<String>(value: opcao, child: Text(opcao)),
+      ),
+    ];
+
+    return DropdownButtonFormField<String>(
+      value: valor ?? _todos,
+      items: items,
+      decoration: InputDecoration(labelText: label),
+      onChanged: (selecionado) {
+        if (selecionado == null || selecionado == _todos) {
+          onChanged(null);
+        } else {
+          onChanged(selecionado);
+        }
+      },
+    );
+  }
+
+  Widget _buildFiltros() {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Filtros', style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 16),
+            Wrap(
+              spacing: 16,
+              runSpacing: 16,
+              children: [
+                SizedBox(
+                  width: 220,
+                  child: _buildDropdown(
+                    label: 'Categoria da máquina',
+                    opcoes: _categorias,
+                    valor: _categoriaSelecionada,
+                    onChanged: (valor) =>
+                        _atualizarFiltro(() => _categoriaSelecionada = valor),
+                  ),
+                ),
+                SizedBox(
+                  width: 200,
+                  child: _buildDropdown(
+                    label: 'Máquina',
+                    opcoes: _maquinas,
+                    valor: _maquinaSelecionada,
+                    onChanged: (valor) =>
+                        _atualizarFiltro(() => _maquinaSelecionada = valor),
+                  ),
+                ),
+                SizedBox(
+                  width: 220,
+                  child: _buildDropdown(
+                    label: 'Part number',
+                    opcoes: _partnumbers,
+                    valor: _partnumberSelecionado,
+                    onChanged: (valor) =>
+                        _atualizarFiltro(() => _partnumberSelecionado = valor),
+                  ),
+                ),
+                SizedBox(
+                  width: 180,
+                  child: _buildDropdown(
+                    label: 'OS',
+                    opcoes: _osOptions,
+                    valor: _osSelecionada,
+                    onChanged: (valor) =>
+                        _atualizarFiltro(() => _osSelecionada = valor),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildGraficos() {
+    final totaisAbertas = _totaisPorStatus('Aberta');
+    final totaisFechadas = _totaisPorStatus('Finalizada');
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final charts = [
+          _StatusPieCard(titulo: 'OS abertas', totais: totaisAbertas),
+          _StatusPieCard(titulo: 'OS finalizadas', totais: totaisFechadas),
+        ];
+
+        if (constraints.maxWidth < 720) {
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [charts[0], const SizedBox(height: 16), charts[1]],
+          );
+        }
+
+        return Row(
+          children: [
+            Expanded(child: charts[0]),
+            const SizedBox(width: 16),
+            Expanded(child: charts[1]),
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _buildResumoOs() {
+    final totais = _contagemOsPorStatus();
+    final cards = [
+      _StatusResumoCard(
+        titulo: 'OS abertas',
+        total: totais['Aberta'] ?? 0,
+        color: Theme.of(context).colorScheme.primary,
+        icon: Icons.folder_open,
+      ),
+      _StatusResumoCard(
+        titulo: 'OS finalizadas',
+        total: totais['Finalizada'] ?? 0,
+        color: Theme.of(context).colorScheme.secondary,
+        icon: Icons.task_alt,
+      ),
+    ];
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        if (constraints.maxWidth < 640) {
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              cards[0],
+              const SizedBox(height: 12),
+              cards[1],
+            ],
+          );
+        }
+
+        return Row(
+          children: [
+            Expanded(child: cards[0]),
+            const SizedBox(width: 12),
+            Expanded(child: cards[1]),
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _buildTabela(List<String> headers) {
+    if (_loading && _allRows.isEmpty) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (_rows.isEmpty) {
+      return Card(
+        child: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Text(
+              'Nenhum dado encontrado com os filtros selecionados.',
+              style: Theme.of(context).textTheme.bodyLarge,
+            ),
+          ),
+        ),
+      );
+    }
+
+    return Card(
+      clipBehavior: Clip.antiAlias,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    'Resultados',
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                ),
+                Text('Total de OS: ${_rows.length}'),
+              ],
+            ),
+          ),
+          const Divider(height: 1),
+          Expanded(
+            child: SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: SingleChildScrollView(
+                child: DataTable(
+                  headingRowColor: MaterialStateColor.resolveWith(
+                    (states) => Theme.of(
+                      context,
+                    ).colorScheme.surfaceVariant.withOpacity(0.4),
+                  ),
+                  columns: headers
+                      .map(
+                        (h) => DataColumn(
+                          label: Text(
+                            _headerMap[h] ?? h,
+                            style: const TextStyle(fontSize: 12),
+                          ),
+                        ),
+                      )
+                      .toList(),
+                  rows: _rows
+                      .map(
+                        (row) => DataRow(
+                          cells: headers
+                              .map(
+                                (h) => DataCell(
+                                  ConstrainedBox(
+                                    constraints: const BoxConstraints(
+                                      maxWidth: 200,
+                                    ),
+                                    child: Text(
+                                      _formatarValor(row, h),
+                                      style: const TextStyle(fontSize: 12),
+                                    ),
+                                  ),
+                                ),
+                              )
+                              .toList(),
+                        ),
+                      )
+                      .toList(),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final headers = _headerMap.keys.toList();
+
+    return Scaffold(
+      appBar: const WindowBar(title: 'Status das OS', showMenu: true),
+      drawer: const SideMenu(current: SideMenuSection.dashboard),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  FilledButton.icon(
+                    onPressed: _loading ? null : _carregar,
+                    icon: const Icon(Icons.refresh),
+                    label: _loading
+                        ? const Text('Atualizando...')
+                        : const Text('Atualizar'),
+                  ),
+                  if (_loading) ...[
+                    const SizedBox(width: 16),
+                    const SizedBox(
+                      width: 18,
+                      height: 18,
+                      child: CircularProgressIndicator(strokeWidth: 2.2),
+                    ),
+                  ],
+                ],
+              ),
+              const SizedBox(height: 16),
+              _buildFiltros(),
+              const SizedBox(height: 16),
+              _buildResumoOs(),
+              const SizedBox(height: 16),
+              _buildGraficos(),
+              const SizedBox(height: 16),
+              Expanded(child: _buildTabela(headers)),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _StatusPieCard extends StatelessWidget {
+  const _StatusPieCard({required this.titulo, required this.totais});
+
+  final String titulo;
+  final Map<String, int> totais;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final total = totais.values.fold<int>(0, (acc, value) => acc + value);
+    final sections = _statusKeys
+        .map((key) => MapEntry(key, totais[key] ?? 0))
+        .where((entry) => entry.value > 0)
+        .map(
+          (entry) => PieChartSectionData(
+            color: _statusColors[entry.key],
+            value: entry.value.toDouble(),
+            showTitle: false,
+            radius: 80,
+          ),
+        )
+        .toList();
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(titulo, style: theme.textTheme.titleMedium),
+            const SizedBox(height: 16),
+            SizedBox(
+              height: 240,
+              child: sections.isEmpty
+                  ? const Center(child: Text('Sem dados para exibir.'))
+                  : Stack(
+                      alignment: Alignment.center,
+                      children: [
+                        PieChart(
+                          PieChartData(
+                            sections: sections,
+                            sectionsSpace: 2,
+                            centerSpaceRadius: 70,
+                            startDegreeOffset: -90,
+                          ),
+                        ),
+                        Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Text(
+                              '$total',
+                              style: theme.textTheme.headlineSmall?.copyWith(
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                            const Text('amostragens'),
+                          ],
+                        ),
+                      ],
+                    ),
+            ),
+            const SizedBox(height: 12),
+            _StatusLegend(totais: totais),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _StatusLegend extends StatelessWidget {
+  const _StatusLegend({required this.totais});
+
+  final Map<String, int> totais;
+
+  @override
+  Widget build(BuildContext context) {
+    final entries = _statusKeys
+        .map((key) => MapEntry(key, totais[key] ?? 0))
+        .toList(growable: false);
+
+    return Wrap(
+      spacing: 12,
+      runSpacing: 8,
+      children: entries
+          .map(
+            (entry) => _LegendEntry(
+              color: _statusColors[entry.key]!,
+              label: '${_headerMap[entry.key]}: ${entry.value}',
+            ),
+          )
+          .toList(),
+    );
+  }
+}
+
+class _StatusResumoCard extends StatelessWidget {
+  const _StatusResumoCard({
+    required this.titulo,
+    required this.total,
+    required this.color,
+    required this.icon,
+  });
+
+  final String titulo;
+  final int total;
+  final Color color;
+  final IconData icon;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Container(
+              width: 48,
+              height: 48,
+              decoration: BoxDecoration(
+                color: color.withOpacity(0.15),
+                borderRadius: BorderRadius.circular(12),
+              ),
+              child: Icon(icon, color: color),
+            ),
+            const SizedBox(width: 16),
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  titulo,
+                  style: theme.textTheme.titleSmall?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  '$total',
+                  style: theme.textTheme.headlineMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _LegendEntry extends StatelessWidget {
+  const _LegendEntry({required this.color, required this.label});
+
+  final Color color;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Container(
+          width: 12,
+          height: 12,
+          decoration: BoxDecoration(
+            color: color,
+            borderRadius: BorderRadius.circular(2),
+          ),
+        ),
+        const SizedBox(width: 6),
+        Text(label),
+      ],
+    );
+  }
+}

--- a/lib/features/operador/presentation/widgets/measurement_tile.dart
+++ b/lib/features/operador/presentation/widgets/measurement_tile.dart
@@ -1099,15 +1099,3 @@ class _MeasurementTileState extends State<MeasurementTile> {
     return _buildAutomaticEntry(context);
   }
 }
-
-double? _parseManualValue(String txt) {
-  final normalized = txt.replaceAll(',', '.').trim();
-  if (normalized.isEmpty) return null;
-  return double.tryParse(normalized);
-}
-
-double? _parseAngleInput(String txt) {
-  final sanitized = txt.replaceAll(RegExp("[°º'’′\"″”]"), '').trim();
-  if (sanitized.isEmpty) return null;
-  return _parseManualValue(sanitized);
-}

--- a/lib/screens/main/components/side_menu.dart
+++ b/lib/screens/main/components/side_menu.dart
@@ -11,6 +11,7 @@ import 'package:admin/features/cadastro_preparadores/presentation/cadastro_prepa
 import 'package:admin/features/export_relatorios/presentation/export_relatorios_page.dart';
 import 'package:admin/features/export_relatorios/presentation/visualizar_relatorios_page.dart';
 import 'package:admin/features/export_relatorios/presentation/tempo_os_page.dart';
+import 'package:admin/features/export_relatorios/presentation/status_os_page.dart';
 import 'package:admin/features/cadastro_maquinas/presentation/cadastro_maquinas_page.dart';
 import 'package:admin/features/login/login_page.dart';
 import 'package:admin/features/users/users_page.dart';
@@ -119,6 +120,11 @@ class SideMenu extends ConsumerWidget {
           title: 'Tempo por OS',
           svgSrc: 'assets/icons/menu_doc.svg',
           press: () => _navigate(context, ref, const TempoOsPage()),
+        ),
+        DrawerListTile(
+          title: 'Status das OS',
+          svgSrc: 'assets/icons/menu_doc.svg',
+          press: () => _navigate(context, ref, const StatusOsPage()),
         ),
       ]);
     }

--- a/lib/services/report_service.dart
+++ b/lib/services/report_service.dart
@@ -127,6 +127,21 @@ class ReportService {
     return null;
   }
 
+  /// Fetch an overview listing all OS with their status and sampling counts.
+  Future<List<Map<String, dynamic>>> fetchOsStatusOverview() async {
+    try {
+      final uri = Uri.parse(_baseUrl).resolve('reports/os_status');
+      final response = await _client.get(uri);
+      if (response.statusCode == 200) {
+        final data = jsonDecode(response.body);
+        if (data is List) {
+          return data.whereType<Map<String, dynamic>>().toList(growable: false);
+        }
+      }
+    } catch (_) {}
+    return [];
+  }
+
   /// Downloads the Excel report for a given OS and type.
   /// Returns `true` if the file was saved successfully.
   Future<bool> exportToExcel({required String os, required String tipo}) async {

--- a/test/report_service_test.dart
+++ b/test/report_service_test.dart
@@ -60,4 +60,15 @@ void main() {
     expect(requestedUri.queryParameters['section'], 'liberacao');
     expect(requestedUri.queryParameters['os'], '456');
   });
+
+  test('fetchOsStatusOverview hits os_status endpoint', () async {
+    late Uri requestedUri;
+    final client = MockClient((req) async {
+      requestedUri = req.url;
+      return http.Response('[]', 200);
+    });
+    final service = ReportService(client: client, baseUrl: 'http://dummy');
+    await service.fetchOsStatusOverview();
+    expect(requestedUri.path, '/reports/os_status');
+  });
 }


### PR DESCRIPTION
## Summary
- atualiza `/reports/os_status` para deduzir contagens a partir das amostragens consolidadas, reutilizando os mesmos rótulos exibidos no Operador
- normaliza o mapeamento de máquinas, categorias e partnumbers usando conjuntos antes da serialização para evitar duplicidades
- adiciona cards de resumo para destacar o total de OS abertas e finalizadas com base nos filtros aplicados

## Testing
- flutter test

------
https://chatgpt.com/codex/tasks/task_e_68d5645c2abc8331a4879dfaf0ca8329