### PR TITLE
Restore pie charts alongside OS summary cards

### DIFF
--- a/lib/features/export_relatorios/presentation/status_os_page.dart
+++ b/lib/features/export_relatorios/presentation/status_os_page.dart
@@ -211,6 +211,10 @@ class _StatusOsPageState extends State<StatusOsPage> {
     });
   }
 
+  int _contarOsPorStatus(String status) {
+    return _rows.where((row) => (row['status'] ?? '') == status).length;
+  }
+
   Map<String, int> _totaisPorStatus(String status) {
     final totais = {for (final key in _statusKeys) key: 0};
     for (final row in _rows) {
@@ -325,15 +329,54 @@ class _StatusOsPageState extends State<StatusOsPage> {
     );
   }
 
+  Widget _buildResumoStatus() {
+    final abertas = _contarOsPorStatus('Aberta');
+    final finalizadas = _contarOsPorStatus('Finalizada');
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final cards = [
+          _StatusCountCard(
+            titulo: 'OS abertas',
+            total: abertas,
+            icon: Icons.folder_open_outlined,
+            color: Theme.of(context).colorScheme.primary,
+          ),
+          _StatusCountCard(
+            titulo: 'OS finalizadas',
+            total: finalizadas,
+            icon: Icons.task_alt_outlined,
+            color: Theme.of(context).colorScheme.secondary,
+          ),
+        ];
+
+        if (constraints.maxWidth < 720) {
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [cards[0], const SizedBox(height: 16), cards[1]],
+          );
+        }
+
+        return Row(
+          children: [
+            Expanded(child: cards[0]),
+            const SizedBox(width: 16),
+            Expanded(child: cards[1]),
+          ],
+        );
+      },
+    );
+  }
+
   Widget _buildGraficos() {
     final totaisAbertas = _totaisPorStatus('Aberta');
-    final totaisFechadas = _totaisPorStatus('Finalizada');
+    final totaisFinalizadas = _totaisPorStatus('Finalizada');
 
     return LayoutBuilder(
       builder: (context, constraints) {
         final charts = [
           _StatusPieCard(titulo: 'OS abertas', totais: totaisAbertas),
-          _StatusPieCard(titulo: 'OS finalizadas', totais: totaisFechadas),
+          _StatusPieCard(titulo: 'OS finalizadas', totais: totaisFinalizadas),
         ];
 
         if (constraints.maxWidth < 720) {
@@ -478,11 +521,67 @@ class _StatusOsPageState extends State<StatusOsPage> {
               const SizedBox(height: 16),
               _buildFiltros(),
               const SizedBox(height: 16),
+              _buildResumoStatus(),
+              const SizedBox(height: 16),
               _buildGraficos(),
               const SizedBox(height: 16),
               Expanded(child: _buildTabela(headers)),
             ],
           ),
+        ),
+      ),
+    );
+  }
+}
+
+class _StatusCountCard extends StatelessWidget {
+  const _StatusCountCard({
+    required this.titulo,
+    required this.total,
+    required this.icon,
+    required this.color,
+  });
+
+  final String titulo;
+  final int total;
+  final IconData icon;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Row(
+          children: [
+            Container(
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: color.withOpacity(0.12),
+                borderRadius: BorderRadius.circular(12),
+              ),
+              child: Icon(icon, color: color, size: 28),
+            ),
+            const SizedBox(width: 16),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(titulo, style: theme.textTheme.titleMedium),
+                  const SizedBox(height: 8),
+                  Text(
+                    '$total',
+                    style: theme.textTheme.headlineMedium?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- add a dedicated status summary layout so the OS abertas/finalizadas totals render as responsive cards above the analytics section
- restore the pie chart layout to its original side-by-side presentation so both original charts remain visible

## Testing
- flutter analyze *(emits existing deprecation warnings from the project)*

------
https://chatgpt.com/codex/tasks/task_e_68d58a8d86848331a9125615fa516378