### PR TITLE
Enforce measurement input whitespace rules and normalize codes

### DIFF
--- a/lib/features/operador/presentation/widgets/measurement_tile.dart
+++ b/lib/features/operador/presentation/widgets/measurement_tile.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import 'package:admin/features/preparacao/data/models.dart';
 
@@ -836,6 +837,9 @@ class _MeasurementTileState extends State<MeasurementTile> {
                   labelText: 'Ângulo (°)',
                   border: OutlineInputBorder(),
                 ),
+                inputFormatters: [
+                  FilteringTextInputFormatter.deny(RegExp(r'\s')),
+                ],
                 onChanged: (_) => _handleChanfroChanged(),
               ),
               const SizedBox(height: 10),
@@ -851,6 +855,9 @@ class _MeasurementTileState extends State<MeasurementTile> {
                   helperText: helper,
                   helperStyle: TextStyle(color: helperColor),
                 ),
+                inputFormatters: [
+                  FilteringTextInputFormatter.deny(RegExp(r'\s')),
+                ],
                 onChanged: (_) => _handleChanfroChanged(),
               ),
             ] else if (isRepetir3) ...[
@@ -896,6 +903,9 @@ class _MeasurementTileState extends State<MeasurementTile> {
                   helperText: helper,
                   helperStyle: TextStyle(color: helperColor),
                 ),
+                inputFormatters: [
+                  FilteringTextInputFormatter.deny(RegExp(r'\s')),
+                ],
                 onChanged: (txt) {
                   final v = _parseManualValue(txt);
                   final novoStatus = item.avaliarStatus(v);

--- a/lib/utils/string_utils.dart
+++ b/lib/utils/string_utils.dart
@@ -5,5 +5,6 @@
 String normalizeCode(String value) {
   final trimmed = value.trim();
   final normalized = trimmed.replaceFirst(RegExp(r'^0+'), '');
-  return normalized.isEmpty ? '0' : normalized;
+  final ensured = normalized.isEmpty ? '0' : normalized;
+  return ensured.toUpperCase();
 }


### PR DESCRIPTION
## Summary
- prevent whitespace entry in manual measurement fields for preparador flows
- ensure normalized codes are uppercased while preserving leading-zero trimming

## Testing
- flutter test *(fails: existing compilation errors in status_os_page.dart due to duplicate declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68d594bc1e088331a4e8da5866ffa244