### PR TITLE
Filter tool-change entries from sampling reports

### DIFF
--- a/app_db.py
+++ b/app_db.py
@@ -82,7 +82,7 @@ def _sql_operador_context_filter(alias: str = "a") -> str:
         " AND NOT EXISTS ("
         "SELECT 1 FROM operador_amostragem_item tf "
         f"WHERE tf.amostragem_id = {alias}.id "
-        "AND LOWER(COALESCE(tf.observacao, '')) LIKE '%troca de ferramenta%')"
+        "AND LOWER(COALESCE(tf.observacao, '')) LIKE '%%troca de ferramenta%%')"
         ")"
     )
 

--- a/app_db.py
+++ b/app_db.py
@@ -444,6 +444,9 @@ def _ensure_schema():
                 "ON preparador_liberacao (os, partnumber, maquina)"
             )
         _ensure_column(c, "operador_amostragem", "maquina", "VARCHAR(128) DEFAULT NULL")
+        _ensure_column(
+            c, "operador_amostragem", "contexto", "VARCHAR(64) DEFAULT NULL"
+        )
         _ensure_column(c, "preparador_registro", "maquina", "VARCHAR(128) DEFAULT NULL")
         _ensure_column(
             c, "preparador_finalizacao", "maquina", "VARCHAR(128) DEFAULT NULL"
@@ -749,6 +752,7 @@ def _medidas_operador_db(part: str, op: str, os_num: Optional[str] = None):
                   JOIN operador_amostragem a ON a.id = i.amostragem_id
                  WHERE TRIM(LEADING '0' FROM TRIM(a.partnumber))=%s
                    AND TRIM(LEADING '0' FROM TRIM(a.operacao))=%s
+                   AND COALESCE(LOWER(a.contexto), '') <> 'troca_ferramenta'
                    {filtro_os}
                  GROUP BY i.idx_medida, i.titulo, i.escolha
                 """,
@@ -1418,10 +1422,10 @@ def resultado_preparador():
                 if contexto_tipo == "troca_ferramenta":
                     cur.execute(
                         """
-                        INSERT INTO operador_amostragem (os, partnumber, operacao, re_operador, maquina)
-                        VALUES (%s, %s, %s, %s, %s)
+                        INSERT INTO operador_amostragem (os, partnumber, operacao, re_operador, maquina, contexto)
+                        VALUES (%s, %s, %s, %s, %s, %s)
                         """,
-                        (os_num, part, op, re_prep, maquina),
+                        (os_num, part, op, re_prep, maquina, contexto_tipo),
                     )
                     amostragem_id = cur.lastrowid
 
@@ -1703,6 +1707,8 @@ def operador_registrar():
     op = _norm_op(payload.get("operacao"))
     maquina = _norm(payload.get("maquina"))
     itens = payload.get("itens", [])
+    contexto = _norm(payload.get("contexto"))
+    contexto_tipo = contexto.lower() if contexto else "operador"
 
     # validações mínimas
     if not os_num or not re_op or not part or not op or not maquina:
@@ -1773,10 +1779,10 @@ def operador_registrar():
                 # cabeçalho
                 cur.execute(
                     """
-                    INSERT INTO operador_amostragem (os, partnumber, operacao, re_operador, maquina)
-                    VALUES (%s, %s, %s, %s, %s)
+                    INSERT INTO operador_amostragem (os, partnumber, operacao, re_operador, maquina, contexto)
+                    VALUES (%s, %s, %s, %s, %s, %s)
                     """,
-                    (os_num, part, op, re_op, maquina),
+                    (os_num, part, op, re_op, maquina, contexto_tipo),
                 )
                 amostragem_id = cur.lastrowid
 
@@ -1888,7 +1894,7 @@ def operador_listar():
     os_num = _norm(request.args.get("os"))
     part = _norm_part(request.args.get("partnumber"))
     op = _norm_op(request.args.get("operacao"))
-    where = []
+    where = ["COALESCE(LOWER(a.contexto), '') <> 'troca_ferramenta'"]
     params = []
     if os_num:
         where.append("a.os = %s")
@@ -2034,7 +2040,8 @@ def operador_encerrar_producao():
         with _conn_db(DB_NAME) as c:
             with c.cursor() as cur:
                 cur.execute(
-                    "SELECT COUNT(*) AS cnt FROM operador_amostragem WHERE os=%s",
+                    "SELECT COUNT(*) AS cnt FROM operador_amostragem"
+                    " WHERE os=%s AND COALESCE(LOWER(contexto), '') <> 'troca_ferramenta'",
                     (os_num,),
                 )
                 if cur.fetchone()["cnt"] == 0:
@@ -2213,6 +2220,7 @@ def listar_relatorios_operador():
                           FROM operador_amostragem a
                           JOIN operador_amostragem_item i ON i.amostragem_id = a.id
                          WHERE a.os = %s
+                           AND COALESCE(LOWER(a.contexto), '') <> 'troca_ferramenta'
                          ORDER BY i.idx_medida, i.created_at
                         """,
                         (os_num,),
@@ -2230,6 +2238,7 @@ def listar_relatorios_operador():
                           JOIN operador_amostragem_item i ON i.amostragem_id = a.id
                          WHERE TRIM(LEADING '0' FROM TRIM(a.partnumber)) = %s
                            AND TRIM(LEADING '0' FROM TRIM(a.operacao)) = %s
+                           AND COALESCE(LOWER(a.contexto), '') <> 'troca_ferramenta'
                          ORDER BY i.idx_medida, i.created_at
                         """,
                         (part, op),
@@ -2255,6 +2264,7 @@ def listar_relatorios_operador():
                                a.created_at
                           FROM operador_amostragem a
                           LEFT JOIN operador_amostragem_item i ON i.amostragem_id = a.id
+                         WHERE COALESCE(LOWER(a.contexto), '') <> 'troca_ferramenta'
                           GROUP BY a.id
                           ORDER BY a.created_at DESC
                           LIMIT 200
@@ -2312,6 +2322,7 @@ def relatorio_os():
                           FROM operador_amostragem a
                           JOIN operador_amostragem_item i ON i.amostragem_id = a.id
                          WHERE a.os=%s
+                           AND COALESCE(LOWER(a.contexto), '') <> 'troca_ferramenta'
                          ORDER BY i.idx_medida, i.created_at
                         """,
                         (os_num,),
@@ -2490,6 +2501,7 @@ def relatorio_status_os():
                            COUNT(*) AS qtd
                       FROM operador_amostragem a
                       JOIN operador_amostragem_item i ON i.amostragem_id = a.id
+                     WHERE COALESCE(LOWER(a.contexto), '') <> 'troca_ferramenta'
                      GROUP BY a.os, a.partnumber, a.maquina, i.status, i.escolha
                     """,
                 )
@@ -2541,6 +2553,7 @@ def relatorio_status_os():
                     SELECT os, re_operador, COUNT(*) AS qtd
                       FROM operador_amostragem
                      WHERE re_operador IS NOT NULL AND re_operador <> ''
+                       AND COALESCE(LOWER(contexto), '') <> 'troca_ferramenta'
                      GROUP BY os, re_operador
                     """,
                 )
@@ -2718,6 +2731,7 @@ def exportar_relatorio_excel():
                         JOIN operador_amostragem_item i ON i.amostragem_id = a.id
 
                         WHERE a.os=%s
+                          AND COALESCE(LOWER(a.contexto), '') <> 'troca_ferramenta'
                         ORDER BY a.created_at DESC, i.idx_medida ASC
                         """,
                         (os_num,),

--- a/app_db.py
+++ b/app_db.py
@@ -73,6 +73,20 @@ def _run_sql_report(sql_path: str, dbname: str = DB_NAME):
     return rows
 
 
+def _sql_operador_context_filter(alias: str = "a") -> str:
+    """Cláusula SQL que ignora registros de troca de ferramenta."""
+
+    alias = alias.strip() or "operador_amostragem"
+    return (
+        f"(COALESCE(LOWER({alias}.contexto), '') <> 'troca_ferramenta'"
+        " AND NOT EXISTS ("
+        "SELECT 1 FROM operador_amostragem_item tf "
+        f"WHERE tf.amostragem_id = {alias}.id "
+        "AND LOWER(COALESCE(tf.observacao, '')) LIKE '%troca de ferramenta%')"
+        ")"
+    )
+
+
 def _tables_exist(cur, *names) -> bool:
     """Verifica se todas as tabelas informadas existem no banco atual."""
     placeholders = ",".join(["%s"] * len(names))
@@ -742,6 +756,7 @@ def _medidas_operador_db(part: str, op: str, os_num: Optional[str] = None):
                 filtro_os = " AND a.os=%s"
                 params.append(os_norm)
 
+            filtro_contexto = _sql_operador_context_filter("a")
             cur.execute(
                 f"""
                 SELECT i.idx_medida,
@@ -752,7 +767,7 @@ def _medidas_operador_db(part: str, op: str, os_num: Optional[str] = None):
                   JOIN operador_amostragem a ON a.id = i.amostragem_id
                  WHERE TRIM(LEADING '0' FROM TRIM(a.partnumber))=%s
                    AND TRIM(LEADING '0' FROM TRIM(a.operacao))=%s
-                   AND COALESCE(LOWER(a.contexto), '') <> 'troca_ferramenta'
+                   AND {filtro_contexto}
                    {filtro_os}
                  GROUP BY i.idx_medida, i.titulo, i.escolha
                 """,
@@ -1894,7 +1909,7 @@ def operador_listar():
     os_num = _norm(request.args.get("os"))
     part = _norm_part(request.args.get("partnumber"))
     op = _norm_op(request.args.get("operacao"))
-    where = ["COALESCE(LOWER(a.contexto), '') <> 'troca_ferramenta'"]
+    where = [_sql_operador_context_filter("a")]
     params = []
     if os_num:
         where.append("a.os = %s")
@@ -2039,9 +2054,11 @@ def operador_encerrar_producao():
     try:
         with _conn_db(DB_NAME) as c:
             with c.cursor() as cur:
+                filtro_contexto = _sql_operador_context_filter("operador_amostragem")
                 cur.execute(
-                    "SELECT COUNT(*) AS cnt FROM operador_amostragem"
-                    " WHERE os=%s AND COALESCE(LOWER(contexto), '') <> 'troca_ferramenta'",
+                    f"SELECT COUNT(*) AS cnt FROM operador_amostragem"
+                    " WHERE os=%s AND "
+                    f"{filtro_contexto}",
                     (os_num,),
                 )
                 if cur.fetchone()["cnt"] == 0:
@@ -2208,19 +2225,20 @@ def listar_relatorios_operador():
     try:
         with _conn_db(DB_NAME) as c:
             with c.cursor() as cur:
+                filtro_contexto = _sql_operador_context_filter("a")
                 registros = []
                 pausa_filters = []
                 pausa_params = []
                 if os_num:
                     cur.execute(
-                        """
+                        f"""
                         SELECT a.os, a.partnumber, a.operacao, a.re_operador, a.maquina,
                                i.idx_medida, i.titulo, i.instrumento,
                                i.faixa_texto, i.escolha, i.status, i.created_at
                           FROM operador_amostragem a
                           JOIN operador_amostragem_item i ON i.amostragem_id = a.id
                          WHERE a.os = %s
-                           AND COALESCE(LOWER(a.contexto), '') <> 'troca_ferramenta'
+                           AND {filtro_contexto}
                          ORDER BY i.idx_medida, i.created_at
                         """,
                         (os_num,),
@@ -2230,7 +2248,7 @@ def listar_relatorios_operador():
                     pausa_params.append(os_num)
                 elif part and op:
                     cur.execute(
-                        """
+                        f"""
                         SELECT a.os, a.partnumber, a.operacao, a.re_operador, a.maquina,
                                i.idx_medida, i.titulo, i.instrumento,
                                i.faixa_texto, i.escolha, i.status, i.created_at
@@ -2238,7 +2256,7 @@ def listar_relatorios_operador():
                           JOIN operador_amostragem_item i ON i.amostragem_id = a.id
                          WHERE TRIM(LEADING '0' FROM TRIM(a.partnumber)) = %s
                            AND TRIM(LEADING '0' FROM TRIM(a.operacao)) = %s
-                           AND COALESCE(LOWER(a.contexto), '') <> 'troca_ferramenta'
+                           AND {filtro_contexto}
                          ORDER BY i.idx_medida, i.created_at
                         """,
                         (part, op),
@@ -2254,7 +2272,7 @@ def listar_relatorios_operador():
                     pausa_params.append(op)
                 else:
                     cur.execute(
-                        """
+                        f"""
                         SELECT a.os, a.partnumber, a.operacao, a.re_operador,
                                CASE
                                   WHEN SUM(CASE WHEN LOWER(i.status) LIKE '%%reprov%%' THEN 1 ELSE 0 END) > 0 THEN 'reprovado'
@@ -2264,7 +2282,7 @@ def listar_relatorios_operador():
                                a.created_at
                           FROM operador_amostragem a
                           LEFT JOIN operador_amostragem_item i ON i.amostragem_id = a.id
-                         WHERE COALESCE(LOWER(a.contexto), '') <> 'troca_ferramenta'
+                         WHERE {filtro_contexto}
                           GROUP BY a.id
                           ORDER BY a.created_at DESC
                           LIMIT 200
@@ -2304,6 +2322,7 @@ def relatorio_os():
     try:
         with _conn_db(DB_NAME) as c:
             with c.cursor() as cur:
+                filtro_contexto = _sql_operador_context_filter("a")
                 os_data = None
                 amostragem = []
                 jornada = []
@@ -2314,7 +2333,7 @@ def relatorio_os():
                     os_data = cur.fetchone()
                 if section in ("full", "amostragem"):
                     cur.execute(
-                        """
+                        f"""
                         SELECT a.os, a.partnumber, a.operacao, a.re_operador,
                                a.maquina,
                                i.idx_medida, i.titulo, i.instrumento,
@@ -2322,7 +2341,7 @@ def relatorio_os():
                           FROM operador_amostragem a
                           JOIN operador_amostragem_item i ON i.amostragem_id = a.id
                          WHERE a.os=%s
-                           AND COALESCE(LOWER(a.contexto), '') <> 'troca_ferramenta'
+                           AND {filtro_contexto}
                          ORDER BY i.idx_medida, i.created_at
                         """,
                         (os_num,),
@@ -2444,6 +2463,7 @@ def relatorio_status_os():
     try:
         with _conn_db(DB_NAME) as c:
             with c.cursor() as cur:
+                filtro_contexto = _sql_operador_context_filter("a")
                 cur.execute(
                     """
                     SELECT codigo, categoria
@@ -2492,7 +2512,7 @@ def relatorio_status_os():
                     por_os[os_num] = dados
 
                 cur.execute(
-                    """
+                    f"""
                     SELECT a.os,
                            a.partnumber,
                            a.maquina,
@@ -2501,7 +2521,7 @@ def relatorio_status_os():
                            COUNT(*) AS qtd
                       FROM operador_amostragem a
                       JOIN operador_amostragem_item i ON i.amostragem_id = a.id
-                     WHERE COALESCE(LOWER(a.contexto), '') <> 'troca_ferramenta'
+                     WHERE {filtro_contexto}
                      GROUP BY a.os, a.partnumber, a.maquina, i.status, i.escolha
                     """,
                 )
@@ -2549,11 +2569,11 @@ def relatorio_status_os():
                             dados[chave] = dados.get(chave, 0) + qtd
 
                 cur.execute(
-                    """
+                    f"""
                     SELECT os, re_operador, COUNT(*) AS qtd
                       FROM operador_amostragem
                      WHERE re_operador IS NOT NULL AND re_operador <> ''
-                       AND COALESCE(LOWER(contexto), '') <> 'troca_ferramenta'
+                       AND {_sql_operador_context_filter('operador_amostragem')}
                      GROUP BY os, re_operador
                     """,
                 )
@@ -2720,8 +2740,9 @@ def exportar_relatorio_excel():
                             combined[key] = row
                     rows = list(combined.values())
                 else:
+                    filtro_contexto = _sql_operador_context_filter("a")
                     cur.execute(
-                        """
+                        f"""
                         SELECT a.os, a.partnumber, a.operacao, a.re_operador, a.maquina,
                                i.idx_medida, i.titulo, i.instrumento, i.faixa_texto,
                                i.minimo, i.maximo, i.unidade, i.periodicidade,
@@ -2731,7 +2752,7 @@ def exportar_relatorio_excel():
                         JOIN operador_amostragem_item i ON i.amostragem_id = a.id
 
                         WHERE a.os=%s
-                          AND COALESCE(LOWER(a.contexto), '') <> 'troca_ferramenta'
+                          AND {filtro_contexto}
                         ORDER BY a.created_at DESC, i.idx_medida ASC
                         """,
                         (os_num,),


### PR DESCRIPTION
## Summary
- persist the sampling context on operador_amostragem records
- tag operator submissions as "operador" and tool-change clones as "troca_ferramenta"
- filter tool-change records out of operator reports, listings, exports and counters

## Testing
- python -m py_compile app_db.py

------
https://chatgpt.com/codex/tasks/task_e_68da5fe6a7b08331aaf17a63be846c5e