### PR TITLE
Add revision date to measurement headers

### DIFF
--- a/app_db.py
+++ b/app_db.py
@@ -647,7 +647,8 @@ def _medidas_preparador_db(part: str, op: str):
         with c.cursor() as cur:
             cur.execute(
                 """
-                SELECT idx_medida, titulo, faixa_texto, instrumento, minimo, maximo
+                SELECT idx_medida, titulo, faixa_texto, instrumento, minimo, maximo,
+                       data_inclusao
                 FROM for07_norm
 
                 WHERE TRIM(LEADING '0' FROM TRIM(partnumber))=%s
@@ -691,6 +692,7 @@ def _medidas_preparador_db(part: str, op: str):
                 "max": mx,
                 "unidade": uni,
                 "instrumento": row.get("instrumento") or "",
+                "data_inclusao": row.get("data_inclusao"),
             }
         )
     return medidas
@@ -721,7 +723,7 @@ def _medidas_operador_db(part: str, op: str, os_num: Optional[str] = None):
             cur.execute(
                 """
                 SELECT idx_medida, titulo, faixa_texto, minimo, maximo,
-                       periodicidade, instrumento,
+                       periodicidade, instrumento, data_inclusao,
                        reprovada_abaixo, alerta_abaixo, alerta_acima, reprovada_acima
                 FROM for09_norm
                 WHERE TRIM(LEADING '0' FROM TRIM(partnumber))=%s
@@ -820,6 +822,7 @@ def _medidas_operador_db(part: str, op: str, os_num: Optional[str] = None):
                 "instrumento": row.get("instrumento") or "",
                 "tolerancias": tolerancias,
                 "contagens": {k: int(v) for k, v in raw_counts.items()},
+                "data_inclusao": row.get("data_inclusao"),
             }
         )
     return medidas

--- a/lib/features/finalizar_os/presentation/finalizar_os_page.dart
+++ b/lib/features/finalizar_os/presentation/finalizar_os_page.dart
@@ -6,6 +6,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:http/http.dart' as http;
+import 'package:intl/intl.dart';
 
 import 'package:admin/features/preparacao/data/models.dart';
 import 'package:admin/features/preparacao/data/repository_provider.dart';
@@ -66,6 +67,7 @@ class MedidasFinalizadorController
               observacao: m.observacao,
               periodicidade: m.periodicidade,
               instrumento: m.instrumento,
+              dataInclusao: m.dataInclusao,
               tolerancias: m.tolerancias,
               contagens: m.contagens,
               anguloMinimo: m.anguloMinimo,
@@ -96,6 +98,7 @@ class MedidasFinalizadorController
       observacao: old.observacao,
       periodicidade: old.periodicidade,
       instrumento: old.instrumento,
+      dataInclusao: old.dataInclusao,
       tolerancias: old.tolerancias,
       contagens: old.contagens,
       anguloMinimo: old.anguloMinimo,
@@ -120,6 +123,7 @@ class MedidasFinalizadorController
         observacao: old.observacao,
         periodicidade: old.periodicidade,
         instrumento: old.instrumento,
+        dataInclusao: old.dataInclusao,
         tolerancias: old.tolerancias,
         contagens: old.contagens,
         anguloMinimo: old.anguloMinimo,
@@ -436,6 +440,9 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
   Widget build(BuildContext context) {
     final medidasAsync = ref.watch(medidasFinalizadorControllerProvider);
     final medidas = medidasAsync.value ?? [];
+    final dataRevisao = medidas.firstDataInclusao != null
+        ? DateFormat('dd/MM/yyyy').format(medidas.firstDataInclusao!.toLocal())
+        : null;
     final flowState = ref.watch(sharedSearchFormProvider);
     final flowLocked = flowState.isActive;
     final flowProcessName = flowState.processDisplayName;
@@ -551,6 +558,11 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
                           SummaryInfo(label: 'O.S.', value: _osCtrl.text),
                           SummaryInfo(label: 'Peça', value: _partCtrl.text),
                           SummaryInfo(label: 'Operação', value: _opCtrl.text),
+                          if (dataRevisao != null)
+                            SummaryInfo(
+                              label: 'Data de revisão',
+                              value: dataRevisao,
+                            ),
                           if ((maquinaValue ?? '').isNotEmpty)
                             SummaryInfo(label: 'Máquina', value: maquinaValue!),
                           if ((categoriaValue ?? '').isNotEmpty)

--- a/lib/features/operador/data/models.dart
+++ b/lib/features/operador/data/models.dart
@@ -85,6 +85,7 @@ class MedidaItem {
   final String? observacao;
   final String? periodicidade;
   final String? instrumento;
+  final DateTime? dataInclusao;
 
   /// Rótulos de tolerância (até 4) vindos do backend do Operador (AE/AF/AG/AH...).
   final List<String> tolerancias;
@@ -104,6 +105,7 @@ class MedidaItem {
     this.observacao,
     this.periodicidade,
     this.instrumento,
+    this.dataInclusao,
     this.tolerancias = const [],
     Map<String, int>? contagens,
     this.anguloMinimo,
@@ -168,6 +170,35 @@ class MedidaItem {
     if (v is num) return v.toDouble();
     final s = v.toString().replaceAll(',', '.').trim();
     return double.tryParse(s);
+  }
+
+  static DateTime? _parseDate(dynamic raw) {
+    if (raw == null) return null;
+    if (raw is DateTime) return raw;
+    if (raw is int) {
+      if (raw > 9999999999) {
+        return DateTime.fromMillisecondsSinceEpoch(raw);
+      }
+      return DateTime.fromMillisecondsSinceEpoch(raw * 1000);
+    }
+    final text = raw.toString().trim();
+    if (text.isEmpty) return null;
+    final normalized = text.contains('T') || text.contains(' ')
+        ? text.replaceFirst(' ', 'T')
+        : text;
+    final parsedIso = DateTime.tryParse(normalized);
+    if (parsedIso != null) return parsedIso;
+    final match = RegExp(r'^(\d{1,2})/(\d{1,2})/(\d{2,4})$').firstMatch(text);
+    if (match != null) {
+      final day = int.tryParse(match.group(1)!);
+      final month = int.tryParse(match.group(2)!);
+      final yearRaw = int.tryParse(match.group(3)!);
+      if (day != null && month != null && yearRaw != null) {
+        final year = yearRaw < 100 ? 2000 + yearRaw : yearRaw;
+        return DateTime(year, month, day);
+      }
+    }
+    return null;
   }
 
   static String _normalizeLower(String s) {
@@ -340,10 +371,7 @@ class MedidaItem {
       var out = input.replaceAll(',', '.');
       out = out.replaceAll('º', '°');
       out = out.replaceAll('×', 'x');
-      out = out.replaceAll(
-        RegExp(r'(?<=[\d°º])\s*[-–—]\s*(?=\d)'),
-        ' - ',
-      );
+      out = out.replaceAll(RegExp(r'(?<=[\d°º])\s*[-–—]\s*(?=\d)'), ' - ');
       out = out.replaceAll(RegExp(r'(\d)°\.(\d+)'), r'$1.$2°');
       out = out.replaceAll(RegExp(r'([°º])\s*[xX]\s*(?=\d)'), r'$1 - ');
       out = out.replaceAll(RegExp(r'([°º])\s+(?=\d)'), r'$1 - ');
@@ -540,6 +568,9 @@ class MedidaItem {
     final observacao = rawObservacao?.toString();
     final periodicidade = rawPeriodicidade?.toString();
     final instrumento = rawInstrumento?.toString();
+    final dataInclusao = _parseDate(
+      map['data_inclusao'] ?? map['dataInclusao'] ?? map['dataInclusão'],
+    );
     double? anguloMinDeduced;
     double? anguloMaxDeduced;
 
@@ -681,6 +712,7 @@ class MedidaItem {
       contagens: counts,
       anguloMinimo: anguloMinDeduced,
       anguloMaximo: anguloMaxDeduced,
+      dataInclusao: dataInclusao,
     );
   }
 
@@ -699,6 +731,16 @@ class MedidaItem {
     'tolerancias': tolerancias,
     'contagens': contagens,
   };
+}
+
+extension OperadorMedidaItemIterableExt on Iterable<MedidaItem> {
+  DateTime? get firstDataInclusao {
+    for (final item in this) {
+      final data = item.dataInclusao;
+      if (data != null) return data;
+    }
+    return null;
+  }
 }
 
 class PreparacaoResultado {

--- a/lib/features/operador/presentation/operador_page.dart
+++ b/lib/features/operador/presentation/operador_page.dart
@@ -7,6 +7,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:http/http.dart' as http;
+import 'package:intl/intl.dart';
 
 import '../../preparacao/data/models.dart';
 import '../data/repository_provider.dart';
@@ -23,12 +24,12 @@ import 'package:admin/models/machine.dart';
 import 'package:admin/features/shared/providers/search_flow_form_provider.dart';
 
 final medidasOperadorControllerProvider =
-StateNotifierProvider.autoDispose<
-    MedidasOperadorController,
-    AsyncValue<List<MedidaItem>>
->((ref) {
-  return MedidasOperadorController(ref);
-});
+    StateNotifierProvider.autoDispose<
+      MedidasOperadorController,
+      AsyncValue<List<MedidaItem>>
+    >((ref) {
+      return MedidasOperadorController(ref);
+    });
 
 class MedidasOperadorController
     extends StateNotifier<AsyncValue<List<MedidaItem>>> {
@@ -71,6 +72,7 @@ class MedidasOperadorController
       observacao: old.observacao,
       periodicidade: old.periodicidade,
       instrumento: old.instrumento,
+      dataInclusao: old.dataInclusao,
       tolerancias: old.tolerancias,
       contagens: old.contagens,
       anguloMinimo: old.anguloMinimo,
@@ -96,6 +98,7 @@ class MedidasOperadorController
         observacao: old.observacao,
         periodicidade: old.periodicidade,
         instrumento: old.instrumento,
+        dataInclusao: old.dataInclusao,
         tolerancias: old.tolerancias,
         contagens: old.contagens,
         anguloMinimo: old.anguloMinimo,
@@ -142,6 +145,7 @@ class MedidasOperadorController
         observacao: old.observacao,
         periodicidade: old.periodicidade,
         instrumento: old.instrumento,
+        dataInclusao: old.dataInclusao,
         tolerancias: old.tolerancias,
         contagens: counts,
         anguloMinimo: old.anguloMinimo,
@@ -215,9 +219,9 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
   }
 
   void _handleFlowStateChange(
-      SharedSearchFormState? previous,
-      SharedSearchFormState next,
-      ) {
+    SharedSearchFormState? previous,
+    SharedSearchFormState next,
+  ) {
     if (!next.isActive ||
         next.effectiveProcess != SearchFlowProcess.amostragem) {
       _activeAmostragemFlow = null;
@@ -227,8 +231,8 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
 
     final wasActive =
         previous != null &&
-            previous.isActive &&
-            previous.effectiveProcess == SearchFlowProcess.amostragem;
+        previous.isActive &&
+        previous.effectiveProcess == SearchFlowProcess.amostragem;
 
     final previousFlow = _activeAmostragemFlow;
     _activeAmostragemFlow = next;
@@ -250,7 +254,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
     unawaited(_checkAmostragemRecente());
     _amostragemMonitorTimer = Timer.periodic(
       const Duration(minutes: 1),
-          (_) => unawaited(_checkAmostragemRecente()),
+      (_) => unawaited(_checkAmostragemRecente()),
     );
   }
 
@@ -311,9 +315,9 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
   }
 
   void _handleAmostragemRecente(
-      SharedSearchFormState flow,
-      DateTime? ultimaAmostragem,
-      ) {
+    SharedSearchFormState flow,
+    DateTime? ultimaAmostragem,
+  ) {
     if (!mounted) return;
     if (ultimaAmostragem != null) {
       _lastAmostragem = ultimaAmostragem;
@@ -371,9 +375,9 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
   }
 
   Future<void> _showAmostragemReminder(
-      SharedSearchFormState flow,
-      Duration reminderInterval,
-      ) async {
+    SharedSearchFormState flow,
+    Duration reminderInterval,
+  ) async {
     if (!mounted || _amostragemReminderDialogOpen) return;
     _amostragemReminderDialogOpen = true;
     _lastReminderShownAt = DateTime.now();
@@ -427,7 +431,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
 
           if (_categoriaSel != null) {
             final possuiMaquina = _maquinas.any(
-                  (m) => m.categoria == _categoriaSel && m.codigo == _maquinaSel,
+              (m) => m.categoria == _categoriaSel && m.codigo == _maquinaSel,
             );
             if (!possuiMaquina && _maquinaSel != null) {
               _maquinaSel = null;
@@ -453,7 +457,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
     final maquina = _maquinaSel;
     if (categoria == null || maquina == null) return false;
     return _maquinas.any(
-          (m) => m.categoria == categoria && m.codigo == maquina,
+      (m) => m.categoria == categoria && m.codigo == maquina,
     );
   }
 
@@ -794,13 +798,13 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                 children: motivos
                     .map(
                       (m) => RadioListTile<String>(
-                    title: Text(m),
-                    value: m,
-                    groupValue: selecionado,
-                    onChanged: (value) =>
-                        setState(() => selecionado = value),
-                  ),
-                )
+                        title: Text(m),
+                        value: m,
+                        groupValue: selecionado,
+                        onChanged: (value) =>
+                            setState(() => selecionado = value),
+                      ),
+                    )
                     .toList(),
               ),
             ),
@@ -912,7 +916,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
         title: const Text('Troca de O.S.'),
         content: const Text(
           'Deseja pausar a O.S. atual e liberar o fluxo para iniciar outra? '
-              'Será necessária nova liberação para retomar a produção desta O.S.',
+          'Será necessária nova liberação para retomar a produção desta O.S.',
         ),
         actions: [
           TextButton(
@@ -964,14 +968,17 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
   @override
   Widget build(BuildContext context) {
     ref.listen<SharedSearchFormState>(sharedSearchFormProvider, (
-        previous,
-        next,
-        ) {
+      previous,
+      next,
+    ) {
       _handleFlowStateChange(previous, next);
     });
 
     final medidasAsync = ref.watch(medidasOperadorControllerProvider);
     final medidas = medidasAsync.value ?? [];
+    final dataRevisao = medidas.firstDataInclusao != null
+        ? DateFormat('dd/MM/yyyy').format(medidas.firstDataInclusao!.toLocal())
+        : null;
     final flowState = ref.watch(sharedSearchFormProvider);
     final flowLocked = flowState.isActive;
     final flowProcessName = flowState.processDisplayName;
@@ -981,43 +988,43 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
     final reOk = _reCtrl.text.trim().isNotEmpty;
     final osOk = _osCtrl.text.trim().isNotEmpty;
     final categoriaValue =
-    (_categoriaSel != null && _categorias.contains(_categoriaSel))
+        (_categoriaSel != null && _categorias.contains(_categoriaSel))
         ? _categoriaSel
         : null;
     final maquinasDisponiveis = _maquinas
         .where((m) => m.categoria == categoriaValue)
         .toList();
     final maquinaValue =
-    (_maquinaSel != null &&
-        maquinasDisponiveis.any((m) => m.codigo == _maquinaSel))
+        (_maquinaSel != null &&
+            maquinasDisponiveis.any((m) => m.codigo == _maquinaSel))
         ? _maquinaSel
         : null;
     final maquinaOk = (maquinaValue ?? '').isNotEmpty;
     final formMatchesFlow =
         !flowLocked ||
-            flowState.matchesValues(
-              os: _osCtrl.text,
-              partNumber: _partCtrl.text,
-              operacao: _opCtrl.text,
-              categoria: categoriaValue,
-              maquina: maquinaValue,
-            );
+        flowState.matchesValues(
+          os: _osCtrl.text,
+          partNumber: _partCtrl.text,
+          operacao: _opCtrl.text,
+          categoria: categoriaValue,
+          maquina: maquinaValue,
+        );
 
     // todas respondidas?
     final todasRespondidas =
         medidas.isNotEmpty &&
-            medidas.every(
-                  (m) =>
+        medidas.every(
+          (m) =>
               m.status != StatusMedida.pendente && (m.medicao ?? '').isNotEmpty,
-            );
+        );
 
     final podeRegistrar =
         formMatchesFlow &&
-            reOk &&
-            osOk &&
-            maquinaOk &&
-            todasRespondidas &&
-            !_registrando;
+        reOk &&
+        osOk &&
+        maquinaOk &&
+        todasRespondidas &&
+        !_registrando;
 
     return Scaffold(
       appBar: WindowBar(
@@ -1087,6 +1094,11 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                           SummaryInfo(label: 'O.S.', value: _osCtrl.text),
                           SummaryInfo(label: 'Peça', value: _partCtrl.text),
                           SummaryInfo(label: 'Operação', value: _opCtrl.text),
+                          if (dataRevisao != null)
+                            SummaryInfo(
+                              label: 'Data de revisão',
+                              value: dataRevisao,
+                            ),
                           if ((maquinaValue ?? '').isNotEmpty)
                             SummaryInfo(label: 'Máquina', value: maquinaValue!),
                           if ((categoriaValue ?? '').isNotEmpty)
@@ -1117,7 +1129,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                                     ],
                                     decoration: const InputDecoration(
                                       labelText:
-                                      'R.E. do Preparador', // ajuste o texto se for Operador
+                                          'R.E. do Preparador', // ajuste o texto se for Operador
                                       border: OutlineInputBorder(),
                                     ),
                                     validator: (v) {
@@ -1171,25 +1183,25 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                                     items: _categorias
                                         .map(
                                           (c) => DropdownMenuItem(
-                                        value: c,
-                                        child: Text(c),
-                                      ),
-                                    )
+                                            value: c,
+                                            child: Text(c),
+                                          ),
+                                        )
                                         .toList(),
                                     onChanged: flowLocked
                                         ? null
                                         : (v) {
-                                      ref
-                                          .read(
-                                        sharedSearchFormProvider
-                                            .notifier,
-                                      )
-                                          .setCategoria(v);
-                                      setState(() {
-                                        _categoriaSel = v;
-                                        _maquinaSel = null;
-                                      });
-                                    },
+                                            ref
+                                                .read(
+                                                  sharedSearchFormProvider
+                                                      .notifier,
+                                                )
+                                                .setCategoria(v);
+                                            setState(() {
+                                              _categoriaSel = v;
+                                              _maquinaSel = null;
+                                            });
+                                          },
                                     validator: (v) => (v == null || v.isEmpty)
                                         ? 'Obrigatório'
                                         : null,
@@ -1206,22 +1218,22 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                                     items: maquinasDisponiveis
                                         .map(
                                           (m) => DropdownMenuItem(
-                                        value: m.codigo,
-                                        child: Text(m.codigo),
-                                      ),
-                                    )
+                                            value: m.codigo,
+                                            child: Text(m.codigo),
+                                          ),
+                                        )
                                         .toList(),
                                     onChanged: flowLocked
                                         ? null
                                         : (v) {
-                                      ref
-                                          .read(
-                                        sharedSearchFormProvider
-                                            .notifier,
-                                      )
-                                          .setMaquina(v);
-                                      setState(() => _maquinaSel = v);
-                                    },
+                                            ref
+                                                .read(
+                                                  sharedSearchFormProvider
+                                                      .notifier,
+                                                )
+                                                .setMaquina(v);
+                                            setState(() => _maquinaSel = v);
+                                          },
                                     validator: (v) => (v == null || v.isEmpty)
                                         ? 'Obrigatório'
                                         : null,
@@ -1244,7 +1256,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                                       border: OutlineInputBorder(),
                                     ),
                                     validator: (v) =>
-                                    (v == null || v.trim().isEmpty)
+                                        (v == null || v.trim().isEmpty)
                                         ? 'Obrigatório'
                                         : null,
                                   ),
@@ -1286,16 +1298,16 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                                     FocusScope.of(context).unfocus();
                                     await ref
                                         .read(
-                                      medidasOperadorControllerProvider
-                                          .notifier,
-                                    )
+                                          medidasOperadorControllerProvider
+                                              .notifier,
+                                        )
                                         .carregar(
-                                      os: _osCtrl.text.trim(),
-                                      partnumber: normalizeCode(
-                                        _partCtrl.text,
-                                      ),
-                                      operacao: normalizeCode(_opCtrl.text),
-                                    );
+                                          os: _osCtrl.text.trim(),
+                                          partnumber: normalizeCode(
+                                            _partCtrl.text,
+                                          ),
+                                          operacao: normalizeCode(_opCtrl.text),
+                                        );
                                     if (mounted) {
                                       setState(() => _mostrarResumo = true);
                                     }
@@ -1369,12 +1381,12 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                                 : null,
                             icon: _registrando
                                 ? const SizedBox(
-                              width: 18,
-                              height: 18,
-                              child: CircularProgressIndicator(
-                                strokeWidth: 2,
-                              ),
-                            )
+                                    width: 18,
+                                    height: 18,
+                                    child: CircularProgressIndicator(
+                                      strokeWidth: 2,
+                                    ),
+                                  )
                                 : const Icon(Icons.save_outlined),
                             label: const Text('Registrar amostragem'),
                           ),

--- a/lib/features/operador/presentation/troca_ferramenta_page.dart
+++ b/lib/features/operador/presentation/troca_ferramenta_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 
 import 'package:flutter/services.dart';
 import 'package:http/http.dart' as http;
+import 'package:intl/intl.dart';
 
 import 'package:admin/features/operador/presentation/widgets/measurement_tile.dart';
 import 'package:admin/features/preparacao/data/models.dart';
@@ -39,6 +40,7 @@ class _TrocaFerramentaPageState extends State<TrocaFerramentaPage> {
   List<MedidaItem> _medidasSelecionadas = [];
   bool _medindo = false;
   bool _registrando = false;
+  String? _dataRevisao;
 
   @override
   void initState() {
@@ -57,6 +59,7 @@ class _TrocaFerramentaPageState extends State<TrocaFerramentaPage> {
     setState(() {
       _loading = true;
       _erro = null;
+      _dataRevisao = null;
     });
 
     final uri = buildApiUri('/preparador/medidas', {
@@ -79,12 +82,17 @@ class _TrocaFerramentaPageState extends State<TrocaFerramentaPage> {
                   )
                   .toList()
             : <MedidaItem>[];
+        final dataInclusao = itens.firstDataInclusao;
+        final dataFormatada = dataInclusao != null
+            ? DateFormat('dd/MM/yyyy').format(dataInclusao.toLocal())
+            : null;
         setState(() {
           _todas = itens;
           _selecionadas = <int>{};
           _medidasSelecionadas = [];
           _medindo = false;
           _loading = false;
+          _dataRevisao = dataFormatada;
         });
       } else if (resp.statusCode == 404 || resp.statusCode == 204) {
         setState(() {
@@ -93,6 +101,7 @@ class _TrocaFerramentaPageState extends State<TrocaFerramentaPage> {
           _medidasSelecionadas = [];
           _medindo = false;
           _loading = false;
+          _dataRevisao = null;
         });
       } else {
         throw Exception('Falha ao carregar (${resp.statusCode}) ${resp.body}');
@@ -102,6 +111,7 @@ class _TrocaFerramentaPageState extends State<TrocaFerramentaPage> {
       setState(() {
         _erro = e.toString();
         _loading = false;
+        _dataRevisao = null;
       });
     }
   }
@@ -139,6 +149,7 @@ class _TrocaFerramentaPageState extends State<TrocaFerramentaPage> {
         observacao: item.observacao,
         periodicidade: item.periodicidade,
         instrumento: item.instrumento,
+        dataInclusao: item.dataInclusao,
         tolerancias: item.tolerancias,
         contagens: item.contagens,
         anguloMinimo: item.anguloMinimo,
@@ -168,6 +179,7 @@ class _TrocaFerramentaPageState extends State<TrocaFerramentaPage> {
       observacao: antigo.observacao,
       periodicidade: antigo.periodicidade,
       instrumento: antigo.instrumento,
+      dataInclusao: antigo.dataInclusao,
       tolerancias: antigo.tolerancias,
       contagens: antigo.contagens,
       anguloMinimo: antigo.anguloMinimo,
@@ -427,6 +439,8 @@ class _TrocaFerramentaPageState extends State<TrocaFerramentaPage> {
                             _buildInfoChip('O.S.', widget.os),
                             _buildInfoChip('Peça', widget.partnumber),
                             _buildInfoChip('Operação', widget.operacao),
+                            if (_dataRevisao != null)
+                              _buildInfoChip('Data de revisão', _dataRevisao!),
                             _buildInfoChip('Máquina', widget.maquina),
                           ],
                         ),

--- a/lib/features/preparacao/data/local_excel_repository.dart
+++ b/lib/features/preparacao/data/local_excel_repository.dart
@@ -78,6 +78,41 @@ class LocalExcelRepository implements MedidasRepository {
         final periodicidade = map['periodicidade']?.toString();
         final instrumento = map['instrumento']?.toString();
 
+        DateTime? parseDate(dynamic rawValue) {
+          if (rawValue == null) return null;
+          if (rawValue is DateTime) return rawValue;
+          if (rawValue is int) {
+            if (rawValue > 9999999999) {
+              return DateTime.fromMillisecondsSinceEpoch(rawValue);
+            }
+            return DateTime.fromMillisecondsSinceEpoch(rawValue * 1000);
+          }
+          final text = rawValue.toString().trim();
+          if (text.isEmpty) return null;
+          final normalized = text.contains('T') || text.contains(' ')
+              ? text.replaceFirst(' ', 'T')
+              : text;
+          final parsedIso = DateTime.tryParse(normalized);
+          if (parsedIso != null) return parsedIso;
+          final match = RegExp(
+            r'^(\d{1,2})/(\d{1,2})/(\d{2,4})$',
+          ).firstMatch(text);
+          if (match != null) {
+            final day = int.tryParse(match.group(1)!);
+            final month = int.tryParse(match.group(2)!);
+            final yearRaw = int.tryParse(match.group(3)!);
+            if (day != null && month != null && yearRaw != null) {
+              final year = yearRaw < 100 ? 2000 + yearRaw : yearRaw;
+              return DateTime(year, month, day);
+            }
+          }
+          return null;
+        }
+
+        final dataInclusao = parseDate(
+          map['data_inclusao'] ?? map['dataInclusao'] ?? map['dataInclusão'],
+        );
+
         final rawTolerancias = map['tolerancias'];
         final tolerancias = (rawTolerancias is List)
             ? rawTolerancias.map((e) => e.toString()).toList()
@@ -247,6 +282,7 @@ class LocalExcelRepository implements MedidasRepository {
           observacao: observacao,
           periodicidade: periodicidade,
           instrumento: instrumento,
+          dataInclusao: dataInclusao,
           tolerancias: tolerancias,
           contagens: contagens,
           anguloMinimo: anguloMinDeduced,

--- a/lib/features/preparacao/data/models.dart
+++ b/lib/features/preparacao/data/models.dart
@@ -83,6 +83,7 @@ class MedidaItem {
   final String? observacao;
   final String? periodicidade;
   final String? instrumento;
+  final DateTime? dataInclusao;
 
   /// Rótulos de tolerância (até 4) vindos do backend do Operador (AE/AF/AG/AH...).
   final List<String> tolerancias;
@@ -102,6 +103,7 @@ class MedidaItem {
     this.observacao,
     this.periodicidade,
     this.instrumento,
+    this.dataInclusao,
     this.tolerancias = const [],
     Map<String, int>? contagens,
     this.anguloMinimo,
@@ -166,6 +168,35 @@ class MedidaItem {
     if (v is num) return v.toDouble();
     final s = v.toString().replaceAll(',', '.').trim();
     return double.tryParse(s);
+  }
+
+  static DateTime? _parseDate(dynamic raw) {
+    if (raw == null) return null;
+    if (raw is DateTime) return raw;
+    if (raw is int) {
+      if (raw > 9999999999) {
+        return DateTime.fromMillisecondsSinceEpoch(raw);
+      }
+      return DateTime.fromMillisecondsSinceEpoch(raw * 1000);
+    }
+    final text = raw.toString().trim();
+    if (text.isEmpty) return null;
+    final normalized = text.contains('T') || text.contains(' ')
+        ? text.replaceFirst(' ', 'T')
+        : text;
+    final parsedIso = DateTime.tryParse(normalized);
+    if (parsedIso != null) return parsedIso;
+    final match = RegExp(r'^(\d{1,2})/(\d{1,2})/(\d{2,4})$').firstMatch(text);
+    if (match != null) {
+      final day = int.tryParse(match.group(1)!);
+      final month = int.tryParse(match.group(2)!);
+      final yearRaw = int.tryParse(match.group(3)!);
+      if (day != null && month != null && yearRaw != null) {
+        final year = yearRaw < 100 ? 2000 + yearRaw : yearRaw;
+        return DateTime(year, month, day);
+      }
+    }
+    return null;
   }
 
   static String _normalizeLower(String s) {
@@ -338,10 +369,7 @@ class MedidaItem {
       var out = input.replaceAll(',', '.');
       out = out.replaceAll('º', '°');
       out = out.replaceAll('×', 'x');
-      out = out.replaceAll(
-        RegExp(r'(?<=[\d°º])\s*[-–—]\s*(?=\d)'),
-        ' - ',
-      );
+      out = out.replaceAll(RegExp(r'(?<=[\d°º])\s*[-–—]\s*(?=\d)'), ' - ');
       out = out.replaceAll(RegExp(r'(\d)°\.(\d+)'), r'$1.$2°');
       out = out.replaceAll(RegExp(r'([°º])\s*[xX]\s*(?=\d)'), r'$1 - ');
       out = out.replaceAll(RegExp(r'([°º])\s+(?=\d)'), r'$1 - ');
@@ -537,6 +565,9 @@ class MedidaItem {
     final observacao = rawObservacao?.toString();
     final periodicidade = rawPeriodicidade?.toString();
     final instrumento = rawInstrumento?.toString();
+    final dataInclusao = _parseDate(
+      map['data_inclusao'] ?? map['dataInclusao'] ?? map['dataInclusão'],
+    );
     double? anguloMinDeduced;
     double? anguloMaxDeduced;
 
@@ -678,6 +709,7 @@ class MedidaItem {
       contagens: counts,
       anguloMinimo: anguloMinDeduced,
       anguloMaximo: anguloMaxDeduced,
+      dataInclusao: dataInclusao,
     );
   }
 
@@ -696,6 +728,16 @@ class MedidaItem {
     'tolerancias': tolerancias,
     'contagens': contagens,
   };
+}
+
+extension MedidaItemIterableExt on Iterable<MedidaItem> {
+  DateTime? get firstDataInclusao {
+    for (final item in this) {
+      final data = item.dataInclusao;
+      if (data != null) return data;
+    }
+    return null;
+  }
 }
 
 class PreparacaoResultado {

--- a/lib/features/preparacao/presentation/preparacao_page.dart
+++ b/lib/features/preparacao/presentation/preparacao_page.dart
@@ -6,6 +6,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:http/http.dart' as http;
+import 'package:intl/intl.dart';
 
 import 'package:admin/features/preparacao/data/models.dart';
 import 'package:admin/features/operador/data/repository_provider.dart';
@@ -67,6 +68,7 @@ class MedidasPreparadorController
               observacao: m.observacao,
               periodicidade: m.periodicidade,
               instrumento: m.instrumento,
+              dataInclusao: m.dataInclusao,
               tolerancias: m.tolerancias,
               contagens: m.contagens,
               anguloMinimo: m.anguloMinimo,
@@ -97,6 +99,7 @@ class MedidasPreparadorController
       observacao: old.observacao,
       periodicidade: old.periodicidade,
       instrumento: old.instrumento,
+      dataInclusao: old.dataInclusao,
       tolerancias: old.tolerancias,
       contagens: old.contagens,
       anguloMinimo: old.anguloMinimo,
@@ -121,6 +124,7 @@ class MedidasPreparadorController
         observacao: old.observacao,
         periodicidade: old.periodicidade,
         instrumento: old.instrumento,
+        dataInclusao: old.dataInclusao,
         tolerancias: old.tolerancias,
         contagens: old.contagens,
         anguloMinimo: old.anguloMinimo,
@@ -465,6 +469,9 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
   Widget build(BuildContext context) {
     final medidasAsync = ref.watch(medidasPreparadorControllerProvider);
     final medidas = medidasAsync.value ?? [];
+    final dataRevisao = medidas.firstDataInclusao != null
+        ? DateFormat('dd/MM/yyyy').format(medidas.firstDataInclusao!.toLocal())
+        : null;
     final flowState = ref.watch(sharedSearchFormProvider);
     final flowLocked = flowState.isActive;
     final flowProcessName = flowState.processDisplayName;
@@ -580,6 +587,11 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
                           SummaryInfo(label: 'O.S.', value: _osCtrl.text),
                           SummaryInfo(label: 'Peça', value: _partCtrl.text),
                           SummaryInfo(label: 'Operação', value: _opCtrl.text),
+                          if (dataRevisao != null)
+                            SummaryInfo(
+                              label: 'Data de revisão',
+                              value: dataRevisao,
+                            ),
                           if ((maquinaValue ?? '').isNotEmpty)
                             SummaryInfo(label: 'Máquina', value: maquinaValue!),
                           if ((categoriaValue ?? '').isNotEmpty)
@@ -886,8 +898,9 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
                         SizedBox(
                           width: double.infinity,
                           child: FilledButton.icon(
-                            onPressed:
-                                podeRegistrar ? _registrarResultado : null,
+                            onPressed: podeRegistrar
+                                ? _registrarResultado
+                                : null,
                             icon: _registrando
                                 ? const SizedBox(
                                     width: 18,


### PR DESCRIPTION
## Summary
- expose `data_inclusao` in the measurement API payloads so the client can access revision dates
- parse and store the revision date in the measurement models and local data sources
- surface the formatted "Data de revisão" value in the preparation, finalization, operator, and tool-change summaries

## Testing
- flutter test

------
https://chatgpt.com/codex/tasks/task_e_68da5ecf04a08331ab17bd8d2efaf9ae