### PR TITLE
Redirect dashboard navigation to StatusOsPage

### DIFF
--- a/lib/features/main_menu/main_menu_page.dart
+++ b/lib/features/main_menu/main_menu_page.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 
-import 'package:admin/screens/main/main_screen.dart';
+import 'package:admin/features/export_relatorios/presentation/status_os_page.dart';
 import 'package:admin/screens/main/components/side_menu.dart';
 import 'package:admin/widgets/window_bar.dart';
 import '../preparacao/presentation/preparacao_page.dart';
@@ -98,7 +98,7 @@ class _MainMenuPageState extends ConsumerState<MainMenuPage> {
       }
       Navigator.of(
         context,
-      ).push(MaterialPageRoute(builder: (_) => MainScreen()));
+      ).push(MaterialPageRoute(builder: (_) => const StatusOsPage()));
     }
 
     final logo = _logos[_logoIndex];

--- a/lib/screens/main/components/side_menu.dart
+++ b/lib/screens/main/components/side_menu.dart
@@ -16,7 +16,6 @@ import 'package:admin/features/cadastro_maquinas/presentation/cadastro_maquinas_
 import 'package:admin/features/login/login_page.dart';
 import 'package:admin/features/users/users_page.dart';
 import 'package:admin/services/auth_service.dart';
-import 'package:admin/screens/main/main_screen.dart';
 import 'package:admin/features/shared/providers/search_flow_form_provider.dart';
 
 enum SideMenuSection { mainMenu, dashboard, preparador, operador, finalizar }
@@ -237,7 +236,7 @@ class SideMenu extends ConsumerWidget {
               _navigate(
                 context,
                 ref,
-                MainScreen(),
+                const StatusOsPage(),
                 allowDuringActiveFlow: true,
               );
             },


### PR DESCRIPTION
## Summary
- update the main menu dashboard shortcut to open the StatusOsPage directly
- route the side menu "Supervisão" entry to the same status page instead of the legacy dashboard screen

## Testing
- flutter test

------
https://chatgpt.com/codex/tasks/task_e_68da7c7bbd788331b33151d49d825d2e