### PR TITLE
Fix auto refresh timer disposal

### DIFF
--- a/lib/features/export_relatorios/presentation/status_os_page.dart
+++ b/lib/features/export_relatorios/presentation/status_os_page.dart
@@ -85,6 +85,7 @@ class _StatusOsPageState extends State<StatusOsPage> {
 
   @override
   void dispose() {
+    _autoRefreshTimer?.cancel();
     _categoriaController.dispose();
     _maquinaController.dispose();
     _partnumberController.dispose();


### PR DESCRIPTION
## Summary
- cancel the periodic status update timer when the status page is disposed to avoid stale callbacks

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da83bdd4248331aa4bae4872faedb9