### PR TITLE
feat: refine theming and main navigation experience

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 
 const primaryColor = Color(0xFF2697FF);
 const secondaryColor = Color(0xFF2A2D3E);
-//const bgColor = Color(0xFF0D0E14);
-const bgColor = Color(0xFF303030);
+const accentColor = Color(0xFF4DD0E1);
+const surfaceColor = Color(0xFF1F212A);
+const surfaceVariantColor = Color(0xFF2B2D36);
+const bgColor = Color(0xFF14151C);
 const defaultPadding = 16.0;

--- a/lib/core/theme/app_theme.dart
+++ b/lib/core/theme/app_theme.dart
@@ -1,0 +1,171 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import 'package:admin/constants.dart';
+
+/// Centralizes the application's theming so every screen shares the same
+/// typography, colors and component shapes. Keeping the definitions together
+/// makes the UI look coherent and simplifies future refinements.
+class AppTheme {
+  const AppTheme._();
+
+  /// Builds the dark theme used throughout the desktop/tablet experience.
+  static ThemeData dark() {
+    const colorScheme = ColorScheme(
+      brightness: Brightness.dark,
+      primary: primaryColor,
+      onPrimary: Colors.white,
+      secondary: accentColor,
+      onSecondary: Colors.black,
+      error: Color(0xFFFF6B6B),
+      onError: Colors.white,
+      background: bgColor,
+      onBackground: Colors.white,
+      surface: surfaceColor,
+      onSurface: Colors.white,
+    );
+
+    final baseTextTheme = GoogleFonts.poppinsTextTheme(
+      ThemeData.dark().textTheme,
+    ).apply(bodyColor: Colors.white, displayColor: Colors.white);
+
+    final elevatedButtonStyle = ElevatedButton.styleFrom(
+      backgroundColor: colorScheme.primary,
+      foregroundColor: colorScheme.onPrimary,
+      padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 14),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+      textStyle: baseTextTheme.labelLarge?.copyWith(
+        fontWeight: FontWeight.w600,
+      ),
+      elevation: 0,
+    );
+
+    final inputDecorationTheme = const InputDecorationTheme(
+      filled: true,
+      fillColor: surfaceVariantColor,
+      border: OutlineInputBorder(
+        borderRadius: BorderRadius.all(Radius.circular(14)),
+        borderSide: BorderSide(color: Colors.transparent),
+      ),
+      enabledBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.all(Radius.circular(14)),
+        borderSide: BorderSide(color: Colors.transparent),
+      ),
+      focusedBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.all(Radius.circular(14)),
+        borderSide: BorderSide(color: accentColor, width: 1.4),
+      ),
+      errorBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.all(Radius.circular(14)),
+        borderSide: BorderSide(color: Color(0xFFFF6B6B), width: 1.2),
+      ),
+      contentPadding: EdgeInsets.symmetric(horizontal: 18, vertical: 14),
+      labelStyle: TextStyle(color: Colors.white70),
+      floatingLabelStyle: TextStyle(color: Colors.white),
+    );
+
+    return ThemeData(
+      useMaterial3: true,
+      colorScheme: colorScheme,
+      scaffoldBackgroundColor: colorScheme.background,
+      canvasColor: surfaceColor,
+      textTheme: baseTextTheme,
+      fontFamily: GoogleFonts.poppins().fontFamily,
+      appBarTheme: AppBarTheme(
+        backgroundColor: Colors.black.withOpacity(0.2),
+        surfaceTintColor: Colors.transparent,
+        elevation: 0,
+        centerTitle: false,
+        titleTextStyle: baseTextTheme.titleMedium,
+      ),
+      cardTheme: CardThemeData(
+        color: surfaceColor.withOpacity(0.92),
+        surfaceTintColor: Colors.transparent,
+        elevation: 0,
+        margin: EdgeInsets.zero,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(18)),
+      ),
+      dialogTheme: DialogThemeData(
+        backgroundColor: surfaceColor,
+        surfaceTintColor: Colors.transparent,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+        titleTextStyle: baseTextTheme.titleLarge,
+        contentTextStyle: baseTextTheme.bodyMedium,
+      ),
+      snackBarTheme: SnackBarThemeData(
+        behavior: SnackBarBehavior.floating,
+        backgroundColor: surfaceColor.withOpacity(0.96),
+        elevation: 4,
+        contentTextStyle: baseTextTheme.bodyMedium?.copyWith(
+          color: Colors.white,
+        ),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+      ),
+      navigationRailTheme: NavigationRailThemeData(
+        backgroundColor: surfaceColor,
+        selectedIconTheme: const IconThemeData(color: Colors.white),
+        unselectedIconTheme: IconThemeData(
+          color: Colors.white.withOpacity(0.6),
+        ),
+        labelType: NavigationRailLabelType.all,
+      ),
+      drawerTheme: DrawerThemeData(
+        backgroundColor: surfaceColor,
+        surfaceTintColor: Colors.transparent,
+        shape: const RoundedRectangleBorder(
+          borderRadius: BorderRadius.only(
+            topRight: Radius.circular(28),
+            bottomRight: Radius.circular(28),
+          ),
+        ),
+      ),
+      elevatedButtonTheme: ElevatedButtonThemeData(style: elevatedButtonStyle),
+      filledButtonTheme: FilledButtonThemeData(style: elevatedButtonStyle),
+      textButtonTheme: TextButtonThemeData(
+        style: TextButton.styleFrom(
+          foregroundColor: Colors.white,
+          textStyle: baseTextTheme.labelLarge,
+        ),
+      ),
+      inputDecorationTheme: inputDecorationTheme,
+      dividerTheme: const DividerThemeData(
+        color: Color(0xFF3A3C46),
+        space: 24,
+        thickness: 0.8,
+      ),
+      listTileTheme: ListTileThemeData(
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+        textColor: Colors.white70,
+        iconColor: Colors.white70,
+        dense: true,
+      ),
+      tooltipTheme: TooltipThemeData(
+        decoration: BoxDecoration(
+          color: Colors.black.withOpacity(0.85),
+          borderRadius: BorderRadius.circular(12),
+        ),
+        textStyle: baseTextTheme.labelSmall,
+      ),
+      scrollbarTheme: ScrollbarThemeData(
+        radius: const Radius.circular(12),
+        thickness: const MaterialStatePropertyAll(8),
+        thumbVisibility: const MaterialStatePropertyAll(true),
+        thumbColor: MaterialStateProperty.resolveWith(
+          (states) => states.contains(MaterialState.hovered)
+              ? accentColor.withOpacity(0.9)
+              : accentColor.withOpacity(0.6),
+        ),
+      ),
+      pageTransitionsTheme: const PageTransitionsTheme(
+        builders: {
+          TargetPlatform.android: FadeUpwardsPageTransitionsBuilder(),
+          TargetPlatform.iOS: FadeUpwardsPageTransitionsBuilder(),
+          TargetPlatform.macOS: FadeUpwardsPageTransitionsBuilder(),
+          TargetPlatform.windows: FadeUpwardsPageTransitionsBuilder(),
+          TargetPlatform.linux: FadeUpwardsPageTransitionsBuilder(),
+        },
+      ),
+      visualDensity: VisualDensity.adaptivePlatformDensity,
+    );
+  }
+}

--- a/lib/features/login/login_page.dart
+++ b/lib/features/login/login_page.dart
@@ -14,67 +14,167 @@ class LoginPage extends ConsumerStatefulWidget {
 class _LoginPageState extends ConsumerState<LoginPage> {
   final _userCtrl = TextEditingController();
   final _passCtrl = TextEditingController();
+  final _formKey = GlobalKey<FormState>();
   String? _error;
+  bool _isLoading = false;
 
   Future<void> _login() async {
+    final form = _formKey.currentState;
+    if (form == null || !form.validate()) {
+      return;
+    }
+    setState(() {
+      _error = null;
+      _isLoading = true;
+    });
     try {
       final ok = await ref
           .read(authServiceProvider.notifier)
-          .login(_userCtrl.text, _passCtrl.text);
+          .login(_userCtrl.text.trim(), _passCtrl.text);
+      if (!mounted) return;
       if (ok) {
-        if (mounted) {
-          Navigator.of(context).pop(true);
-        }
+        Navigator.of(context).pop(true);
       } else {
-        if (mounted) {
-          setState(() => _error = 'Credenciais inválidas');
-        }
+        setState(
+          () => _error = 'Credenciais inválidas. Verifique e tente novamente.',
+        );
       }
     } catch (e) {
       if (mounted) {
-        setState(() => _error = 'Erro ao conectar-se ao servidor');
+        setState(() => _error = 'Não foi possível conectar-se ao servidor.');
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _isLoading = false);
       }
     }
   }
 
   @override
+  void dispose() {
+    _userCtrl.dispose();
+    _passCtrl.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
-
       appBar: const WindowBar(title: 'Login', showProfile: false),
       body: Center(
         child: SingleChildScrollView(
           padding: const EdgeInsets.all(32),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Image.asset('assets/images/logo.png', height: 85),
-              const SizedBox(height: 32),
-              TextField(
-                controller: _userCtrl,
-                decoration: const InputDecoration(labelText: 'Usuário'),
-                textInputAction: TextInputAction.next,
-                onSubmitted: (_) => FocusScope.of(context).nextFocus(),
-              ),
-              const SizedBox(height: 16),
-              TextField(
-                controller: _passCtrl,
-                decoration: const InputDecoration(labelText: 'Senha'),
-                obscureText: true,
-                textInputAction: TextInputAction.done,
-                onSubmitted: (_) => _login(),
-              ),
-              if (_error != null)
-                Padding(
-                  padding: const EdgeInsets.only(top: 8),
-                  child: Text(
-                    _error!,
-                    style: const TextStyle(color: Colors.red),
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 420),
+            child: Card(
+              elevation: 0,
+              child: Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 28,
+                  vertical: 32,
+                ),
+                child: Form(
+                  key: _formKey,
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Image.asset('assets/images/logo.png', height: 60),
+                        ],
+                      ),
+                      const SizedBox(height: 24),
+                      Text(
+                        'Bem-vindo de volta',
+                        style: Theme.of(context).textTheme.headlineSmall
+                            ?.copyWith(fontWeight: FontWeight.w600),
+                        textAlign: TextAlign.center,
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        'Entre com suas credenciais para continuar.',
+                        style: Theme.of(
+                          context,
+                        ).textTheme.bodyMedium?.copyWith(color: Colors.white70),
+                        textAlign: TextAlign.center,
+                      ),
+                      const SizedBox(height: 32),
+                      TextFormField(
+                        controller: _userCtrl,
+                        textInputAction: TextInputAction.next,
+                        decoration: const InputDecoration(
+                          labelText: 'Usuário',
+                          prefixIcon: Icon(Icons.person_outline),
+                        ),
+                        validator: (value) {
+                          if (value == null || value.trim().isEmpty) {
+                            return 'Informe seu usuário';
+                          }
+                          return null;
+                        },
+                        onFieldSubmitted: (_) =>
+                            FocusScope.of(context).nextFocus(),
+                      ),
+                      const SizedBox(height: 20),
+                      TextFormField(
+                        controller: _passCtrl,
+                        textInputAction: TextInputAction.done,
+                        obscureText: true,
+                        decoration: const InputDecoration(
+                          labelText: 'Senha',
+                          prefixIcon: Icon(Icons.lock_outline),
+                        ),
+                        validator: (value) {
+                          if (value == null || value.isEmpty) {
+                            return 'Informe sua senha';
+                          }
+                          if (value.length < 4) {
+                            return 'A senha deve conter pelo menos 4 caracteres';
+                          }
+                          return null;
+                        },
+                        onFieldSubmitted: (_) => _login(),
+                      ),
+                      const SizedBox(height: 16),
+                      AnimatedSwitcher(
+                        duration: const Duration(milliseconds: 250),
+                        child: _error == null
+                            ? const SizedBox(height: 0)
+                            : Padding(
+                                padding: const EdgeInsets.only(bottom: 8),
+                                child: Text(
+                                  _error!,
+                                  key: ValueKey(_error),
+                                  style: Theme.of(context).textTheme.bodySmall
+                                      ?.copyWith(
+                                        color: Theme.of(
+                                          context,
+                                        ).colorScheme.error,
+                                      ),
+                                  textAlign: TextAlign.center,
+                                ),
+                              ),
+                      ),
+                      const SizedBox(height: 8),
+                      ElevatedButton(
+                        onPressed: _isLoading ? null : _login,
+                        child: _isLoading
+                            ? const SizedBox(
+                                height: 20,
+                                width: 20,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2.4,
+                                ),
+                              )
+                            : const Text('Entrar'),
+                      ),
+                    ],
                   ),
                 ),
-              const SizedBox(height: 24),
-              ElevatedButton(onPressed: _login, child: const Text('Entrar')),
-            ],
+              ),
+            ),
           ),
         ),
       ),

--- a/lib/features/main_menu/main_menu_page.dart
+++ b/lib/features/main_menu/main_menu_page.dart
@@ -1,9 +1,11 @@
 import 'dart:async';
+import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 
+import 'package:admin/constants.dart';
 import 'package:admin/features/export_relatorios/presentation/status_os_page.dart';
 import 'package:admin/screens/main/components/side_menu.dart';
 import 'package:admin/widgets/window_bar.dart';
@@ -62,9 +64,9 @@ class _MainMenuPageState extends ConsumerState<MainMenuPage> {
       final mensagem = osAtual.isEmpty
           ? 'Finalize a O.S. em andamento antes de iniciar outra.'
           : 'Finalize a O.S. $osAtual antes de iniciar outra.';
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text(mensagem)));
+      ScaffoldMessenger.of(context)
+        ..clearSnackBars()
+        ..showSnackBar(SnackBar(content: Text(mensagem)));
     }
 
     void openFlowPage(Widget page) {
@@ -102,115 +104,328 @@ class _MainMenuPageState extends ConsumerState<MainMenuPage> {
     }
 
     final logo = _logos[_logoIndex];
+    final theme = Theme.of(context);
+    final entries = [
+      _MenuEntry(
+        title: 'Preparador',
+        description:
+            'Organize recursos, prepare itens e acompanhe o fluxo inicial.',
+        iconAsset: 'assets/icons/FOR007.svg',
+        accentColor: primaryColor,
+        onTap: () => openFlowPage(const PreparacaoPage()),
+      ),
+      _MenuEntry(
+        title: 'Operador',
+        description:
+            'Registre atividades de produção e mantenha o time sincronizado.',
+        iconAsset: 'assets/icons/Amostragem.svg',
+        accentColor: const Color(0xFFF6A560),
+        onTap: () => openFlowPage(const OperadorPage()),
+      ),
+      _MenuEntry(
+        title: 'Finalizar OS',
+        description:
+            'Conclua ordens de serviço garantindo rastreabilidade completa.',
+        iconAsset: 'assets/icons/FOR008.svg',
+        accentColor: const Color(0xFF8E7CFF),
+        onTap: () => openFlowPage(const FinalizarOsPage()),
+      ),
+      _MenuEntry(
+        title: 'Supervisão',
+        description:
+            'Visualize indicadores e relatórios estratégicos em tempo real.',
+        iconAsset: 'assets/icons/Dashboard.svg',
+        accentColor: accentColor,
+        onTap: () => openAdmin(),
+        semanticLabel: 'Acessar supervisão e dashboards',
+      ),
+    ];
+
     return Scaffold(
       appBar: const WindowBar(title: 'Menu Principal', showMenu: true),
       drawer: const SideMenu(current: SideMenuSection.mainMenu),
-
-      // ====== INÍCIO: Wallpaper (única mudança) ======
-      body: Stack(
-        children: [
-          // Conteúdo principal
-          Column(
+      body: Container(
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            colors: [Color(0xFF10121C), Color(0xFF151A24), Color(0xFF1E2332)],
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+          ),
+        ),
+        child: SafeArea(
+          child: Stack(
             children: [
-              const SizedBox(height: 10),
-              Image.asset('assets/images/traco.png'),
-              const SizedBox(height: 0),
-              Expanded(
-                child: Center(
-                  child: FittedBox(
-                    fit: BoxFit.scaleDown,
+              const Positioned(
+                top: -120,
+                left: -70,
+                child: _DecorativeBlob(
+                  size: 260,
+                  colors: [Color(0x552697FF), Color(0x332697FF)],
+                ),
+              ),
+              const Positioned(
+                bottom: -160,
+                right: -90,
+                child: _DecorativeBlob(
+                  size: 320,
+                  colors: [Color(0x554DD0E1), Color(0x334DD0E1)],
+                ),
+              ),
+              Align(
+                alignment: Alignment.topCenter,
+                child: SingleChildScrollView(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 24,
+                    vertical: 32,
+                  ),
+                  child: ConstrainedBox(
+                    constraints: const BoxConstraints(maxWidth: 1100),
                     child: Column(
-                      // sem scroll
+                      crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        _MenuButton(
-                          image: 'assets/icons/FOR007.svg',
-                          onPressed: () => openFlowPage(const PreparacaoPage()),
+                        Text(
+                          'Bem-vindo ao Relic TT',
+                          style: theme.textTheme.headlineSmall?.copyWith(
+                            fontWeight: FontWeight.w600,
+                          ),
                         ),
-                        _MenuButton(
-                          image: 'assets/icons/Amostragem.svg',
-                          onPressed: () => openFlowPage(const OperadorPage()),
+                        const SizedBox(height: 12),
+                        Text(
+                          'Selecione o módulo desejado para iniciar o seu fluxo de trabalho.',
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                            color: Colors.white70,
+                          ),
                         ),
-                        _MenuButton(
-                          image: 'assets/icons/FOR008.svg',
-                          onPressed: () =>
-                              openFlowPage(const FinalizarOsPage()),
-                        ),
-                        _MenuButton(
-                          image: 'assets/icons/Dashboard.svg',
-                          onPressed: openAdmin,
-                        ),
+                        const SizedBox(height: 24),
+                        Image.asset('assets/images/traco.png', height: 2),
+                        const SizedBox(height: 32),
+                        _MenuGrid(entries: entries),
                       ],
+                    ),
+                  ),
+                ),
+              ),
+              Align(
+                alignment: Alignment.bottomRight,
+                child: Padding(
+                  padding: const EdgeInsets.all(24.0),
+                  child: AnimatedSwitcher(
+                    duration: const Duration(milliseconds: 500),
+                    child: Image.asset(
+                      logo.asset,
+                      key: ValueKey(_logoIndex),
+                      height: logo.height,
+                      width: logo.width,
                     ),
                   ),
                 ),
               ),
             ],
           ),
-
-          // Logo no canto inferior direito
-          Align(
-            alignment: Alignment.bottomRight,
-            child: Padding(
-              padding: const EdgeInsets.all(16.0),
-              child: AnimatedSwitcher(
-                duration: const Duration(milliseconds: 500),
-                child: Image.asset(
-                  logo.asset,
-                  key: ValueKey(_logoIndex),
-                  height: logo.height,
-                  width: logo.width,
-                ),
-              ),
-            ),
-          ),
-        ],
+        ),
       ),
     );
   }
 }
 
-class _MenuButton extends StatefulWidget {
-  const _MenuButton({required this.image, required this.onPressed});
+class _MenuEntry {
+  const _MenuEntry({
+    required this.title,
+    required this.description,
+    required this.iconAsset,
+    required this.onTap,
+    required this.accentColor,
+    this.semanticLabel,
+  });
 
-  final String image;
-  final VoidCallback onPressed;
-
-  @override
-  State<_MenuButton> createState() => _MenuButtonState();
+  final String title;
+  final String description;
+  final String iconAsset;
+  final VoidCallback onTap;
+  final Color accentColor;
+  final String? semanticLabel;
 }
 
-class _MenuButtonState extends State<_MenuButton> {
-  bool _hovering = false;
-  bool _pressed = false;
+class _MenuGrid extends StatelessWidget {
+  const _MenuGrid({required this.entries});
 
-  double get _scale => _pressed ? 0.95 : (_hovering ? 1.05 : 1.0);
+  final List<_MenuEntry> entries;
 
   @override
   Widget build(BuildContext context) {
-    final width = MediaQuery.of(context).size.width;
-    final buttonWidth = width < 500 ? width * 0.8 : 300.0;
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        if (constraints.maxWidth < 640) {
+          return Column(
+            children: [
+              for (final entry in entries) ...[
+                _MenuCard(entry: entry, maxWidth: constraints.maxWidth),
+                const SizedBox(height: 20),
+              ],
+            ],
+          );
+        }
 
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 8.0),
-      child: AnimatedScale(
-        scale: _scale,
-        duration: const Duration(milliseconds: 150),
-        child: SizedBox(
-          width: buttonWidth,
-          height: 120,
-          child: Material(
-            color: Colors.transparent,
-            child: InkWell(
-              onTap: widget.onPressed,
-              onHover: (v) => setState(() => _hovering = v),
-              onTapDown: (_) => setState(() => _pressed = true),
-              onTapUp: (_) => setState(() => _pressed = false),
-              onTapCancel: () => setState(() => _pressed = false),
-              mouseCursor: SystemMouseCursors.click,
-              hoverColor: Colors.transparent,
-              highlightColor: Colors.transparent,
-              splashColor: Colors.transparent,
-              child: SvgPicture.asset(widget.image, fit: BoxFit.contain),
+        final width = constraints.maxWidth;
+        final double cardWidth = width >= 960 ? 320 : (width / 2) - 16;
+
+        return Wrap(
+          spacing: 24,
+          runSpacing: 24,
+          children: entries
+              .map(
+                (entry) => _MenuCard(
+                  entry: entry,
+                  maxWidth: cardWidth.clamp(260.0, 360.0).toDouble(),
+                ),
+              )
+              .toList(),
+        );
+      },
+    );
+  }
+}
+
+class _MenuCard extends StatefulWidget {
+  const _MenuCard({required this.entry, required this.maxWidth});
+
+  final _MenuEntry entry;
+  final double maxWidth;
+
+  @override
+  State<_MenuCard> createState() => _MenuCardState();
+}
+
+class _MenuCardState extends State<_MenuCard> {
+  bool _hovering = false;
+  bool _pressed = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final accent = widget.entry.accentColor;
+    final scale = _pressed ? 0.97 : (_hovering ? 1.02 : 1.0);
+
+    return SizedBox(
+      width: widget.maxWidth,
+      child: MouseRegion(
+        onEnter: (_) => setState(() => _hovering = true),
+        onExit: (_) => setState(() {
+          _hovering = false;
+          _pressed = false;
+        }),
+        child: AnimatedScale(
+          duration: const Duration(milliseconds: 200),
+          scale: scale,
+          child: AnimatedContainer(
+            duration: const Duration(milliseconds: 220),
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(22),
+              border: Border.all(
+                color: _hovering
+                    ? accent.withOpacity(0.55)
+                    : Colors.white.withOpacity(0.06),
+              ),
+              gradient: _hovering
+                  ? LinearGradient(
+                      colors: [
+                        accent.withOpacity(0.22),
+                        theme.colorScheme.surface.withOpacity(0.85),
+                      ],
+                      begin: Alignment.topLeft,
+                      end: Alignment.bottomRight,
+                    )
+                  : null,
+              color: _hovering
+                  ? null
+                  : theme.colorScheme.surface.withOpacity(0.78),
+              boxShadow: [
+                BoxShadow(
+                  color: _hovering
+                      ? accent.withOpacity(0.35)
+                      : Colors.black.withOpacity(0.45),
+                  blurRadius: _hovering ? 34 : 22,
+                  offset: const Offset(0, 18),
+                ),
+              ],
+            ),
+            child: Material(
+              type: MaterialType.transparency,
+              child: Semantics(
+                button: true,
+                label: widget.entry.semanticLabel ?? widget.entry.title,
+                child: InkWell(
+                  borderRadius: BorderRadius.circular(22),
+                  onTap: widget.entry.onTap,
+                  onHighlightChanged: (value) =>
+                      setState(() => _pressed = value),
+                  child: Padding(
+                    padding: const EdgeInsets.all(24),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        DecoratedBox(
+                          decoration: BoxDecoration(
+                            color: accent.withOpacity(0.22),
+                            borderRadius: BorderRadius.circular(16),
+                          ),
+                          child: Padding(
+                            padding: const EdgeInsets.all(12),
+                            child: SvgPicture.asset(
+                              widget.entry.iconAsset,
+                              width: 36,
+                              height: 36,
+                            ),
+                          ),
+                        ),
+                        const SizedBox(height: 24),
+                        Text(
+                          widget.entry.title,
+                          style: theme.textTheme.titleMedium?.copyWith(
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                        const SizedBox(height: 8),
+                        Text(
+                          widget.entry.description,
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                            color: Colors.white70,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _DecorativeBlob extends StatelessWidget {
+  const _DecorativeBlob({required this.size, required this.colors});
+
+  final double size;
+  final List<Color> colors;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: size,
+      height: size,
+      child: ClipOval(
+        child: BackdropFilter(
+          filter: ui.ImageFilter.blur(sigmaX: 140, sigmaY: 140),
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              gradient: RadialGradient(
+                colors: colors,
+                center: Alignment.center,
+                radius: 0.9,
+              ),
             ),
           ),
         ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:google_fonts/google_fonts.dart';
 import 'package:provider/provider.dart' as pv;
 import 'package:window_manager/window_manager.dart';
 import 'package:admin/utils/platform_utils.dart';
@@ -12,6 +12,7 @@ import 'package:admin/constants.dart';
 import 'package:admin/controllers/menu_app_controller.dart';
 import 'package:admin/features/main_menu/main_menu_page.dart';
 import 'package:admin/features/shared/providers/search_flow_form_provider.dart';
+import 'package:admin/core/theme/app_theme.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -56,16 +57,28 @@ class MyApp extends StatelessWidget {
       ],
       child: MaterialApp(
         debugShowCheckedModeBanner: false,
-        title: 'Flutter Admin Panel',
-        theme: ThemeData.dark().copyWith(
-          scaffoldBackgroundColor: bgColor,
-          textTheme: GoogleFonts.poppinsTextTheme(
-            Theme.of(context).textTheme,
-          ).apply(bodyColor: Colors.white),
-          canvasColor: secondaryColor,
-        ),
+        title: 'Relic TT',
+        theme: AppTheme.dark(),
+        builder: (context, child) {
+          return ScrollConfiguration(
+            behavior: const _AppScrollBehavior(),
+            child: child ?? const SizedBox.shrink(),
+          );
+        },
         home: const MainMenuPage(),
       ),
     );
   }
+}
+
+class _AppScrollBehavior extends MaterialScrollBehavior {
+  const _AppScrollBehavior();
+
+  @override
+  Set<PointerDeviceKind> get dragDevices => {
+    PointerDeviceKind.touch,
+    PointerDeviceKind.mouse,
+    PointerDeviceKind.stylus,
+    PointerDeviceKind.trackpad,
+  };
 }


### PR DESCRIPTION
## Summary
- centralize color, typography, and component styling in a reusable dark AppTheme
- redesign the main menu with descriptive action cards and updated background accents
- modernize the login experience with form validation, feedback, and loading states

## Testing
- flutter test

------
https://chatgpt.com/codex/tasks/task_e_68dac3c959008331b418bc7c182d1236