### PR TITLE
Fix status OS filter fields losing text on Android

### DIFF
--- a/lib/features/export_relatorios/presentation/status_os_page.dart
+++ b/lib/features/export_relatorios/presentation/status_os_page.dart
@@ -560,13 +560,31 @@ class _StatusOsPageState extends State<StatusOsPage> {
                   final resolvedMaxWidth = maxWidth.isFinite && maxWidth > 0
                       ? maxWidth
                       : MediaQuery.of(context).size.width;
-                  final spacing = 12.0;
-                  final maxItemWidth = math.min(240.0, resolvedMaxWidth);
-                  final minItemWidth = math.min(180.0, maxItemWidth);
+                  const spacing = 16.0;
+                  const runSpacing = 16.0;
+
+                  if (resolvedMaxWidth >= 900) {
+                    return Row(
+                      children: [
+                        for (var i = 0; i < dropdowns.length; i++)
+                          Expanded(
+                            child: Padding(
+                              padding: EdgeInsets.only(
+                                right: i == dropdowns.length - 1 ? 0 : spacing,
+                              ),
+                              child: dropdowns[i],
+                            ),
+                          ),
+                      ],
+                    );
+                  }
+
+                  final maxItemWidth = math.min(320.0, resolvedMaxWidth);
+                  final minItemWidth = math.min(200.0, maxItemWidth);
 
                   return Wrap(
                     spacing: spacing,
-                    runSpacing: 12,
+                    runSpacing: runSpacing,
                     children: [
                       for (final dropdown in dropdowns)
                         ConstrainedBox(

--- a/lib/features/export_relatorios/presentation/status_os_page.dart
+++ b/lib/features/export_relatorios/presentation/status_os_page.dart
@@ -53,7 +53,7 @@ class _StatusOsPageState extends State<StatusOsPage> {
   List<String> _categorias = const <String>[];
   List<String> _maquinas = const <String>[];
   Map<String, List<String>> _maquinasPorCategoria =
-  const <String, List<String>>{};
+      const <String, List<String>>{};
   List<String> _partnumbers = const <String>[];
   List<String> _osOptions = const <String>[];
   List<String> _resOptions = const <String>[];
@@ -70,6 +70,12 @@ class _StatusOsPageState extends State<StatusOsPage> {
   late final TextEditingController _osController;
   late final TextEditingController _reController;
 
+  late final FocusNode _categoriaFocusNode;
+  late final FocusNode _maquinaFocusNode;
+  late final FocusNode _partnumberFocusNode;
+  late final FocusNode _osFocusNode;
+  late final FocusNode _reFocusNode;
+
   @override
   void initState() {
     super.initState();
@@ -78,6 +84,11 @@ class _StatusOsPageState extends State<StatusOsPage> {
     _partnumberController = TextEditingController();
     _osController = TextEditingController();
     _reController = TextEditingController();
+    _categoriaFocusNode = FocusNode(debugLabel: 'categoriaDropdown');
+    _maquinaFocusNode = FocusNode(debugLabel: 'maquinaDropdown');
+    _partnumberFocusNode = FocusNode(debugLabel: 'partnumberDropdown');
+    _osFocusNode = FocusNode(debugLabel: 'osDropdown');
+    _reFocusNode = FocusNode(debugLabel: 'reDropdown');
     Future.microtask(_carregar);
     _autoRefreshTimer = Timer.periodic(const Duration(seconds: 1), (_) {
       if (!mounted || _loading) return;
@@ -93,6 +104,11 @@ class _StatusOsPageState extends State<StatusOsPage> {
     _partnumberController.dispose();
     _osController.dispose();
     _reController.dispose();
+    _categoriaFocusNode.dispose();
+    _maquinaFocusNode.dispose();
+    _partnumberFocusNode.dispose();
+    _osFocusNode.dispose();
+    _reFocusNode.dispose();
     super.dispose();
   }
 
@@ -102,57 +118,57 @@ class _StatusOsPageState extends State<StatusOsPage> {
     if (!mounted) return;
     final parsed = data
         .map<Map<String, dynamic>>((raw) {
-      final mapa = Map<String, dynamic>.from(raw);
-      for (final key in _statusKeys) {
-        final valor = mapa[key];
-        if (valor is num) {
-          mapa[key] = valor.toInt();
-        } else {
-          mapa[key] = 0;
-        }
-      }
-      mapa['categorias'] = SplayTreeSet<String>.from(
-        (mapa['categorias'] as List?)?.whereType<String>() ??
-            const <String>[],
-      ).toList(growable: false);
-      mapa['maquinas'] = SplayTreeSet<String>.from(
-        (mapa['maquinas'] as List?)?.whereType<String>() ??
-            const <String>[],
-      ).toList(growable: false);
-      mapa['partnumbers'] = SplayTreeSet<String>.from(
-        (mapa['partnumbers'] as List?)?.whereType<String>() ??
-            const <String>[],
-      ).toList(growable: false);
-      mapa['status'] = (mapa['status'] ?? '').toString();
-      mapa['os'] = (mapa['os'] ?? '').toString();
-      final reCounts = <_ReSamplingCount>[];
-      final amostragensPorRe = mapa['amostragens_por_re'];
-      if (amostragensPorRe is List) {
-        for (final entry in amostragensPorRe) {
-          if (entry is! Map) continue;
-          final re = (entry['re'] ?? '').toString().trim();
-          if (re.isEmpty) continue;
-          final totalRaw = entry['total'];
-          final total = totalRaw is num
-              ? totalRaw.toInt()
-              : int.tryParse(totalRaw?.toString() ?? '') ?? 0;
-          if (total <= 0) continue;
-          reCounts.add(_ReSamplingCount(re: re, total: total));
-        }
-      } else if (amostragensPorRe is Map) {
-        amostragensPorRe.forEach((key, value) {
-          final re = (key ?? '').toString().trim();
-          if (re.isEmpty) return;
-          final total = value is num
-              ? value.toInt()
-              : int.tryParse(value?.toString() ?? '') ?? 0;
-          if (total <= 0) return;
-          reCounts.add(_ReSamplingCount(re: re, total: total));
-        });
-      }
-      mapa['amostragens_por_re'] = reCounts;
-      return mapa;
-    })
+          final mapa = Map<String, dynamic>.from(raw);
+          for (final key in _statusKeys) {
+            final valor = mapa[key];
+            if (valor is num) {
+              mapa[key] = valor.toInt();
+            } else {
+              mapa[key] = 0;
+            }
+          }
+          mapa['categorias'] = SplayTreeSet<String>.from(
+            (mapa['categorias'] as List?)?.whereType<String>() ??
+                const <String>[],
+          ).toList(growable: false);
+          mapa['maquinas'] = SplayTreeSet<String>.from(
+            (mapa['maquinas'] as List?)?.whereType<String>() ??
+                const <String>[],
+          ).toList(growable: false);
+          mapa['partnumbers'] = SplayTreeSet<String>.from(
+            (mapa['partnumbers'] as List?)?.whereType<String>() ??
+                const <String>[],
+          ).toList(growable: false);
+          mapa['status'] = (mapa['status'] ?? '').toString();
+          mapa['os'] = (mapa['os'] ?? '').toString();
+          final reCounts = <_ReSamplingCount>[];
+          final amostragensPorRe = mapa['amostragens_por_re'];
+          if (amostragensPorRe is List) {
+            for (final entry in amostragensPorRe) {
+              if (entry is! Map) continue;
+              final re = (entry['re'] ?? '').toString().trim();
+              if (re.isEmpty) continue;
+              final totalRaw = entry['total'];
+              final total = totalRaw is num
+                  ? totalRaw.toInt()
+                  : int.tryParse(totalRaw?.toString() ?? '') ?? 0;
+              if (total <= 0) continue;
+              reCounts.add(_ReSamplingCount(re: re, total: total));
+            }
+          } else if (amostragensPorRe is Map) {
+            amostragensPorRe.forEach((key, value) {
+              final re = (key ?? '').toString().trim();
+              if (re.isEmpty) return;
+              final total = value is num
+                  ? value.toInt()
+                  : int.tryParse(value?.toString() ?? '') ?? 0;
+              if (total <= 0) return;
+              reCounts.add(_ReSamplingCount(re: re, total: total));
+            });
+          }
+          mapa['amostragens_por_re'] = reCounts;
+          return mapa;
+        })
         .toList(growable: false);
 
     final categorias = SplayTreeSet<String>();
@@ -169,7 +185,7 @@ class _StatusOsPageState extends State<StatusOsPage> {
       for (final categoria in row['categorias'].cast<String>()) {
         final bucket = maquinasPorCategoria.putIfAbsent(
           categoria,
-              () => SplayTreeSet<String>(),
+          () => SplayTreeSet<String>(),
         );
         bucket.addAll(maquinasDaLinha);
       }
@@ -228,7 +244,7 @@ class _StatusOsPageState extends State<StatusOsPage> {
       _categorias = categorias.toList(growable: false);
       _maquinas = maquinas.toList(growable: false);
       _maquinasPorCategoria = maquinasPorCategoria.map(
-            (key, value) => MapEntry(key, value.toList(growable: false)),
+        (key, value) => MapEntry(key, value.toList(growable: false)),
       );
       _partnumbers = partnumbers.toList(growable: false);
       _osOptions = ordens.toList(growable: false);
@@ -238,65 +254,77 @@ class _StatusOsPageState extends State<StatusOsPage> {
       _partnumberSelecionado = partnumberSelecionado;
       _osSelecionada = osSelecionada;
       _reSelecionado = reSelecionado;
-      _atualizarTextoDropdown(_categoriaController, categoriaSelecionada);
-      _atualizarTextoDropdown(_maquinaController, maquinaSelecionada);
-      _atualizarTextoDropdown(_partnumberController, partnumberSelecionado);
-      _atualizarTextoDropdown(_osController, osSelecionada);
-      _atualizarTextoDropdown(_reController, reSelecionado);
+      _atualizarTextoDropdown(
+        _categoriaController,
+        categoriaSelecionada,
+        _categoriaFocusNode,
+      );
+      _atualizarTextoDropdown(
+        _maquinaController,
+        maquinaSelecionada,
+        _maquinaFocusNode,
+      );
+      _atualizarTextoDropdown(
+        _partnumberController,
+        partnumberSelecionado,
+        _partnumberFocusNode,
+      );
+      _atualizarTextoDropdown(_osController, osSelecionada, _osFocusNode);
+      _atualizarTextoDropdown(_reController, reSelecionado, _reFocusNode);
       _loading = false;
     });
   }
 
   List<Map<String, dynamic>> _filtrarLista(
-      List<Map<String, dynamic>> base, {
-        String? categoria,
-        String? maquina,
-        String? partnumber,
-        String? os,
-        String? re,
-      }) {
+    List<Map<String, dynamic>> base, {
+    String? categoria,
+    String? maquina,
+    String? partnumber,
+    String? os,
+    String? re,
+  }) {
     return base
         .where((row) {
-      final categorias =
-          (row['categorias'] as List?)?.whereType<String>().toList() ??
+          final categorias =
+              (row['categorias'] as List?)?.whereType<String>().toList() ??
               const [];
-      final maquinas =
-          (row['maquinas'] as List?)?.whereType<String>().toList() ??
+          final maquinas =
+              (row['maquinas'] as List?)?.whereType<String>().toList() ??
               const [];
-      final partnumbers =
-          (row['partnumbers'] as List?)?.whereType<String>().toList() ??
+          final partnumbers =
+              (row['partnumbers'] as List?)?.whereType<String>().toList() ??
               const [];
-      final osValor = row['os']?.toString() ?? '';
-      final reAmostragens = row['amostragens_por_re'];
+          final osValor = row['os']?.toString() ?? '';
+          final reAmostragens = row['amostragens_por_re'];
 
-      if (categoria != null &&
-          categoria.isNotEmpty &&
-          !categorias.contains(categoria)) {
-        return false;
-      }
-      if (maquina != null &&
-          maquina.isNotEmpty &&
-          !maquinas.contains(maquina)) {
-        return false;
-      }
-      if (partnumber != null &&
-          partnumber.isNotEmpty &&
-          !partnumbers.contains(partnumber)) {
-        return false;
-      }
-      if (os != null && os.isNotEmpty && osValor != os) {
-        return false;
-      }
-      if (re != null && re.isNotEmpty) {
-        final contemRe =
-            reAmostragens is List<_ReSamplingCount> &&
+          if (categoria != null &&
+              categoria.isNotEmpty &&
+              !categorias.contains(categoria)) {
+            return false;
+          }
+          if (maquina != null &&
+              maquina.isNotEmpty &&
+              !maquinas.contains(maquina)) {
+            return false;
+          }
+          if (partnumber != null &&
+              partnumber.isNotEmpty &&
+              !partnumbers.contains(partnumber)) {
+            return false;
+          }
+          if (os != null && os.isNotEmpty && osValor != os) {
+            return false;
+          }
+          if (re != null && re.isNotEmpty) {
+            final contemRe =
+                reAmostragens is List<_ReSamplingCount> &&
                 reAmostragens.any((item) => item.re == re);
-        if (!contemRe) {
-          return false;
-        }
-      }
-      return true;
-    })
+            if (!contemRe) {
+              return false;
+            }
+          }
+          return true;
+        })
         .toList(growable: false);
   }
 
@@ -323,13 +351,21 @@ class _StatusOsPageState extends State<StatusOsPage> {
   }
 
   void _atualizarTextoDropdown(
-      TextEditingController controller,
-      String? valorSelecionado,
-      ) {
+    TextEditingController controller,
+    String? valorSelecionado,
+    FocusNode focusNode,
+  ) {
     final texto = valorSelecionado ?? '';
-    if (controller.text != texto) {
-      controller.text = texto;
-    }
+    if (controller.text == texto) return;
+
+    final shouldUpdate = valorSelecionado != null || !focusNode.hasFocus;
+    if (!shouldUpdate) return;
+
+    controller.value = controller.value.copyWith(
+      text: texto,
+      selection: TextSelection.collapsed(offset: texto.length),
+      composing: TextRange.empty,
+    );
   }
 
   Map<String, int> _totaisGeraisAmostragens() {
@@ -368,13 +404,14 @@ class _StatusOsPageState extends State<StatusOsPage> {
     required String? valor,
     required ValueChanged<String?> onChanged,
     required TextEditingController controller,
+    required FocusNode focusNode,
   }) {
-    _atualizarTextoDropdown(controller, valor);
+    _atualizarTextoDropdown(controller, valor, focusNode);
 
     final entries = <DropdownMenuEntry<String>>[
       const DropdownMenuEntry<String>(value: _todos, label: 'Todos'),
       ...opcoes.map(
-            (opcao) => DropdownMenuEntry<String>(value: opcao, label: opcao),
+        (opcao) => DropdownMenuEntry<String>(value: opcao, label: opcao),
       ),
     ];
 
@@ -386,6 +423,11 @@ class _StatusOsPageState extends State<StatusOsPage> {
       enableFilter: true,
       requestFocusOnTap: true,
       initialSelection: valor,
+      focusNode: focusNode,
+      inputDecorationTheme: const InputDecorationTheme(
+        border: OutlineInputBorder(),
+        isDense: true,
+      ),
       onSelected: (selecionado) {
         if (selecionado == null || selecionado == _todos) {
           onChanged(null);
@@ -405,16 +447,25 @@ class _StatusOsPageState extends State<StatusOsPage> {
         opcoes: _categorias,
         valor: _categoriaSelecionada,
         controller: _categoriaController,
+        focusNode: _categoriaFocusNode,
         onChanged: (valor) => _atualizarFiltro(() {
           _categoriaSelecionada = valor;
-          _atualizarTextoDropdown(_categoriaController, _categoriaSelecionada);
+          _atualizarTextoDropdown(
+            _categoriaController,
+            _categoriaSelecionada,
+            _categoriaFocusNode,
+          );
           if (_categoriaSelecionada != null) {
             final maquinasDisponiveis =
-            _maquinasPorCategoria[_categoriaSelecionada];
+                _maquinasPorCategoria[_categoriaSelecionada];
             if (maquinasDisponiveis == null ||
                 !maquinasDisponiveis.contains(_maquinaSelecionada)) {
               _maquinaSelecionada = null;
-              _atualizarTextoDropdown(_maquinaController, _maquinaSelecionada);
+              _atualizarTextoDropdown(
+                _maquinaController,
+                _maquinaSelecionada,
+                _maquinaFocusNode,
+              );
             }
           }
         }),
@@ -424,9 +475,14 @@ class _StatusOsPageState extends State<StatusOsPage> {
         opcoes: _obterMaquinasDisponiveis(),
         valor: _maquinaSelecionada,
         controller: _maquinaController,
+        focusNode: _maquinaFocusNode,
         onChanged: (valor) => _atualizarFiltro(() {
           _maquinaSelecionada = valor;
-          _atualizarTextoDropdown(_maquinaController, _maquinaSelecionada);
+          _atualizarTextoDropdown(
+            _maquinaController,
+            _maquinaSelecionada,
+            _maquinaFocusNode,
+          );
         }),
       ),
       _buildDropdown(
@@ -434,11 +490,13 @@ class _StatusOsPageState extends State<StatusOsPage> {
         opcoes: _partnumbers,
         valor: _partnumberSelecionado,
         controller: _partnumberController,
+        focusNode: _partnumberFocusNode,
         onChanged: (valor) => _atualizarFiltro(() {
           _partnumberSelecionado = valor;
           _atualizarTextoDropdown(
             _partnumberController,
             _partnumberSelecionado,
+            _partnumberFocusNode,
           );
         }),
       ),
@@ -447,9 +505,10 @@ class _StatusOsPageState extends State<StatusOsPage> {
         opcoes: _osOptions,
         valor: _osSelecionada,
         controller: _osController,
+        focusNode: _osFocusNode,
         onChanged: (valor) => _atualizarFiltro(() {
           _osSelecionada = valor;
-          _atualizarTextoDropdown(_osController, _osSelecionada);
+          _atualizarTextoDropdown(_osController, _osSelecionada, _osFocusNode);
         }),
       ),
       _buildDropdown(
@@ -457,9 +516,10 @@ class _StatusOsPageState extends State<StatusOsPage> {
         opcoes: _resOptions,
         valor: _reSelecionado,
         controller: _reController,
+        focusNode: _reFocusNode,
         onChanged: (valor) => _atualizarFiltro(() {
           _reSelecionado = valor;
-          _atualizarTextoDropdown(_reController, _reSelecionado);
+          _atualizarTextoDropdown(_reController, _reSelecionado, _reFocusNode);
         }),
       ),
     ];
@@ -756,10 +816,10 @@ class _OsInteractivePieState extends State<_OsInteractivePie> {
 
     final shouldResetIndex =
         _touchedIndex >= widget.slices.length ||
-            (_touchedIndex >= 0 &&
-                _touchedIndex < oldWidget.slices.length &&
-                oldWidget.slices[_touchedIndex].label !=
-                    widget.slices[_touchedIndex].label);
+        (_touchedIndex >= 0 &&
+            _touchedIndex < oldWidget.slices.length &&
+            oldWidget.slices[_touchedIndex].label !=
+                widget.slices[_touchedIndex].label);
 
     if (shouldResetIndex) {
       setState(() => _touchedIndex = -1);
@@ -768,7 +828,7 @@ class _OsInteractivePieState extends State<_OsInteractivePie> {
 
   void _handleTouch(FlTouchEvent event, PieTouchResponse? response) {
     final newIndex =
-    event.isInterestedForInteractions && response?.touchedSection != null
+        event.isInterestedForInteractions && response?.touchedSection != null
         ? response!.touchedSection!.touchedSectionIndex
         : -1;
     if (newIndex != _touchedIndex) {
@@ -787,7 +847,7 @@ class _OsInteractivePieState extends State<_OsInteractivePie> {
         : 2.0;
 
     final hoveredLabel =
-    (_touchedIndex >= 0 && _touchedIndex < widget.slices.length)
+        (_touchedIndex >= 0 && _touchedIndex < widget.slices.length)
         ? widget.slices[_touchedIndex].label
         : null;
     final labelStyle = theme.textTheme.bodyMedium?.copyWith(
@@ -818,8 +878,10 @@ class _OsInteractivePieState extends State<_OsInteractivePie> {
               value: slice.value,
               showTitle: false,
               radius: isTouched ? touchedRadius : baseRadius,
-              badgeWidget:
-                  _OsSliceBadge(label: slice.label, visible: isTouched),
+              badgeWidget: _OsSliceBadge(
+                label: slice.label,
+                visible: isTouched,
+              ),
               badgePositionPercentageOffset: badgeOffset,
             ),
           );
@@ -838,8 +900,7 @@ class _OsInteractivePieState extends State<_OsInteractivePie> {
                       sectionsSpace: sectionsSpace,
                       centerSpaceRadius: centerSpace,
                       startDegreeOffset: -90,
-                      pieTouchData:
-                          PieTouchData(touchCallback: _handleTouch),
+                      pieTouchData: PieTouchData(touchCallback: _handleTouch),
                     ),
                   ),
                   Positioned.fill(
@@ -956,14 +1017,14 @@ class _SamplingPieCard extends StatelessWidget {
         .toList(growable: false);
     final total = entries.fold<int>(0, (acc, item) => acc + item.value);
     final reEntries =
-    totaisPorRe.entries
-        .where((entry) => entry.value > 0)
-        .toList(growable: false)
-      ..sort((a, b) {
-        final diff = b.value.compareTo(a.value);
-        if (diff != 0) return diff;
-        return a.key.compareTo(b.key);
-      });
+        totaisPorRe.entries
+            .where((entry) => entry.value > 0)
+            .toList(growable: false)
+          ..sort((a, b) {
+            final diff = b.value.compareTo(a.value);
+            if (diff != 0) return diff;
+            return a.key.compareTo(b.key);
+          });
 
     Widget buildChart() {
       if (total == 0) {
@@ -1115,10 +1176,10 @@ class _InteractivePieWithLegendState extends State<_InteractivePieWithLegend> {
 
     final shouldResetIndex =
         _touchedIndex >= widget.slices.length ||
-            (_touchedIndex >= 0 &&
-                _touchedIndex < oldWidget.slices.length &&
-                oldWidget.slices[_touchedIndex].label !=
-                    widget.slices[_touchedIndex].label);
+        (_touchedIndex >= 0 &&
+            _touchedIndex < oldWidget.slices.length &&
+            oldWidget.slices[_touchedIndex].label !=
+                widget.slices[_touchedIndex].label);
 
     if (shouldResetIndex) {
       setState(() => _touchedIndex = -1);
@@ -1127,7 +1188,7 @@ class _InteractivePieWithLegendState extends State<_InteractivePieWithLegend> {
 
   void _handleTouch(FlTouchEvent event, PieTouchResponse? response) {
     final newIndex =
-    event.isInterestedForInteractions && response?.touchedSection != null
+        event.isInterestedForInteractions && response?.touchedSection != null
         ? response!.touchedSection!.touchedSectionIndex
         : -1;
     if (newIndex != _touchedIndex) {
@@ -1149,8 +1210,8 @@ class _InteractivePieWithLegendState extends State<_InteractivePieWithLegend> {
 
     final hoveredLabel =
         (_touchedIndex >= 0 && _touchedIndex < widget.slices.length)
-            ? widget.slices[_touchedIndex].label
-            : null;
+        ? widget.slices[_touchedIndex].label
+        : null;
     final hoveredStyle = theme.textTheme.bodyMedium?.copyWith(
       color: theme.colorScheme.onSurface.withOpacity(0.82),
       fontWeight: FontWeight.w600,
@@ -1285,8 +1346,8 @@ class _LegendEntry extends StatelessWidget {
     final theme = Theme.of(context);
     final background = highlighted
         ? theme.colorScheme.surfaceVariant.withOpacity(
-      theme.brightness == Brightness.dark ? 0.45 : 0.6,
-    )
+            theme.brightness == Brightness.dark ? 0.45 : 0.6,
+          )
         : Colors.transparent;
     final textStyle = theme.textTheme.bodySmall?.copyWith(
       color: theme.colorScheme.onSurface.withOpacity(highlighted ? 0.92 : 0.8),
@@ -1313,12 +1374,12 @@ class _LegendEntry extends StatelessWidget {
                 borderRadius: BorderRadius.circular(4),
                 boxShadow: highlighted
                     ? [
-                  BoxShadow(
-                    color: color.withOpacity(0.36),
-                    blurRadius: 10,
-                    offset: const Offset(0, 2),
-                  ),
-                ]
+                        BoxShadow(
+                          color: color.withOpacity(0.36),
+                          blurRadius: 10,
+                          offset: const Offset(0, 2),
+                        ),
+                      ]
                     : null,
               ),
             ),
@@ -1410,12 +1471,7 @@ List<Color> _buildPalette(ThemeData theme, int count) {
     hue = (hue + goldenRatio) % 1.0;
     final saturation = 0.78;
     final value = 0.88;
-    final color = HSVColor.fromAHSV(
-      1,
-      hue * 360,
-      saturation,
-      value,
-    ).toColor();
+    final color = HSVColor.fromAHSV(1, hue * 360, saturation, value).toColor();
     if (!colors.any((existing) => existing.value == color.value)) {
       colors.add(color);
     }

--- a/lib/features/export_relatorios/presentation/status_os_page.dart
+++ b/lib/features/export_relatorios/presentation/status_os_page.dart
@@ -349,15 +349,21 @@ class _StatusOsPageState extends State<StatusOsPage> {
     String? valorSelecionado,
     FocusNode focusNode,
   ) {
-    final texto = valorSelecionado ?? '';
-    if (controller.text == texto) return;
+    if (valorSelecionado == null) {
+      if (focusNode.hasFocus || controller.text.isEmpty) return;
+      controller.value = controller.value.copyWith(
+        text: '',
+        selection: const TextSelection.collapsed(offset: 0),
+        composing: TextRange.empty,
+      );
+      return;
+    }
 
-    final shouldUpdate = valorSelecionado != null || !focusNode.hasFocus;
-    if (!shouldUpdate) return;
+    if (controller.text == valorSelecionado) return;
 
     controller.value = controller.value.copyWith(
-      text: texto,
-      selection: TextSelection.collapsed(offset: texto.length),
+      text: valorSelecionado,
+      selection: TextSelection.collapsed(offset: valorSelecionado.length),
       composing: TextRange.empty,
     );
   }
@@ -402,6 +408,18 @@ class _StatusOsPageState extends State<StatusOsPage> {
   }) {
     _atualizarTextoDropdown(controller, valor, focusNode);
 
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final borderRadius = BorderRadius.circular(8);
+    final enabledBorder = OutlineInputBorder(
+      borderRadius: borderRadius,
+      borderSide: BorderSide(color: colorScheme.outlineVariant, width: 1.2),
+    );
+    final focusedBorder = OutlineInputBorder(
+      borderRadius: borderRadius,
+      borderSide: BorderSide(color: colorScheme.primary, width: 1.6),
+    );
+
     final entries = <DropdownMenuEntry<String>>[
       const DropdownMenuEntry<String>(value: _todos, label: 'Todos'),
       ...opcoes.map(
@@ -421,16 +439,17 @@ class _StatusOsPageState extends State<StatusOsPage> {
       dropdownMenuEntries: entries,
       enableFilter: true,
       requestFocusOnTap: true,
-      initialSelection: valor,
       focusNode: focusNode,
-      inputDecorationTheme: const InputDecorationTheme(
-        border: OutlineInputBorder(),
-        enabledBorder: OutlineInputBorder(),
-        focusedBorder: OutlineInputBorder(),
+      inputDecorationTheme: InputDecorationTheme(
+        border: enabledBorder,
+        enabledBorder: enabledBorder,
+        focusedBorder: focusedBorder,
         isDense: true,
+        contentPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
       ),
       onSelected: (selecionado) {
         if (selecionado == null || selecionado == _todos) {
+          controller.clear();
           onChanged(null);
         } else {
           onChanged(selecionado);
@@ -541,11 +560,12 @@ class _StatusOsPageState extends State<StatusOsPage> {
                   final resolvedMaxWidth = maxWidth.isFinite && maxWidth > 0
                       ? maxWidth
                       : MediaQuery.of(context).size.width;
-                  final maxItemWidth = math.min(320.0, resolvedMaxWidth);
-                  final minItemWidth = math.min(220.0, maxItemWidth);
+                  final spacing = 12.0;
+                  final maxItemWidth = math.min(240.0, resolvedMaxWidth);
+                  final minItemWidth = math.min(180.0, maxItemWidth);
 
                   return Wrap(
-                    spacing: 16,
+                    spacing: spacing,
                     runSpacing: 12,
                     children: [
                       for (final dropdown in dropdowns)

--- a/lib/features/export_relatorios/presentation/status_os_page.dart
+++ b/lib/features/export_relatorios/presentation/status_os_page.dart
@@ -70,12 +70,13 @@ class _StatusOsPageState extends State<StatusOsPage> {
   final TextEditingController _osController = TextEditingController();
   final TextEditingController _reController = TextEditingController();
 
-  final FocusNode _categoriaFocusNode =
-      FocusNode(debugLabel: 'categoriaDropdown');
-  final FocusNode _maquinaFocusNode =
-      FocusNode(debugLabel: 'maquinaDropdown');
-  final FocusNode _partnumberFocusNode =
-      FocusNode(debugLabel: 'partnumberDropdown');
+  final FocusNode _categoriaFocusNode = FocusNode(
+    debugLabel: 'categoriaDropdown',
+  );
+  final FocusNode _maquinaFocusNode = FocusNode(debugLabel: 'maquinaDropdown');
+  final FocusNode _partnumberFocusNode = FocusNode(
+    debugLabel: 'partnumberDropdown',
+  );
   final FocusNode _osFocusNode = FocusNode(debugLabel: 'osDropdown');
   final FocusNode _reFocusNode = FocusNode(debugLabel: 'reDropdown');
 
@@ -410,7 +411,12 @@ class _StatusOsPageState extends State<StatusOsPage> {
 
     return DropdownMenu<String>(
       controller: controller,
-      label: Text(label),
+      label: Text(
+        label,
+        maxLines: 2,
+        softWrap: true,
+        overflow: TextOverflow.visible,
+      ),
       hintText: 'Todos',
       dropdownMenuEntries: entries,
       enableFilter: true,
@@ -434,8 +440,6 @@ class _StatusOsPageState extends State<StatusOsPage> {
   }
 
   Widget _buildFiltros() {
-    const gap = 12.0;
-
     final dropdowns = <Widget>[
       _buildDropdown(
         label: 'Grupo de máquina',
@@ -531,36 +535,27 @@ class _StatusOsPageState extends State<StatusOsPage> {
               const SizedBox(height: 16),
               LayoutBuilder(
                 builder: (context, constraints) {
-                  final itemCount = dropdowns.length;
-                  if (itemCount == 0) {
-                    return const SizedBox.shrink();
-                  }
-
                   final maxWidth = constraints.maxWidth.isFinite
                       ? constraints.maxWidth
                       : MediaQuery.of(context).size.width;
-                  var spacing = gap;
-                  if (itemCount > 1 && maxWidth.isFinite) {
-                    final requiredSpacing = spacing * (itemCount - 1);
-                    if (requiredSpacing > maxWidth) {
-                      spacing = maxWidth / (itemCount - 1 + itemCount);
-                    }
-                  }
-                  final totalSpacing = spacing * (itemCount - 1);
-                  final availableForItems = (maxWidth - totalSpacing).clamp(
-                    0.0,
-                    double.infinity,
-                  );
-                  final itemWidth = itemCount > 0
-                      ? availableForItems / itemCount
-                      : 0.0;
+                  final resolvedMaxWidth = maxWidth.isFinite && maxWidth > 0
+                      ? maxWidth
+                      : MediaQuery.of(context).size.width;
+                  final maxItemWidth = math.min(320.0, resolvedMaxWidth);
+                  final minItemWidth = math.min(220.0, maxItemWidth);
 
-                  return Row(
+                  return Wrap(
+                    spacing: 16,
+                    runSpacing: 12,
                     children: [
-                      for (var i = 0; i < itemCount; i++) ...[
-                        SizedBox(width: itemWidth, child: dropdowns[i]),
-                        if (i < itemCount - 1) SizedBox(width: spacing),
-                      ],
+                      for (final dropdown in dropdowns)
+                        ConstrainedBox(
+                          constraints: BoxConstraints(
+                            minWidth: minItemWidth,
+                            maxWidth: maxItemWidth,
+                          ),
+                          child: dropdown,
+                        ),
                     ],
                   );
                 },

--- a/lib/features/export_relatorios/presentation/status_os_page.dart
+++ b/lib/features/export_relatorios/presentation/status_os_page.dart
@@ -419,6 +419,8 @@ class _StatusOsPageState extends State<StatusOsPage> {
       focusNode: focusNode,
       inputDecorationTheme: const InputDecorationTheme(
         border: OutlineInputBorder(),
+        enabledBorder: OutlineInputBorder(),
+        focusedBorder: OutlineInputBorder(),
         isDense: true,
       ),
       onSelected: (selecionado) {

--- a/lib/features/export_relatorios/presentation/status_os_page.dart
+++ b/lib/features/export_relatorios/presentation/status_os_page.dart
@@ -64,31 +64,24 @@ class _StatusOsPageState extends State<StatusOsPage> {
   String? _osSelecionada;
   String? _reSelecionado;
 
-  late final TextEditingController _categoriaController;
-  late final TextEditingController _maquinaController;
-  late final TextEditingController _partnumberController;
-  late final TextEditingController _osController;
-  late final TextEditingController _reController;
+  final TextEditingController _categoriaController = TextEditingController();
+  final TextEditingController _maquinaController = TextEditingController();
+  final TextEditingController _partnumberController = TextEditingController();
+  final TextEditingController _osController = TextEditingController();
+  final TextEditingController _reController = TextEditingController();
 
-  late final FocusNode _categoriaFocusNode;
-  late final FocusNode _maquinaFocusNode;
-  late final FocusNode _partnumberFocusNode;
-  late final FocusNode _osFocusNode;
-  late final FocusNode _reFocusNode;
+  final FocusNode _categoriaFocusNode =
+      FocusNode(debugLabel: 'categoriaDropdown');
+  final FocusNode _maquinaFocusNode =
+      FocusNode(debugLabel: 'maquinaDropdown');
+  final FocusNode _partnumberFocusNode =
+      FocusNode(debugLabel: 'partnumberDropdown');
+  final FocusNode _osFocusNode = FocusNode(debugLabel: 'osDropdown');
+  final FocusNode _reFocusNode = FocusNode(debugLabel: 'reDropdown');
 
   @override
   void initState() {
     super.initState();
-    _categoriaController = TextEditingController();
-    _maquinaController = TextEditingController();
-    _partnumberController = TextEditingController();
-    _osController = TextEditingController();
-    _reController = TextEditingController();
-    _categoriaFocusNode = FocusNode(debugLabel: 'categoriaDropdown');
-    _maquinaFocusNode = FocusNode(debugLabel: 'maquinaDropdown');
-    _partnumberFocusNode = FocusNode(debugLabel: 'partnumberDropdown');
-    _osFocusNode = FocusNode(debugLabel: 'osDropdown');
-    _reFocusNode = FocusNode(debugLabel: 'reDropdown');
     Future.microtask(_carregar);
     _autoRefreshTimer = Timer.periodic(const Duration(seconds: 1), (_) {
       if (!mounted || _loading) return;


### PR DESCRIPTION
## Summary
- prevent the status OS dropdown filters from resetting typed text while the auto-refresh runs by tracking focus for each field
- add outline borders to the filter dropdown inputs to match the expected styling

## Testing
- flutter test *(fails: Unable to load asset: "assets/images/logotuptech1.png")*

------
https://chatgpt.com/codex/tasks/task_e_68dbc04fb7d48331b0c74baeae57f816