### PR TITLE
Ensure Enter advances focus across flow search forms

### DIFF
--- a/lib/features/finalizar_os/presentation/finalizar_os_page.dart
+++ b/lib/features/finalizar_os/presentation/finalizar_os_page.dart
@@ -28,12 +28,12 @@ class FinalizarOsPage extends ConsumerStatefulWidget {
 }
 
 final medidasFinalizadorControllerProvider =
-StateNotifierProvider.autoDispose<
-    MedidasFinalizadorController,
-    AsyncValue<List<MedidaItem>>
->((ref) {
-  return MedidasFinalizadorController(ref);
-});
+    StateNotifierProvider.autoDispose<
+      MedidasFinalizadorController,
+      AsyncValue<List<MedidaItem>>
+    >((ref) {
+      return MedidasFinalizadorController(ref);
+    });
 
 class MedidasFinalizadorController
     extends StateNotifier<AsyncValue<List<MedidaItem>>> {
@@ -56,24 +56,24 @@ class MedidasFinalizadorController
       final normalizados = itens
           .map(
             (m) => MedidaItem(
-          indice: m.indice,
-          titulo: m.titulo,
-          faixaTexto: m.faixaTexto,
-          minimo: m.minimo,
-          maximo: m.maximo,
-          unidade: m.unidade,
-          status: StatusMedida.pendente,
-          medicao: null,
-          observacao: m.observacao,
-          periodicidade: m.periodicidade,
-          instrumento: m.instrumento,
-          dataInclusao: m.dataInclusao,
-          tolerancias: m.tolerancias,
-          contagens: m.contagens,
-          anguloMinimo: m.anguloMinimo,
-          anguloMaximo: m.anguloMaximo,
-        ),
-      )
+              indice: m.indice,
+              titulo: m.titulo,
+              faixaTexto: m.faixaTexto,
+              minimo: m.minimo,
+              maximo: m.maximo,
+              unidade: m.unidade,
+              status: StatusMedida.pendente,
+              medicao: null,
+              observacao: m.observacao,
+              periodicidade: m.periodicidade,
+              instrumento: m.instrumento,
+              dataInclusao: m.dataInclusao,
+              tolerancias: m.tolerancias,
+              contagens: m.contagens,
+              anguloMinimo: m.anguloMinimo,
+              anguloMaximo: m.anguloMaximo,
+            ),
+          )
           .toList();
 
       state = AsyncValue.data(normalizados);
@@ -141,6 +141,11 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
   final _partCtrl = TextEditingController();
   final _opCtrl = TextEditingController();
 
+  final _reFocusNode = FocusNode();
+  final _osFocusNode = FocusNode();
+  final _partFocusNode = FocusNode();
+  final _opFocusNode = FocusNode();
+
   final List<Machine> _maquinas = [];
   final List<String> _categorias = [];
   String? _categoriaSel;
@@ -154,6 +159,26 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
   late final VoidCallback _partSyncListener;
   late final VoidCallback _opSyncListener;
 
+  void _unfocusKeyboard() {
+    FocusManager.instance.primaryFocus?.unfocus();
+  }
+
+  void _submitField({
+    required bool flowLocked,
+    FocusNode? next,
+  }) {
+    if (flowLocked) {
+      _unfocusKeyboard();
+      return;
+    }
+
+    if (next != null) {
+      next.requestFocus();
+    } else {
+      _unfocusKeyboard();
+    }
+  }
+
   void _resetFinalizada() {
     if (_osFinalizada) setState(() => _osFinalizada = false);
   }
@@ -161,8 +186,10 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
   void _voltarParaMenuPrincipal() {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
-      Navigator.of(context, rootNavigator: true)
-          .popUntil((route) => route.isFirst);
+      Navigator.of(
+        context,
+        rootNavigator: true,
+      ).popUntil((route) => route.isFirst);
     });
   }
 
@@ -219,7 +246,7 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
 
           if (_categoriaSel != null) {
             final possuiMaquina = _maquinas.any(
-                  (m) => m.categoria == _categoriaSel && m.codigo == _maquinaSel,
+              (m) => m.categoria == _categoriaSel && m.codigo == _maquinaSel,
             );
             if (!possuiMaquina && _maquinaSel != null) {
               _maquinaSel = null;
@@ -245,7 +272,7 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
     final maquina = _maquinaSel;
     if (categoria == null || maquina == null) return false;
     return _maquinas.any(
-          (m) => m.categoria == categoria && m.codigo == maquina,
+      (m) => m.categoria == categoria && m.codigo == maquina,
     );
   }
 
@@ -288,6 +315,10 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
     _osCtrl.removeListener(_osSyncListener);
     _partCtrl.removeListener(_partSyncListener);
     _opCtrl.removeListener(_opSyncListener);
+    _reFocusNode.dispose();
+    _osFocusNode.dispose();
+    _partFocusNode.dispose();
+    _opFocusNode.dispose();
     _reCtrl.dispose();
     _osCtrl.dispose();
     _partCtrl.dispose();
@@ -353,9 +384,9 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
     final reprovadas = medidas
         .where(
           (m) =>
-      m.status == StatusMedida.reprovadaAbaixo ||
-          m.status == StatusMedida.reprovadaAcima,
-    )
+              m.status == StatusMedida.reprovadaAbaixo ||
+              m.status == StatusMedida.reprovadaAcima,
+        )
         .toList();
     if (reprovadas.isNotEmpty) {
       if (!mounted) return;
@@ -463,41 +494,41 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
     final reOk = _reCtrl.text.trim().isNotEmpty;
     final osOk = _osCtrl.text.trim().isNotEmpty;
     final categoriaValue =
-    (_categoriaSel != null && _categorias.contains(_categoriaSel))
+        (_categoriaSel != null && _categorias.contains(_categoriaSel))
         ? _categoriaSel
         : null;
     final maquinasDisponiveis = _maquinas
         .where((m) => m.categoria == categoriaValue)
         .toList();
     final maquinaValue =
-    (_maquinaSel != null &&
-        maquinasDisponiveis.any((m) => m.codigo == _maquinaSel))
+        (_maquinaSel != null &&
+            maquinasDisponiveis.any((m) => m.codigo == _maquinaSel))
         ? _maquinaSel
         : null;
     final maquinaOk = (maquinaValue ?? '').isNotEmpty;
     final formMatchesFlow =
         !flowLocked ||
-            flowState.matchesValues(
-              os: _osCtrl.text,
-              partNumber: _partCtrl.text,
-              operacao: _opCtrl.text,
-              categoria: categoriaValue,
-              maquina: maquinaValue,
-            );
+        flowState.matchesValues(
+          os: _osCtrl.text,
+          partNumber: _partCtrl.text,
+          operacao: _opCtrl.text,
+          categoria: categoriaValue,
+          maquina: maquinaValue,
+        );
     final todasOk =
         medidas.isNotEmpty &&
-            medidas.every(
-                  (m) =>
+        medidas.every(
+          (m) =>
               (m.medicao ?? '').isNotEmpty && m.status != StatusMedida.pendente,
-            );
+        );
     final podeRegistrar =
         formMatchesFlow &&
-            reOk &&
-            osOk &&
-            maquinaOk &&
-            todasOk &&
-            !_registrando &&
-            !_osFinalizada;
+        reOk &&
+        osOk &&
+        maquinaOk &&
+        todasOk &&
+        !_registrando &&
+        !_osFinalizada;
 
     return Scaffold(
       appBar: WindowBar(
@@ -595,16 +626,25 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
                                 Expanded(
                                   child: TextFormField(
                                     controller: _reCtrl,
+                                    focusNode: _reFocusNode,
                                     textInputAction: TextInputAction.next,
                                     keyboardType: TextInputType.number,
                                     inputFormatters: [
                                       FilteringTextInputFormatter.digitsOnly,
                                     ],
-                                    decoration: const InputDecoration(
-                                      labelText:
-                                      'R.E. do Preparador', // ajuste o texto se for Operador
-                                      border: OutlineInputBorder(),
-                                    ),
+                                  decoration: const InputDecoration(
+                                    labelText:
+                                        'R.E. do Preparador', // ajuste o texto se for Operador
+                                    border: OutlineInputBorder(),
+                                  ),
+                                  onEditingComplete: () => _submitField(
+                                    flowLocked: flowLocked,
+                                    next: _osFocusNode,
+                                  ),
+                                  onFieldSubmitted: (_) => _submitField(
+                                    flowLocked: flowLocked,
+                                    next: _osFocusNode,
+                                  ),
                                     validator: (v) {
                                       final s = (v ?? '').trim();
                                       if (s.isEmpty) return 'Obrigatório';
@@ -621,15 +661,24 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
                                   child: TextFormField(
                                     controller: _osCtrl,
                                     enabled: !flowLocked,
+                                    focusNode: _osFocusNode,
                                     textInputAction: TextInputAction.next,
                                     keyboardType: TextInputType.number,
                                     inputFormatters: [
                                       FilteringTextInputFormatter.digitsOnly,
                                     ],
-                                    decoration: const InputDecoration(
-                                      labelText: 'O.S.',
-                                      border: OutlineInputBorder(),
-                                    ),
+                                  decoration: const InputDecoration(
+                                    labelText: 'O.S.',
+                                    border: OutlineInputBorder(),
+                                  ),
+                                  onEditingComplete: () => _submitField(
+                                    flowLocked: flowLocked,
+                                    next: _partFocusNode,
+                                  ),
+                                  onFieldSubmitted: (_) => _submitField(
+                                    flowLocked: flowLocked,
+                                    next: _partFocusNode,
+                                  ),
                                     validator: (v) {
                                       final s = (v ?? '').trim();
                                       if (s.isEmpty) return 'Obrigatório';
@@ -656,25 +705,25 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
                                     items: _categorias
                                         .map(
                                           (c) => DropdownMenuItem(
-                                        value: c,
-                                        child: Text(c),
-                                      ),
-                                    )
+                                            value: c,
+                                            child: Text(c),
+                                          ),
+                                        )
                                         .toList(),
                                     onChanged: flowLocked
                                         ? null
                                         : (v) {
-                                      ref
-                                          .read(
-                                        sharedSearchFormProvider
-                                            .notifier,
-                                      )
-                                          .setCategoria(v);
-                                      setState(() {
-                                        _categoriaSel = v;
-                                        _maquinaSel = null;
-                                      });
-                                    },
+                                            ref
+                                                .read(
+                                                  sharedSearchFormProvider
+                                                      .notifier,
+                                                )
+                                                .setCategoria(v);
+                                            setState(() {
+                                              _categoriaSel = v;
+                                              _maquinaSel = null;
+                                            });
+                                          },
                                     validator: (v) => (v == null || v.isEmpty)
                                         ? 'Obrigatório'
                                         : null,
@@ -691,22 +740,22 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
                                     items: maquinasDisponiveis
                                         .map(
                                           (m) => DropdownMenuItem(
-                                        value: m.codigo,
-                                        child: Text(m.codigo),
-                                      ),
-                                    )
+                                            value: m.codigo,
+                                            child: Text(m.codigo),
+                                          ),
+                                        )
                                         .toList(),
                                     onChanged: flowLocked
                                         ? null
                                         : (v) {
-                                      ref
-                                          .read(
-                                        sharedSearchFormProvider
-                                            .notifier,
-                                      )
-                                          .setMaquina(v);
-                                      setState(() => _maquinaSel = v);
-                                    },
+                                            ref
+                                                .read(
+                                                  sharedSearchFormProvider
+                                                      .notifier,
+                                                )
+                                                .setMaquina(v);
+                                            setState(() => _maquinaSel = v);
+                                          },
                                     validator: (v) => (v == null || v.isEmpty)
                                         ? 'Obrigatório'
                                         : null,
@@ -724,13 +773,22 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
                                   child: TextFormField(
                                     controller: _partCtrl,
                                     enabled: !flowLocked,
+                                    focusNode: _partFocusNode,
                                     textInputAction: TextInputAction.next,
-                                    decoration: const InputDecoration(
-                                      labelText: 'Código da peça',
-                                      border: OutlineInputBorder(),
-                                    ),
+                                  decoration: const InputDecoration(
+                                    labelText: 'Código da peça',
+                                    border: OutlineInputBorder(),
+                                  ),
+                                  onEditingComplete: () => _submitField(
+                                    flowLocked: flowLocked,
+                                    next: _opFocusNode,
+                                  ),
+                                  onFieldSubmitted: (_) => _submitField(
+                                    flowLocked: flowLocked,
+                                    next: _opFocusNode,
+                                  ),
                                     validator: (v) =>
-                                    (v == null || v.trim().isEmpty)
+                                        (v == null || v.trim().isEmpty)
                                         ? 'Obrigatório'
                                         : null,
                                   ),
@@ -741,14 +799,22 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
                                   child: TextFormField(
                                     controller: _opCtrl,
                                     enabled: !flowLocked,
+                                    focusNode: _opFocusNode,
+                                    textInputAction: TextInputAction.done,
                                     keyboardType: TextInputType.number,
                                     inputFormatters: [
                                       FilteringTextInputFormatter.digitsOnly,
                                     ],
-                                    decoration: const InputDecoration(
-                                      labelText: 'Operação',
-                                      border: OutlineInputBorder(),
-                                    ),
+                                  decoration: const InputDecoration(
+                                    labelText: 'Operação',
+                                    border: OutlineInputBorder(),
+                                  ),
+                                  onEditingComplete: () => _submitField(
+                                    flowLocked: flowLocked,
+                                  ),
+                                  onFieldSubmitted: (_) => _submitField(
+                                    flowLocked: flowLocked,
+                                  ),
                                     validator: (v) {
                                       final s = (v ?? '').trim();
                                       if (s.isEmpty) return 'Obrigatório';
@@ -772,15 +838,15 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
                                     FocusScope.of(context).unfocus();
                                     await ref
                                         .read(
-                                      medidasFinalizadorControllerProvider
-                                          .notifier,
-                                    )
+                                          medidasFinalizadorControllerProvider
+                                              .notifier,
+                                        )
                                         .carregar(
-                                      partnumber: normalizeCode(
-                                        _partCtrl.text,
-                                      ),
-                                      operacao: normalizeCode(_opCtrl.text),
-                                    );
+                                          partnumber: normalizeCode(
+                                            _partCtrl.text,
+                                          ),
+                                          operacao: normalizeCode(_opCtrl.text),
+                                        );
                                     if (mounted) {
                                       setState(() => _mostrarResumo = true);
                                     }
@@ -819,12 +885,12 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
                                 : null,
                             icon: _registrando
                                 ? const SizedBox(
-                              width: 18,
-                              height: 18,
-                              child: CircularProgressIndicator(
-                                strokeWidth: 2,
-                              ),
-                            )
+                                    width: 18,
+                                    height: 18,
+                                    child: CircularProgressIndicator(
+                                      strokeWidth: 2,
+                                    ),
+                                  )
                                 : const Icon(Icons.save_outlined),
                             label: const Text('Finalizar OS'),
                           ),

--- a/lib/features/operador/presentation/operador_page.dart
+++ b/lib/features/operador/presentation/operador_page.dart
@@ -24,12 +24,12 @@ import 'package:admin/models/machine.dart';
 import 'package:admin/features/shared/providers/search_flow_form_provider.dart';
 
 final medidasOperadorControllerProvider =
-StateNotifierProvider.autoDispose<
-    MedidasOperadorController,
-    AsyncValue<List<MedidaItem>>
->((ref) {
-  return MedidasOperadorController(ref);
-});
+    StateNotifierProvider.autoDispose<
+      MedidasOperadorController,
+      AsyncValue<List<MedidaItem>>
+    >((ref) {
+      return MedidasOperadorController(ref);
+    });
 
 class MedidasOperadorController
     extends StateNotifier<AsyncValue<List<MedidaItem>>> {
@@ -170,6 +170,11 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
   final _partCtrl = TextEditingController();
   final _opCtrl = TextEditingController();
 
+  final _reFocusNode = FocusNode();
+  final _osFocusNode = FocusNode();
+  final _partFocusNode = FocusNode();
+  final _opFocusNode = FocusNode();
+
   final List<Machine> _maquinas = [];
   final List<String> _categorias = [];
   String? _categoriaSel;
@@ -187,6 +192,26 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
   bool _amostragemReminderDialogOpen = false;
   DateTime? _lastAmostragem;
   DateTime? _lastReminderShownAt;
+
+  void _unfocusKeyboard() {
+    FocusManager.instance.primaryFocus?.unfocus();
+  }
+
+  void _submitField({
+    required bool flowLocked,
+    FocusNode? next,
+  }) {
+    if (flowLocked) {
+      _unfocusKeyboard();
+      return;
+    }
+
+    if (next != null) {
+      next.requestFocus();
+    } else {
+      _unfocusKeyboard();
+    }
+  }
 
   @override
   void initState() {
@@ -219,9 +244,9 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
   }
 
   void _handleFlowStateChange(
-      SharedSearchFormState? previous,
-      SharedSearchFormState next,
-      ) {
+    SharedSearchFormState? previous,
+    SharedSearchFormState next,
+  ) {
     if (!next.isActive ||
         next.effectiveProcess != SearchFlowProcess.amostragem) {
       _activeAmostragemFlow = null;
@@ -231,8 +256,8 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
 
     final wasActive =
         previous != null &&
-            previous.isActive &&
-            previous.effectiveProcess == SearchFlowProcess.amostragem;
+        previous.isActive &&
+        previous.effectiveProcess == SearchFlowProcess.amostragem;
 
     final previousFlow = _activeAmostragemFlow;
     _activeAmostragemFlow = next;
@@ -254,7 +279,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
     unawaited(_checkAmostragemRecente());
     _amostragemMonitorTimer = Timer.periodic(
       const Duration(minutes: 1),
-          (_) => unawaited(_checkAmostragemRecente()),
+      (_) => unawaited(_checkAmostragemRecente()),
     );
   }
 
@@ -315,9 +340,9 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
   }
 
   void _handleAmostragemRecente(
-      SharedSearchFormState flow,
-      DateTime? ultimaAmostragem,
-      ) {
+    SharedSearchFormState flow,
+    DateTime? ultimaAmostragem,
+  ) {
     if (!mounted) return;
     if (ultimaAmostragem != null) {
       _lastAmostragem = ultimaAmostragem;
@@ -375,9 +400,9 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
   }
 
   Future<void> _showAmostragemReminder(
-      SharedSearchFormState flow,
-      Duration reminderInterval,
-      ) async {
+    SharedSearchFormState flow,
+    Duration reminderInterval,
+  ) async {
     if (!mounted || _amostragemReminderDialogOpen) return;
     _amostragemReminderDialogOpen = true;
     _lastReminderShownAt = DateTime.now();
@@ -431,7 +456,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
 
           if (_categoriaSel != null) {
             final possuiMaquina = _maquinas.any(
-                  (m) => m.categoria == _categoriaSel && m.codigo == _maquinaSel,
+              (m) => m.categoria == _categoriaSel && m.codigo == _maquinaSel,
             );
             if (!possuiMaquina && _maquinaSel != null) {
               _maquinaSel = null;
@@ -457,7 +482,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
     final maquina = _maquinaSel;
     if (categoria == null || maquina == null) return false;
     return _maquinas.any(
-          (m) => m.categoria == categoria && m.codigo == maquina,
+      (m) => m.categoria == categoria && m.codigo == maquina,
     );
   }
 
@@ -498,6 +523,10 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
     _osCtrl.removeListener(_osSyncListener);
     _partCtrl.removeListener(_partSyncListener);
     _opCtrl.removeListener(_opSyncListener);
+    _reFocusNode.dispose();
+    _osFocusNode.dispose();
+    _partFocusNode.dispose();
+    _opFocusNode.dispose();
     _reCtrl.dispose();
     _osCtrl.dispose();
     _partCtrl.dispose();
@@ -798,13 +827,13 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                 children: motivos
                     .map(
                       (m) => RadioListTile<String>(
-                    title: Text(m),
-                    value: m,
-                    groupValue: selecionado,
-                    onChanged: (value) =>
-                        setState(() => selecionado = value),
-                  ),
-                )
+                        title: Text(m),
+                        value: m,
+                        groupValue: selecionado,
+                        onChanged: (value) =>
+                            setState(() => selecionado = value),
+                      ),
+                    )
                     .toList(),
               ),
             ),
@@ -916,7 +945,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
         title: const Text('Troca de O.S.'),
         content: const Text(
           'Deseja pausar a O.S. atual e liberar o fluxo para iniciar outra? '
-              'Será necessária nova liberação para retomar a produção desta O.S.',
+          'Será necessária nova liberação para retomar a produção desta O.S.',
         ),
         actions: [
           TextButton(
@@ -968,9 +997,9 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
   @override
   Widget build(BuildContext context) {
     ref.listen<SharedSearchFormState>(sharedSearchFormProvider, (
-        previous,
-        next,
-        ) {
+      previous,
+      next,
+    ) {
       _handleFlowStateChange(previous, next);
     });
 
@@ -988,43 +1017,43 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
     final reOk = _reCtrl.text.trim().isNotEmpty;
     final osOk = _osCtrl.text.trim().isNotEmpty;
     final categoriaValue =
-    (_categoriaSel != null && _categorias.contains(_categoriaSel))
+        (_categoriaSel != null && _categorias.contains(_categoriaSel))
         ? _categoriaSel
         : null;
     final maquinasDisponiveis = _maquinas
         .where((m) => m.categoria == categoriaValue)
         .toList();
     final maquinaValue =
-    (_maquinaSel != null &&
-        maquinasDisponiveis.any((m) => m.codigo == _maquinaSel))
+        (_maquinaSel != null &&
+            maquinasDisponiveis.any((m) => m.codigo == _maquinaSel))
         ? _maquinaSel
         : null;
     final maquinaOk = (maquinaValue ?? '').isNotEmpty;
     final formMatchesFlow =
         !flowLocked ||
-            flowState.matchesValues(
-              os: _osCtrl.text,
-              partNumber: _partCtrl.text,
-              operacao: _opCtrl.text,
-              categoria: categoriaValue,
-              maquina: maquinaValue,
-            );
+        flowState.matchesValues(
+          os: _osCtrl.text,
+          partNumber: _partCtrl.text,
+          operacao: _opCtrl.text,
+          categoria: categoriaValue,
+          maquina: maquinaValue,
+        );
 
     // todas respondidas?
     final todasRespondidas =
         medidas.isNotEmpty &&
-            medidas.every(
-                  (m) =>
+        medidas.every(
+          (m) =>
               m.status != StatusMedida.pendente && (m.medicao ?? '').isNotEmpty,
-            );
+        );
 
     final podeRegistrar =
         formMatchesFlow &&
-            reOk &&
-            osOk &&
-            maquinaOk &&
-            todasRespondidas &&
-            !_registrando;
+        reOk &&
+        osOk &&
+        maquinaOk &&
+        todasRespondidas &&
+        !_registrando;
 
     return Scaffold(
       appBar: WindowBar(
@@ -1122,16 +1151,25 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                                 Expanded(
                                   child: TextFormField(
                                     controller: _reCtrl,
+                                    focusNode: _reFocusNode,
                                     textInputAction: TextInputAction.next,
                                     keyboardType: TextInputType.number,
                                     inputFormatters: [
                                       FilteringTextInputFormatter.digitsOnly,
                                     ],
-                                    decoration: const InputDecoration(
-                                      labelText:
-                                      'R.E. do Preparador', // ajuste o texto se for Operador
-                                      border: OutlineInputBorder(),
-                                    ),
+                                  decoration: const InputDecoration(
+                                    labelText:
+                                        'R.E. do Preparador', // ajuste o texto se for Operador
+                                    border: OutlineInputBorder(),
+                                  ),
+                                  onEditingComplete: () => _submitField(
+                                    flowLocked: flowLocked,
+                                    next: _osFocusNode,
+                                  ),
+                                  onFieldSubmitted: (_) => _submitField(
+                                    flowLocked: flowLocked,
+                                    next: _osFocusNode,
+                                  ),
                                     validator: (v) {
                                       final s = (v ?? '').trim();
                                       if (s.isEmpty) return 'Obrigatório';
@@ -1148,15 +1186,24 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                                   child: TextFormField(
                                     controller: _osCtrl,
                                     enabled: !flowLocked,
+                                    focusNode: _osFocusNode,
                                     textInputAction: TextInputAction.next,
                                     keyboardType: TextInputType.number,
                                     inputFormatters: [
                                       FilteringTextInputFormatter.digitsOnly,
                                     ],
-                                    decoration: const InputDecoration(
-                                      labelText: 'O.S.',
-                                      border: OutlineInputBorder(),
-                                    ),
+                                  decoration: const InputDecoration(
+                                    labelText: 'O.S.',
+                                    border: OutlineInputBorder(),
+                                  ),
+                                  onEditingComplete: () => _submitField(
+                                    flowLocked: flowLocked,
+                                    next: _partFocusNode,
+                                  ),
+                                  onFieldSubmitted: (_) => _submitField(
+                                    flowLocked: flowLocked,
+                                    next: _partFocusNode,
+                                  ),
                                     validator: (v) {
                                       final s = (v ?? '').trim();
                                       if (s.isEmpty) return 'Obrigatório';
@@ -1183,25 +1230,25 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                                     items: _categorias
                                         .map(
                                           (c) => DropdownMenuItem(
-                                        value: c,
-                                        child: Text(c),
-                                      ),
-                                    )
+                                            value: c,
+                                            child: Text(c),
+                                          ),
+                                        )
                                         .toList(),
                                     onChanged: flowLocked
                                         ? null
                                         : (v) {
-                                      ref
-                                          .read(
-                                        sharedSearchFormProvider
-                                            .notifier,
-                                      )
-                                          .setCategoria(v);
-                                      setState(() {
-                                        _categoriaSel = v;
-                                        _maquinaSel = null;
-                                      });
-                                    },
+                                            ref
+                                                .read(
+                                                  sharedSearchFormProvider
+                                                      .notifier,
+                                                )
+                                                .setCategoria(v);
+                                            setState(() {
+                                              _categoriaSel = v;
+                                              _maquinaSel = null;
+                                            });
+                                          },
                                     validator: (v) => (v == null || v.isEmpty)
                                         ? 'Obrigatório'
                                         : null,
@@ -1218,22 +1265,22 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                                     items: maquinasDisponiveis
                                         .map(
                                           (m) => DropdownMenuItem(
-                                        value: m.codigo,
-                                        child: Text(m.codigo),
-                                      ),
-                                    )
+                                            value: m.codigo,
+                                            child: Text(m.codigo),
+                                          ),
+                                        )
                                         .toList(),
                                     onChanged: flowLocked
                                         ? null
                                         : (v) {
-                                      ref
-                                          .read(
-                                        sharedSearchFormProvider
-                                            .notifier,
-                                      )
-                                          .setMaquina(v);
-                                      setState(() => _maquinaSel = v);
-                                    },
+                                            ref
+                                                .read(
+                                                  sharedSearchFormProvider
+                                                      .notifier,
+                                                )
+                                                .setMaquina(v);
+                                            setState(() => _maquinaSel = v);
+                                          },
                                     validator: (v) => (v == null || v.isEmpty)
                                         ? 'Obrigatório'
                                         : null,
@@ -1250,13 +1297,22 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                                   child: TextFormField(
                                     controller: _partCtrl,
                                     enabled: !flowLocked,
+                                    focusNode: _partFocusNode,
                                     textInputAction: TextInputAction.next,
-                                    decoration: const InputDecoration(
-                                      labelText: 'Código da peça',
-                                      border: OutlineInputBorder(),
-                                    ),
+                                  decoration: const InputDecoration(
+                                    labelText: 'Código da peça',
+                                    border: OutlineInputBorder(),
+                                  ),
+                                  onEditingComplete: () => _submitField(
+                                    flowLocked: flowLocked,
+                                    next: _opFocusNode,
+                                  ),
+                                  onFieldSubmitted: (_) => _submitField(
+                                    flowLocked: flowLocked,
+                                    next: _opFocusNode,
+                                  ),
                                     validator: (v) =>
-                                    (v == null || v.trim().isEmpty)
+                                        (v == null || v.trim().isEmpty)
                                         ? 'Obrigatório'
                                         : null,
                                   ),
@@ -1267,14 +1323,22 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                                   child: TextFormField(
                                     controller: _opCtrl,
                                     enabled: !flowLocked,
+                                    focusNode: _opFocusNode,
+                                    textInputAction: TextInputAction.done,
                                     keyboardType: TextInputType.number,
                                     inputFormatters: [
                                       FilteringTextInputFormatter.digitsOnly,
                                     ],
-                                    decoration: const InputDecoration(
-                                      labelText: 'Operação',
-                                      border: OutlineInputBorder(),
-                                    ),
+                                  decoration: const InputDecoration(
+                                    labelText: 'Operação',
+                                    border: OutlineInputBorder(),
+                                  ),
+                                  onEditingComplete: () => _submitField(
+                                    flowLocked: flowLocked,
+                                  ),
+                                  onFieldSubmitted: (_) => _submitField(
+                                    flowLocked: flowLocked,
+                                  ),
                                     validator: (v) {
                                       final s = (v ?? '').trim();
                                       if (s.isEmpty) return 'Obrigatório';
@@ -1298,16 +1362,16 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                                     FocusScope.of(context).unfocus();
                                     await ref
                                         .read(
-                                      medidasOperadorControllerProvider
-                                          .notifier,
-                                    )
+                                          medidasOperadorControllerProvider
+                                              .notifier,
+                                        )
                                         .carregar(
-                                      os: _osCtrl.text.trim(),
-                                      partnumber: normalizeCode(
-                                        _partCtrl.text,
-                                      ),
-                                      operacao: normalizeCode(_opCtrl.text),
-                                    );
+                                          os: _osCtrl.text.trim(),
+                                          partnumber: normalizeCode(
+                                            _partCtrl.text,
+                                          ),
+                                          operacao: normalizeCode(_opCtrl.text),
+                                        );
                                     if (mounted) {
                                       setState(() => _mostrarResumo = true);
                                     }
@@ -1381,12 +1445,12 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                                 : null,
                             icon: _registrando
                                 ? const SizedBox(
-                              width: 18,
-                              height: 18,
-                              child: CircularProgressIndicator(
-                                strokeWidth: 2,
-                              ),
-                            )
+                                    width: 18,
+                                    height: 18,
+                                    child: CircularProgressIndicator(
+                                      strokeWidth: 2,
+                                    ),
+                                  )
                                 : const Icon(Icons.save_outlined),
                             label: const Text('Registrar amostragem'),
                           ),

--- a/lib/features/operador/presentation/troca_ferramenta_page.dart
+++ b/lib/features/operador/presentation/troca_ferramenta_page.dart
@@ -76,11 +76,11 @@ class _TrocaFerramentaPageState extends State<TrocaFerramentaPage> {
         final data = jsonDecode(body);
         final itens = data is List
             ? data
-            .map<MedidaItem>(
-              (e) =>
-              MedidaItem.fromMap((e as Map).cast<String, dynamic>()),
-        )
-            .toList()
+                  .map<MedidaItem>(
+                    (e) =>
+                        MedidaItem.fromMap((e as Map).cast<String, dynamic>()),
+                  )
+                  .toList()
             : <MedidaItem>[];
         final dataInclusao = itens.firstDataInclusao;
         final dataFormatada = dataInclusao != null
@@ -238,8 +238,8 @@ class _TrocaFerramentaPageState extends State<TrocaFerramentaPage> {
       return;
     }
     final pendentes = _medidasSelecionadas.where(
-          (m) =>
-      m.status == StatusMedida.pendente ||
+      (m) =>
+          m.status == StatusMedida.pendente ||
           (m.medicao == null || m.medicao!.trim().isEmpty),
     );
     if (pendentes.isNotEmpty) {
@@ -252,7 +252,7 @@ class _TrocaFerramentaPageState extends State<TrocaFerramentaPage> {
     }
 
     final naoAprovadas = _medidasSelecionadas.where(
-          (m) => m.status != StatusMedida.ok,
+      (m) => m.status != StatusMedida.ok,
     );
     if (naoAprovadas.isNotEmpty) {
       ScaffoldMessenger.of(context).showSnackBar(
@@ -365,6 +365,9 @@ class _TrocaFerramentaPageState extends State<TrocaFerramentaPage> {
               border: OutlineInputBorder(),
               isDense: true,
             ),
+            textInputAction: TextInputAction.done,
+            onEditingComplete: () => FocusScope.of(context).unfocus(),
+            onSubmitted: (_) => FocusScope.of(context).unfocus(),
           ),
         ],
       ),
@@ -410,132 +413,132 @@ class _TrocaFerramentaPageState extends State<TrocaFerramentaPage> {
               ? const Center(child: CircularProgressIndicator())
               : _erro != null
               ? Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              Text(
-                'Erro ao carregar medidas:\n${_erro!}',
-                textAlign: TextAlign.center,
-              ),
-              const SizedBox(height: 12),
-              FilledButton.icon(
-                onPressed: _carregarMedidas,
-                icon: const Icon(Icons.refresh),
-                label: const Text('Tentar novamente'),
-              ),
-            ],
-          )
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Text(
+                      'Erro ao carregar medidas:\n${_erro!}',
+                      textAlign: TextAlign.center,
+                    ),
+                    const SizedBox(height: 12),
+                    FilledButton.icon(
+                      onPressed: _carregarMedidas,
+                      icon: const Icon(Icons.refresh),
+                      label: const Text('Tentar novamente'),
+                    ),
+                  ],
+                )
               : Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Card(
-                margin: EdgeInsets.zero,
-                child: Padding(
-                  padding: const EdgeInsets.all(16.0),
-                  child: Wrap(
-                    spacing: 24,
-                    runSpacing: 12,
-                    children: [
-                      _buildEditableReChip(),
-                      _buildInfoChip('O.S.', widget.os),
-                      _buildInfoChip('Peça', widget.partnumber),
-                      _buildInfoChip('Operação', widget.operacao),
-                      if (_dataRevisao != null)
-                        _buildInfoChip('Data de revisão', _dataRevisao!),
-                      _buildInfoChip('Máquina', widget.maquina),
-                    ],
-                  ),
-                ),
-              ),
-              const SizedBox(height: 16),
-              if (!_medindo) ...[
-                Text(
-                  'Selecione as medidas impactadas pela troca da ferramenta.',
-                  style: Theme.of(context).textTheme.titleMedium,
-                ),
-                const SizedBox(height: 12),
-                Expanded(
-                  child: _todas.isEmpty
-                      ? const Center(
-                    child: Text('Nenhuma medida disponível.'),
-                  )
-                      : ListView.separated(
-                    itemCount: _todas.length,
-                    separatorBuilder: (_, __) =>
-                    const Divider(height: 1),
-                    itemBuilder: (context, index) {
-                      final item = _todas[index];
-                      final selecionado = _selecionadas.contains(
-                        index,
-                      );
-                      final subtitulo = _subtitleFor(item);
-                      return CheckboxListTile(
-                        value: selecionado,
-                        onChanged: (value) =>
-                            _toggleSelecao(index, value),
-                        title: Text(
-                          item.titulo.isEmpty
-                              ? '(sem título)'
-                              : item.titulo,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Card(
+                      margin: EdgeInsets.zero,
+                      child: Padding(
+                        padding: const EdgeInsets.all(16.0),
+                        child: Wrap(
+                          spacing: 24,
+                          runSpacing: 12,
+                          children: [
+                            _buildEditableReChip(),
+                            _buildInfoChip('O.S.', widget.os),
+                            _buildInfoChip('Peça', widget.partnumber),
+                            _buildInfoChip('Operação', widget.operacao),
+                            if (_dataRevisao != null)
+                              _buildInfoChip('Data de revisão', _dataRevisao!),
+                            _buildInfoChip('Máquina', widget.maquina),
+                          ],
                         ),
-                        subtitle: subtitulo.isEmpty
-                            ? null
-                            : Text(subtitulo),
-                      );
-                    },
-                  ),
-                ),
-                const SizedBox(height: 12),
-                Align(
-                  alignment: Alignment.centerRight,
-                  child: FilledButton.icon(
-                    onPressed: _selecionadas.isEmpty
-                        ? null
-                        : _avancarParaMedicao,
-                    icon: const Icon(Icons.playlist_add_check),
-                    label: const Text('Prosseguir para medição (FOR07)'),
-                  ),
-                ),
-              ] else ...[
-                Text(
-                  'Realize as medições selecionadas (FOR07).',
-                  style: Theme.of(context).textTheme.titleMedium,
-                ),
-                const SizedBox(height: 12),
-                Expanded(
-                  child: ListView.builder(
-                    itemCount: _medidasSelecionadas.length,
-                    itemBuilder: (context, index) {
-                      final item = _medidasSelecionadas[index];
-                      return MeasurementTile(
-                        index: index,
-                        item: item,
-                        manualEntry: true,
-                        onSelect: (status, medicao) =>
-                            _atualizarMedicao(index, status, medicao),
-                      );
-                    },
-                  ),
-                ),
-                const SizedBox(height: 12),
-                Align(
-                  alignment: Alignment.centerRight,
-                  child: FilledButton.icon(
-                    onPressed: _registrando ? null : _registrarMedicoes,
-                    icon: _registrando
-                        ? const SizedBox(
-                      width: 18,
-                      height: 18,
-                      child: CircularProgressIndicator(
-                        strokeWidth: 2,
                       ),
-                    )
-                        : const Icon(Icons.save_outlined),
-                    label: const Text('Registrar medições'),
-                  ),
+                    ),
+                    const SizedBox(height: 16),
+                    if (!_medindo) ...[
+                      Text(
+                        'Selecione as medidas impactadas pela troca da ferramenta.',
+                        style: Theme.of(context).textTheme.titleMedium,
+                      ),
+                      const SizedBox(height: 12),
+                      Expanded(
+                        child: _todas.isEmpty
+                            ? const Center(
+                                child: Text('Nenhuma medida disponível.'),
+                              )
+                            : ListView.separated(
+                                itemCount: _todas.length,
+                                separatorBuilder: (_, __) =>
+                                    const Divider(height: 1),
+                                itemBuilder: (context, index) {
+                                  final item = _todas[index];
+                                  final selecionado = _selecionadas.contains(
+                                    index,
+                                  );
+                                  final subtitulo = _subtitleFor(item);
+                                  return CheckboxListTile(
+                                    value: selecionado,
+                                    onChanged: (value) =>
+                                        _toggleSelecao(index, value),
+                                    title: Text(
+                                      item.titulo.isEmpty
+                                          ? '(sem título)'
+                                          : item.titulo,
+                                    ),
+                                    subtitle: subtitulo.isEmpty
+                                        ? null
+                                        : Text(subtitulo),
+                                  );
+                                },
+                              ),
+                      ),
+                      const SizedBox(height: 12),
+                      Align(
+                        alignment: Alignment.centerRight,
+                        child: FilledButton.icon(
+                          onPressed: _selecionadas.isEmpty
+                              ? null
+                              : _avancarParaMedicao,
+                          icon: const Icon(Icons.playlist_add_check),
+                          label: const Text('Prosseguir para medição (FOR07)'),
+                        ),
+                      ),
+                    ] else ...[
+                      Text(
+                        'Realize as medições selecionadas (FOR07).',
+                        style: Theme.of(context).textTheme.titleMedium,
+                      ),
+                      const SizedBox(height: 12),
+                      Expanded(
+                        child: ListView.builder(
+                          itemCount: _medidasSelecionadas.length,
+                          itemBuilder: (context, index) {
+                            final item = _medidasSelecionadas[index];
+                            return MeasurementTile(
+                              index: index,
+                              item: item,
+                              manualEntry: true,
+                              onSelect: (status, medicao) =>
+                                  _atualizarMedicao(index, status, medicao),
+                            );
+                          },
+                        ),
+                      ),
+                      const SizedBox(height: 12),
+                      Align(
+                        alignment: Alignment.centerRight,
+                        child: FilledButton.icon(
+                          onPressed: _registrando ? null : _registrarMedicoes,
+                          icon: _registrando
+                              ? const SizedBox(
+                                  width: 18,
+                                  height: 18,
+                                  child: CircularProgressIndicator(
+                                    strokeWidth: 2,
+                                  ),
+                                )
+                              : const Icon(Icons.save_outlined),
+                          label: const Text('Registrar medições'),
+                        ),
+                      ),
+                    ],
+                  ],
                 ),
-              ],
-            ],
-          ),
         ),
       ),
     );

--- a/lib/features/preparacao/presentation/preparacao_page.dart
+++ b/lib/features/preparacao/presentation/preparacao_page.dart
@@ -144,6 +144,11 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
   final _partCtrl = TextEditingController();
   final _opCtrl = TextEditingController();
 
+  final _reFocusNode = FocusNode();
+  final _osFocusNode = FocusNode();
+  final _partFocusNode = FocusNode();
+  final _opFocusNode = FocusNode();
+
   final List<Machine> _maquinas = [];
   final List<String> _categorias = [];
   String? _categoriaSel;
@@ -156,6 +161,26 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
   late final VoidCallback _osSyncListener;
   late final VoidCallback _partSyncListener;
   late final VoidCallback _opSyncListener;
+
+  void _unfocusKeyboard() {
+    FocusManager.instance.primaryFocus?.unfocus();
+  }
+
+  void _submitField({
+    required bool flowLocked,
+    FocusNode? next,
+  }) {
+    if (flowLocked) {
+      _unfocusKeyboard();
+      return;
+    }
+
+    if (next != null) {
+      next.requestFocus();
+    } else {
+      _unfocusKeyboard();
+    }
+  }
 
   void _resetLiberada() {
     if (_osLiberada) setState(() => _osLiberada = false);
@@ -305,6 +330,10 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
     _osCtrl.removeListener(_osSyncListener);
     _partCtrl.removeListener(_partSyncListener);
     _opCtrl.removeListener(_opSyncListener);
+    _reFocusNode.dispose();
+    _osFocusNode.dispose();
+    _partFocusNode.dispose();
+    _opFocusNode.dispose();
     _reCtrl.dispose();
     _osCtrl.dispose();
     _partCtrl.dispose();
@@ -625,6 +654,7 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
                                     _compactFormBreakpoint;
                                 final reField = TextFormField(
                                   controller: _reCtrl,
+                                  focusNode: _reFocusNode,
                                   textInputAction: TextInputAction.next,
                                   keyboardType: TextInputType.number,
                                   inputFormatters: [
@@ -633,6 +663,14 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
                                   decoration: const InputDecoration(
                                     labelText: 'R.E. do Preparador',
                                     border: OutlineInputBorder(),
+                                  ),
+                                  onEditingComplete: () => _submitField(
+                                    flowLocked: flowLocked,
+                                    next: _osFocusNode,
+                                  ),
+                                  onFieldSubmitted: (_) => _submitField(
+                                    flowLocked: flowLocked,
+                                    next: _osFocusNode,
                                   ),
                                   validator: (v) {
                                     final s = (v ?? '').trim();
@@ -646,6 +684,7 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
                                 final osField = TextFormField(
                                   controller: _osCtrl,
                                   enabled: !flowLocked,
+                                  focusNode: _osFocusNode,
                                   textInputAction: TextInputAction.next,
                                   keyboardType: TextInputType.number,
                                   inputFormatters: [
@@ -654,6 +693,14 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
                                   decoration: const InputDecoration(
                                     labelText: 'O.S.',
                                     border: OutlineInputBorder(),
+                                  ),
+                                  onEditingComplete: () => _submitField(
+                                    flowLocked: flowLocked,
+                                    next: _partFocusNode,
+                                  ),
+                                  onFieldSubmitted: (_) => _submitField(
+                                    flowLocked: flowLocked,
+                                    next: _partFocusNode,
                                   ),
                                   validator: (v) {
                                     final s = (v ?? '').trim();
@@ -793,10 +840,19 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
                                 final partField = TextFormField(
                                   controller: _partCtrl,
                                   enabled: !flowLocked,
+                                  focusNode: _partFocusNode,
                                   textInputAction: TextInputAction.next,
                                   decoration: const InputDecoration(
                                     labelText: 'Código da peça',
                                     border: OutlineInputBorder(),
+                                  ),
+                                  onEditingComplete: () => _submitField(
+                                    flowLocked: flowLocked,
+                                    next: _opFocusNode,
+                                  ),
+                                  onFieldSubmitted: (_) => _submitField(
+                                    flowLocked: flowLocked,
+                                    next: _opFocusNode,
                                   ),
                                   validator: (v) =>
                                       (v == null || v.trim().isEmpty)
@@ -806,6 +862,8 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
                                 final operacaoField = TextFormField(
                                   controller: _opCtrl,
                                   enabled: !flowLocked,
+                                  focusNode: _opFocusNode,
+                                  textInputAction: TextInputAction.done,
                                   keyboardType: TextInputType.number,
                                   inputFormatters: [
                                     FilteringTextInputFormatter.digitsOnly,
@@ -813,6 +871,12 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
                                   decoration: const InputDecoration(
                                     labelText: 'Operação',
                                     border: OutlineInputBorder(),
+                                  ),
+                                  onEditingComplete: () => _submitField(
+                                    flowLocked: flowLocked,
+                                  ),
+                                  onFieldSubmitted: (_) => _submitField(
+                                    flowLocked: flowLocked,
                                   ),
                                   validator: (v) {
                                     final s = (v ?? '').trim();


### PR DESCRIPTION
## Summary
- add a shared helper on the preparação, finalização and operador pages to either advance to the next focus node or close the keyboard
- update each search form field so Enter triggers the helper, keeping focus traversal until the final operação input

## Testing
- flutter test

------
https://chatgpt.com/codex/tasks/task_e_68dbfc24b7108331b578f361e7e8b58e