### PR TITLE
Fix Enter key focus traversal for measurement fields

### DIFF
--- a/lib/features/finalizar_os/presentation/finalizar_os_page.dart
+++ b/lib/features/finalizar_os/presentation/finalizar_os_page.dart
@@ -28,12 +28,12 @@ class FinalizarOsPage extends ConsumerStatefulWidget {
 }
 
 final medidasFinalizadorControllerProvider =
-StateNotifierProvider.autoDispose<
-    MedidasFinalizadorController,
-    AsyncValue<List<MedidaItem>>
->((ref) {
-  return MedidasFinalizadorController(ref);
-});
+    StateNotifierProvider.autoDispose<
+      MedidasFinalizadorController,
+      AsyncValue<List<MedidaItem>>
+    >((ref) {
+      return MedidasFinalizadorController(ref);
+    });
 
 class MedidasFinalizadorController
     extends StateNotifier<AsyncValue<List<MedidaItem>>> {
@@ -56,24 +56,24 @@ class MedidasFinalizadorController
       final normalizados = itens
           .map(
             (m) => MedidaItem(
-          indice: m.indice,
-          titulo: m.titulo,
-          faixaTexto: m.faixaTexto,
-          minimo: m.minimo,
-          maximo: m.maximo,
-          unidade: m.unidade,
-          status: StatusMedida.pendente,
-          medicao: null,
-          observacao: m.observacao,
-          periodicidade: m.periodicidade,
-          instrumento: m.instrumento,
-          dataInclusao: m.dataInclusao,
-          tolerancias: m.tolerancias,
-          contagens: m.contagens,
-          anguloMinimo: m.anguloMinimo,
-          anguloMaximo: m.anguloMaximo,
-        ),
-      )
+              indice: m.indice,
+              titulo: m.titulo,
+              faixaTexto: m.faixaTexto,
+              minimo: m.minimo,
+              maximo: m.maximo,
+              unidade: m.unidade,
+              status: StatusMedida.pendente,
+              medicao: null,
+              observacao: m.observacao,
+              periodicidade: m.periodicidade,
+              instrumento: m.instrumento,
+              dataInclusao: m.dataInclusao,
+              tolerancias: m.tolerancias,
+              contagens: m.contagens,
+              anguloMinimo: m.anguloMinimo,
+              anguloMaximo: m.anguloMaximo,
+            ),
+          )
           .toList();
 
       state = AsyncValue.data(normalizados);
@@ -141,6 +141,11 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
   final _partCtrl = TextEditingController();
   final _opCtrl = TextEditingController();
 
+  final _reFocusNode = FocusNode();
+  final _osFocusNode = FocusNode();
+  final _partFocusNode = FocusNode();
+  final _opFocusNode = FocusNode();
+
   final List<Machine> _maquinas = [];
   final List<String> _categorias = [];
   String? _categoriaSel;
@@ -154,6 +159,23 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
   late final VoidCallback _partSyncListener;
   late final VoidCallback _opSyncListener;
 
+  void _unfocusKeyboard() {
+    FocusManager.instance.primaryFocus?.unfocus();
+  }
+
+  void _submitField({required bool flowLocked, FocusNode? next}) {
+    if (flowLocked) {
+      _unfocusKeyboard();
+      return;
+    }
+
+    if (next != null) {
+      next.requestFocus();
+    } else {
+      _unfocusKeyboard();
+    }
+  }
+
   void _resetFinalizada() {
     if (_osFinalizada) setState(() => _osFinalizada = false);
   }
@@ -161,8 +183,10 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
   void _voltarParaMenuPrincipal() {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
-      Navigator.of(context, rootNavigator: true)
-          .popUntil((route) => route.isFirst);
+      Navigator.of(
+        context,
+        rootNavigator: true,
+      ).popUntil((route) => route.isFirst);
     });
   }
 
@@ -219,7 +243,7 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
 
           if (_categoriaSel != null) {
             final possuiMaquina = _maquinas.any(
-                  (m) => m.categoria == _categoriaSel && m.codigo == _maquinaSel,
+              (m) => m.categoria == _categoriaSel && m.codigo == _maquinaSel,
             );
             if (!possuiMaquina && _maquinaSel != null) {
               _maquinaSel = null;
@@ -245,7 +269,7 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
     final maquina = _maquinaSel;
     if (categoria == null || maquina == null) return false;
     return _maquinas.any(
-          (m) => m.categoria == categoria && m.codigo == maquina,
+      (m) => m.categoria == categoria && m.codigo == maquina,
     );
   }
 
@@ -288,6 +312,10 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
     _osCtrl.removeListener(_osSyncListener);
     _partCtrl.removeListener(_partSyncListener);
     _opCtrl.removeListener(_opSyncListener);
+    _reFocusNode.dispose();
+    _osFocusNode.dispose();
+    _partFocusNode.dispose();
+    _opFocusNode.dispose();
     _reCtrl.dispose();
     _osCtrl.dispose();
     _partCtrl.dispose();
@@ -353,9 +381,9 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
     final reprovadas = medidas
         .where(
           (m) =>
-      m.status == StatusMedida.reprovadaAbaixo ||
-          m.status == StatusMedida.reprovadaAcima,
-    )
+              m.status == StatusMedida.reprovadaAbaixo ||
+              m.status == StatusMedida.reprovadaAcima,
+        )
         .toList();
     if (reprovadas.isNotEmpty) {
       if (!mounted) return;
@@ -463,41 +491,41 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
     final reOk = _reCtrl.text.trim().isNotEmpty;
     final osOk = _osCtrl.text.trim().isNotEmpty;
     final categoriaValue =
-    (_categoriaSel != null && _categorias.contains(_categoriaSel))
+        (_categoriaSel != null && _categorias.contains(_categoriaSel))
         ? _categoriaSel
         : null;
     final maquinasDisponiveis = _maquinas
         .where((m) => m.categoria == categoriaValue)
         .toList();
     final maquinaValue =
-    (_maquinaSel != null &&
-        maquinasDisponiveis.any((m) => m.codigo == _maquinaSel))
+        (_maquinaSel != null &&
+            maquinasDisponiveis.any((m) => m.codigo == _maquinaSel))
         ? _maquinaSel
         : null;
     final maquinaOk = (maquinaValue ?? '').isNotEmpty;
     final formMatchesFlow =
         !flowLocked ||
-            flowState.matchesValues(
-              os: _osCtrl.text,
-              partNumber: _partCtrl.text,
-              operacao: _opCtrl.text,
-              categoria: categoriaValue,
-              maquina: maquinaValue,
-            );
+        flowState.matchesValues(
+          os: _osCtrl.text,
+          partNumber: _partCtrl.text,
+          operacao: _opCtrl.text,
+          categoria: categoriaValue,
+          maquina: maquinaValue,
+        );
     final todasOk =
         medidas.isNotEmpty &&
-            medidas.every(
-                  (m) =>
+        medidas.every(
+          (m) =>
               (m.medicao ?? '').isNotEmpty && m.status != StatusMedida.pendente,
-            );
+        );
     final podeRegistrar =
         formMatchesFlow &&
-            reOk &&
-            osOk &&
-            maquinaOk &&
-            todasOk &&
-            !_registrando &&
-            !_osFinalizada;
+        reOk &&
+        osOk &&
+        maquinaOk &&
+        todasOk &&
+        !_registrando &&
+        !_osFinalizada;
 
     return Scaffold(
       appBar: WindowBar(
@@ -522,319 +550,360 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
       body: SafeArea(
         child: Padding(
           padding: const EdgeInsets.all(16.0),
-          child: CustomScrollView(
-            keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
-            slivers: [
-              SliverToBoxAdapter(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
-                    if (flowLocked)
-                      Container(
-                        margin: const EdgeInsets.only(bottom: 12),
-                        padding: const EdgeInsets.all(12),
-                        decoration: BoxDecoration(
-                          color: Theme.of(
-                            context,
-                          ).colorScheme.surfaceContainerHighest,
-                          borderRadius: BorderRadius.circular(8),
-                        ),
-                        child: Row(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Icon(
-                              Icons.lock,
-                              size: 18,
-                              color: Theme.of(context).colorScheme.primary,
-                            ),
-                            const SizedBox(width: 8),
-                            Expanded(
-                              child: Text(
-                                flowOs.isEmpty
-                                    ? 'Existe um fluxo de $flowProcessName em andamento. Finalize a O.S. atual para iniciar outra.'
-                                    : 'Fluxo de $flowProcessName ativo para a O.S. $flowOs. Finalize a O.S. atual para iniciar outra.',
-                                style: Theme.of(context).textTheme.bodyMedium,
+          child: FocusTraversalGroup(
+            policy: OrderedTraversalPolicy(),
+            child: CustomScrollView(
+              keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
+              slivers: [
+                SliverToBoxAdapter(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      if (flowLocked)
+                        Container(
+                          margin: const EdgeInsets.only(bottom: 12),
+                          padding: const EdgeInsets.all(12),
+                          decoration: BoxDecoration(
+                            color: Theme.of(
+                              context,
+                            ).colorScheme.surfaceContainerHighest,
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          child: Row(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Icon(
+                                Icons.lock,
+                                size: 18,
+                                color: Theme.of(context).colorScheme.primary,
                               ),
-                            ),
-                          ],
+                              const SizedBox(width: 8),
+                              Expanded(
+                                child: Text(
+                                  flowOs.isEmpty
+                                      ? 'Existe um fluxo de $flowProcessName em andamento. Finalize a O.S. atual para iniciar outra.'
+                                      : 'Fluxo de $flowProcessName ativo para a O.S. $flowOs. Finalize a O.S. atual para iniciar outra.',
+                                  style: Theme.of(context).textTheme.bodyMedium,
+                                ),
+                              ),
+                            ],
+                          ),
                         ),
-                      ),
-                    if (_mostrarResumo) ...[
-                      SearchSummarySection(
-                        reLabel: 'R.E. do Preparador',
-                        reValue: _reCtrl.text,
-                        items: [
-                          SummaryInfo(label: 'O.S.', value: _osCtrl.text),
-                          SummaryInfo(label: 'Peça', value: _partCtrl.text),
-                          SummaryInfo(label: 'Operação', value: _opCtrl.text),
-                          if (dataRevisao != null)
-                            SummaryInfo(
-                              label: 'Data de revisão',
-                              value: dataRevisao,
-                            ),
-                          if ((maquinaValue ?? '').isNotEmpty)
-                            SummaryInfo(label: 'Máquina', value: maquinaValue!),
-                          if ((categoriaValue ?? '').isNotEmpty)
-                            SummaryInfo(
-                              label: 'Categoria',
-                              value: categoriaValue!,
-                            ),
-                        ],
-                        onEdit: () {
-                          FocusScope.of(context).unfocus();
-                          setState(() => _mostrarResumo = false);
-                        },
-                      ),
-                    ] else ...[
-                      Form(
-                        key: _formKey,
-                        child: Column(
-                          children: [
-                            Row(
-                              children: [
-                                Expanded(
-                                  child: TextFormField(
-                                    controller: _reCtrl,
-                                    textInputAction: TextInputAction.next,
-                                    keyboardType: TextInputType.number,
-                                    inputFormatters: [
-                                      FilteringTextInputFormatter.digitsOnly,
-                                    ],
-                                    decoration: const InputDecoration(
-                                      labelText:
-                                      'R.E. do Preparador', // ajuste o texto se for Operador
-                                      border: OutlineInputBorder(),
-                                    ),
-                                    validator: (v) {
-                                      final s = (v ?? '').trim();
-                                      if (s.isEmpty) return 'Obrigatório';
-                                      if (!RegExp(r'^[0-9]+$').hasMatch(s)) {
-                                        return 'Apenas números';
-                                      }
-                                      return null;
-                                    },
-                                  ),
-                                ),
-                                const SizedBox(width: 12),
-                                SizedBox(
-                                  width: 140, // igual ao campo Operação
-                                  child: TextFormField(
-                                    controller: _osCtrl,
-                                    enabled: !flowLocked,
-                                    textInputAction: TextInputAction.next,
-                                    keyboardType: TextInputType.number,
-                                    inputFormatters: [
-                                      FilteringTextInputFormatter.digitsOnly,
-                                    ],
-                                    decoration: const InputDecoration(
-                                      labelText: 'O.S.',
-                                      border: OutlineInputBorder(),
-                                    ),
-                                    validator: (v) {
-                                      final s = (v ?? '').trim();
-                                      if (s.isEmpty) return 'Obrigatório';
-                                      if (!RegExp(r'^[0-9]+$').hasMatch(s)) {
-                                        return 'Apenas números';
-                                      }
-                                      return null;
-                                    },
-                                  ),
-                                ),
-                              ],
-                            ),
-                            const SizedBox(height: 12),
-
-                            Row(
-                              children: [
-                                Expanded(
-                                  child: DropdownButtonFormField<String>(
-                                    value: categoriaValue,
-                                    decoration: const InputDecoration(
-                                      labelText: 'Categoria',
-                                      border: OutlineInputBorder(),
-                                    ),
-                                    items: _categorias
-                                        .map(
-                                          (c) => DropdownMenuItem(
-                                        value: c,
-                                        child: Text(c),
+                      if (_mostrarResumo) ...[
+                        SearchSummarySection(
+                          reLabel: 'R.E. do Preparador',
+                          reValue: _reCtrl.text,
+                          items: [
+                            SummaryInfo(label: 'O.S.', value: _osCtrl.text),
+                            SummaryInfo(label: 'Peça', value: _partCtrl.text),
+                            SummaryInfo(label: 'Operação', value: _opCtrl.text),
+                            if (dataRevisao != null)
+                              SummaryInfo(
+                                label: 'Data de revisão',
+                                value: dataRevisao,
+                              ),
+                            if ((maquinaValue ?? '').isNotEmpty)
+                              SummaryInfo(
+                                label: 'Máquina',
+                                value: maquinaValue!,
+                              ),
+                            if ((categoriaValue ?? '').isNotEmpty)
+                              SummaryInfo(
+                                label: 'Categoria',
+                                value: categoriaValue!,
+                              ),
+                          ],
+                          onEdit: () {
+                            FocusScope.of(context).unfocus();
+                            setState(() => _mostrarResumo = false);
+                          },
+                        ),
+                      ] else ...[
+                        Form(
+                          key: _formKey,
+                          child: Column(
+                            children: [
+                              Row(
+                                children: [
+                                  Expanded(
+                                    child: TextFormField(
+                                      controller: _reCtrl,
+                                      focusNode: _reFocusNode,
+                                      textInputAction: TextInputAction.next,
+                                      keyboardType: TextInputType.number,
+                                      inputFormatters: [
+                                        FilteringTextInputFormatter.digitsOnly,
+                                      ],
+                                      decoration: const InputDecoration(
+                                        labelText:
+                                            'R.E. do Preparador', // ajuste o texto se for Operador
+                                        border: OutlineInputBorder(),
                                       ),
-                                    )
-                                        .toList(),
-                                    onChanged: flowLocked
-                                        ? null
-                                        : (v) {
-                                      ref
+                                      onEditingComplete: () => _submitField(
+                                        flowLocked: flowLocked,
+                                        next: _osFocusNode,
+                                      ),
+                                      onFieldSubmitted: (_) => _submitField(
+                                        flowLocked: flowLocked,
+                                        next: _osFocusNode,
+                                      ),
+                                      validator: (v) {
+                                        final s = (v ?? '').trim();
+                                        if (s.isEmpty) return 'Obrigatório';
+                                        if (!RegExp(r'^[0-9]+$').hasMatch(s)) {
+                                          return 'Apenas números';
+                                        }
+                                        return null;
+                                      },
+                                    ),
+                                  ),
+                                  const SizedBox(width: 12),
+                                  SizedBox(
+                                    width: 140, // igual ao campo Operação
+                                    child: TextFormField(
+                                      controller: _osCtrl,
+                                      enabled: !flowLocked,
+                                      focusNode: _osFocusNode,
+                                      textInputAction: TextInputAction.next,
+                                      keyboardType: TextInputType.number,
+                                      inputFormatters: [
+                                        FilteringTextInputFormatter.digitsOnly,
+                                      ],
+                                      decoration: const InputDecoration(
+                                        labelText: 'O.S.',
+                                        border: OutlineInputBorder(),
+                                      ),
+                                      onEditingComplete: () => _submitField(
+                                        flowLocked: flowLocked,
+                                        next: _partFocusNode,
+                                      ),
+                                      onFieldSubmitted: (_) => _submitField(
+                                        flowLocked: flowLocked,
+                                        next: _partFocusNode,
+                                      ),
+                                      validator: (v) {
+                                        final s = (v ?? '').trim();
+                                        if (s.isEmpty) return 'Obrigatório';
+                                        if (!RegExp(r'^[0-9]+$').hasMatch(s)) {
+                                          return 'Apenas números';
+                                        }
+                                        return null;
+                                      },
+                                    ),
+                                  ),
+                                ],
+                              ),
+                              const SizedBox(height: 12),
+
+                              Row(
+                                children: [
+                                  Expanded(
+                                    child: DropdownButtonFormField<String>(
+                                      value: categoriaValue,
+                                      decoration: const InputDecoration(
+                                        labelText: 'Categoria',
+                                        border: OutlineInputBorder(),
+                                      ),
+                                      items: _categorias
+                                          .map(
+                                            (c) => DropdownMenuItem(
+                                              value: c,
+                                              child: Text(c),
+                                            ),
+                                          )
+                                          .toList(),
+                                      onChanged: flowLocked
+                                          ? null
+                                          : (v) {
+                                              ref
+                                                  .read(
+                                                    sharedSearchFormProvider
+                                                        .notifier,
+                                                  )
+                                                  .setCategoria(v);
+                                              setState(() {
+                                                _categoriaSel = v;
+                                                _maquinaSel = null;
+                                              });
+                                            },
+                                      validator: (v) => (v == null || v.isEmpty)
+                                          ? 'Obrigatório'
+                                          : null,
+                                    ),
+                                  ),
+                                  const SizedBox(width: 12),
+                                  Expanded(
+                                    child: DropdownButtonFormField<String>(
+                                      value: maquinaValue,
+                                      decoration: const InputDecoration(
+                                        labelText: 'Grupo de máquina',
+                                        border: OutlineInputBorder(),
+                                      ),
+                                      items: maquinasDisponiveis
+                                          .map(
+                                            (m) => DropdownMenuItem(
+                                              value: m.codigo,
+                                              child: Text(m.codigo),
+                                            ),
+                                          )
+                                          .toList(),
+                                      onChanged: flowLocked
+                                          ? null
+                                          : (v) {
+                                              ref
+                                                  .read(
+                                                    sharedSearchFormProvider
+                                                        .notifier,
+                                                  )
+                                                  .setMaquina(v);
+                                              setState(() => _maquinaSel = v);
+                                            },
+                                      validator: (v) => (v == null || v.isEmpty)
+                                          ? 'Obrigatório'
+                                          : null,
+                                    ),
+                                  ),
+                                ],
+                              ),
+
+                              const SizedBox(height: 12),
+
+                              // ---------- PartNumber + Operação (Operação só números) ----------
+                              Row(
+                                children: [
+                                  Expanded(
+                                    child: TextFormField(
+                                      controller: _partCtrl,
+                                      enabled: !flowLocked,
+                                      focusNode: _partFocusNode,
+                                      textInputAction: TextInputAction.next,
+                                      decoration: const InputDecoration(
+                                        labelText: 'Código da peça',
+                                        border: OutlineInputBorder(),
+                                      ),
+                                      onEditingComplete: () => _submitField(
+                                        flowLocked: flowLocked,
+                                        next: _opFocusNode,
+                                      ),
+                                      onFieldSubmitted: (_) => _submitField(
+                                        flowLocked: flowLocked,
+                                        next: _opFocusNode,
+                                      ),
+                                      validator: (v) =>
+                                          (v == null || v.trim().isEmpty)
+                                          ? 'Obrigatório'
+                                          : null,
+                                    ),
+                                  ),
+                                  const SizedBox(width: 12),
+                                  SizedBox(
+                                    width: 140,
+                                    child: TextFormField(
+                                      controller: _opCtrl,
+                                      enabled: !flowLocked,
+                                      focusNode: _opFocusNode,
+                                      textInputAction: TextInputAction.done,
+                                      keyboardType: TextInputType.number,
+                                      inputFormatters: [
+                                        FilteringTextInputFormatter.digitsOnly,
+                                      ],
+                                      decoration: const InputDecoration(
+                                        labelText: 'Operação',
+                                        border: OutlineInputBorder(),
+                                      ),
+                                      onEditingComplete: () =>
+                                          _submitField(flowLocked: flowLocked),
+                                      onFieldSubmitted: (_) =>
+                                          _submitField(flowLocked: flowLocked),
+                                      validator: (v) {
+                                        final s = (v ?? '').trim();
+                                        if (s.isEmpty) return 'Obrigatório';
+                                        if (!RegExp(r'^[0-9]+$').hasMatch(s)) {
+                                          return 'Apenas números';
+                                        }
+                                        return null;
+                                      },
+                                    ),
+                                  ),
+                                ],
+                              ),
+
+                              const SizedBox(height: 12),
+                              SizedBox(
+                                width: double.infinity,
+                                child: FilledButton.icon(
+                                  onPressed: () async {
+                                    if (_formKey.currentState!.validate()) {
+                                      if (!_ensureFlowConsistency()) return;
+                                      FocusScope.of(context).unfocus();
+                                      await ref
                                           .read(
-                                        sharedSearchFormProvider
-                                            .notifier,
-                                      )
-                                          .setCategoria(v);
-                                      setState(() {
-                                        _categoriaSel = v;
-                                        _maquinaSel = null;
-                                      });
-                                    },
-                                    validator: (v) => (v == null || v.isEmpty)
-                                        ? 'Obrigatório'
-                                        : null,
-                                  ),
-                                ),
-                                const SizedBox(width: 12),
-                                Expanded(
-                                  child: DropdownButtonFormField<String>(
-                                    value: maquinaValue,
-                                    decoration: const InputDecoration(
-                                      labelText: 'Grupo de máquina',
-                                      border: OutlineInputBorder(),
-                                    ),
-                                    items: maquinasDisponiveis
-                                        .map(
-                                          (m) => DropdownMenuItem(
-                                        value: m.codigo,
-                                        child: Text(m.codigo),
-                                      ),
-                                    )
-                                        .toList(),
-                                    onChanged: flowLocked
-                                        ? null
-                                        : (v) {
-                                      ref
-                                          .read(
-                                        sharedSearchFormProvider
-                                            .notifier,
-                                      )
-                                          .setMaquina(v);
-                                      setState(() => _maquinaSel = v);
-                                    },
-                                    validator: (v) => (v == null || v.isEmpty)
-                                        ? 'Obrigatório'
-                                        : null,
-                                  ),
-                                ),
-                              ],
-                            ),
-
-                            const SizedBox(height: 12),
-
-                            // ---------- PartNumber + Operação (Operação só números) ----------
-                            Row(
-                              children: [
-                                Expanded(
-                                  child: TextFormField(
-                                    controller: _partCtrl,
-                                    enabled: !flowLocked,
-                                    textInputAction: TextInputAction.next,
-                                    decoration: const InputDecoration(
-                                      labelText: 'Código da peça',
-                                      border: OutlineInputBorder(),
-                                    ),
-                                    validator: (v) =>
-                                    (v == null || v.trim().isEmpty)
-                                        ? 'Obrigatório'
-                                        : null,
-                                  ),
-                                ),
-                                const SizedBox(width: 12),
-                                SizedBox(
-                                  width: 140,
-                                  child: TextFormField(
-                                    controller: _opCtrl,
-                                    enabled: !flowLocked,
-                                    keyboardType: TextInputType.number,
-                                    inputFormatters: [
-                                      FilteringTextInputFormatter.digitsOnly,
-                                    ],
-                                    decoration: const InputDecoration(
-                                      labelText: 'Operação',
-                                      border: OutlineInputBorder(),
-                                    ),
-                                    validator: (v) {
-                                      final s = (v ?? '').trim();
-                                      if (s.isEmpty) return 'Obrigatório';
-                                      if (!RegExp(r'^[0-9]+$').hasMatch(s)) {
-                                        return 'Apenas números';
+                                            medidasFinalizadorControllerProvider
+                                                .notifier,
+                                          )
+                                          .carregar(
+                                            partnumber: normalizeCode(
+                                              _partCtrl.text,
+                                            ),
+                                            operacao: normalizeCode(
+                                              _opCtrl.text,
+                                            ),
+                                          );
+                                      if (mounted) {
+                                        setState(() => _mostrarResumo = true);
                                       }
-                                      return null;
-                                    },
-                                  ),
-                                ),
-                              ],
-                            ),
-
-                            const SizedBox(height: 12),
-                            SizedBox(
-                              width: double.infinity,
-                              child: FilledButton.icon(
-                                onPressed: () async {
-                                  if (_formKey.currentState!.validate()) {
-                                    if (!_ensureFlowConsistency()) return;
-                                    FocusScope.of(context).unfocus();
-                                    await ref
-                                        .read(
-                                      medidasFinalizadorControllerProvider
-                                          .notifier,
-                                    )
-                                        .carregar(
-                                      partnumber: normalizeCode(
-                                        _partCtrl.text,
-                                      ),
-                                      operacao: normalizeCode(_opCtrl.text),
-                                    );
-                                    if (mounted) {
-                                      setState(() => _mostrarResumo = true);
                                     }
-                                  }
-                                },
-                                icon: const Icon(Icons.search),
-                                label: const Text('Carregar medidas'),
+                                  },
+                                  icon: const Icon(Icons.search),
+                                  label: const Text('Carregar medidas'),
+                                ),
                               ),
-                            ),
-                          ],
-                        ),
-                      ),
-                    ],
-                    const SizedBox(height: 16),
-                  ],
-                ),
-              ),
-              ..._buildMedidasSlivers(medidasAsync),
-              SliverFillRemaining(
-                hasScrollBody: false,
-                child: AnimatedPadding(
-                  duration: const Duration(milliseconds: 200),
-                  curve: Curves.easeOut,
-                  padding: EdgeInsets.only(bottom: actionBottomPadding),
-                  child: SafeArea(
-                    top: false,
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.end,
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                      children: [
-                        SizedBox(
-                          width: double.infinity,
-                          child: FilledButton.icon(
-                            onPressed: podeRegistrar
-                                ? _registrarFinalizacao
-                                : null,
-                            icon: _registrando
-                                ? const SizedBox(
-                              width: 18,
-                              height: 18,
-                              child: CircularProgressIndicator(
-                                strokeWidth: 2,
-                              ),
-                            )
-                                : const Icon(Icons.save_outlined),
-                            label: const Text('Finalizar OS'),
+                            ],
                           ),
                         ),
                       ],
+                      const SizedBox(height: 16),
+                    ],
+                  ),
+                ),
+                ..._buildMedidasSlivers(medidasAsync),
+                SliverFillRemaining(
+                  hasScrollBody: false,
+                  child: AnimatedPadding(
+                    duration: const Duration(milliseconds: 200),
+                    curve: Curves.easeOut,
+                    padding: EdgeInsets.only(bottom: actionBottomPadding),
+                    child: SafeArea(
+                      top: false,
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.end,
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          SizedBox(
+                            width: double.infinity,
+                            child: FilledButton.icon(
+                              onPressed: podeRegistrar
+                                  ? _registrarFinalizacao
+                                  : null,
+                              icon: _registrando
+                                  ? const SizedBox(
+                                      width: 18,
+                                      height: 18,
+                                      child: CircularProgressIndicator(
+                                        strokeWidth: 2,
+                                      ),
+                                    )
+                                  : const Icon(Icons.save_outlined),
+                              label: const Text('Finalizar OS'),
+                            ),
+                          ),
+                        ],
+                      ),
                     ),
                   ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/features/operador/presentation/operador_page.dart
+++ b/lib/features/operador/presentation/operador_page.dart
@@ -24,12 +24,12 @@ import 'package:admin/models/machine.dart';
 import 'package:admin/features/shared/providers/search_flow_form_provider.dart';
 
 final medidasOperadorControllerProvider =
-StateNotifierProvider.autoDispose<
-    MedidasOperadorController,
-    AsyncValue<List<MedidaItem>>
->((ref) {
-  return MedidasOperadorController(ref);
-});
+    StateNotifierProvider.autoDispose<
+      MedidasOperadorController,
+      AsyncValue<List<MedidaItem>>
+    >((ref) {
+      return MedidasOperadorController(ref);
+    });
 
 class MedidasOperadorController
     extends StateNotifier<AsyncValue<List<MedidaItem>>> {
@@ -170,6 +170,11 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
   final _partCtrl = TextEditingController();
   final _opCtrl = TextEditingController();
 
+  final _reFocusNode = FocusNode();
+  final _osFocusNode = FocusNode();
+  final _partFocusNode = FocusNode();
+  final _opFocusNode = FocusNode();
+
   final List<Machine> _maquinas = [];
   final List<String> _categorias = [];
   String? _categoriaSel;
@@ -187,6 +192,23 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
   bool _amostragemReminderDialogOpen = false;
   DateTime? _lastAmostragem;
   DateTime? _lastReminderShownAt;
+
+  void _unfocusKeyboard() {
+    FocusManager.instance.primaryFocus?.unfocus();
+  }
+
+  void _submitField({required bool flowLocked, FocusNode? next}) {
+    if (flowLocked) {
+      _unfocusKeyboard();
+      return;
+    }
+
+    if (next != null) {
+      next.requestFocus();
+    } else {
+      _unfocusKeyboard();
+    }
+  }
 
   @override
   void initState() {
@@ -219,9 +241,9 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
   }
 
   void _handleFlowStateChange(
-      SharedSearchFormState? previous,
-      SharedSearchFormState next,
-      ) {
+    SharedSearchFormState? previous,
+    SharedSearchFormState next,
+  ) {
     if (!next.isActive ||
         next.effectiveProcess != SearchFlowProcess.amostragem) {
       _activeAmostragemFlow = null;
@@ -231,8 +253,8 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
 
     final wasActive =
         previous != null &&
-            previous.isActive &&
-            previous.effectiveProcess == SearchFlowProcess.amostragem;
+        previous.isActive &&
+        previous.effectiveProcess == SearchFlowProcess.amostragem;
 
     final previousFlow = _activeAmostragemFlow;
     _activeAmostragemFlow = next;
@@ -254,7 +276,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
     unawaited(_checkAmostragemRecente());
     _amostragemMonitorTimer = Timer.periodic(
       const Duration(minutes: 1),
-          (_) => unawaited(_checkAmostragemRecente()),
+      (_) => unawaited(_checkAmostragemRecente()),
     );
   }
 
@@ -315,9 +337,9 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
   }
 
   void _handleAmostragemRecente(
-      SharedSearchFormState flow,
-      DateTime? ultimaAmostragem,
-      ) {
+    SharedSearchFormState flow,
+    DateTime? ultimaAmostragem,
+  ) {
     if (!mounted) return;
     if (ultimaAmostragem != null) {
       _lastAmostragem = ultimaAmostragem;
@@ -375,9 +397,9 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
   }
 
   Future<void> _showAmostragemReminder(
-      SharedSearchFormState flow,
-      Duration reminderInterval,
-      ) async {
+    SharedSearchFormState flow,
+    Duration reminderInterval,
+  ) async {
     if (!mounted || _amostragemReminderDialogOpen) return;
     _amostragemReminderDialogOpen = true;
     _lastReminderShownAt = DateTime.now();
@@ -431,7 +453,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
 
           if (_categoriaSel != null) {
             final possuiMaquina = _maquinas.any(
-                  (m) => m.categoria == _categoriaSel && m.codigo == _maquinaSel,
+              (m) => m.categoria == _categoriaSel && m.codigo == _maquinaSel,
             );
             if (!possuiMaquina && _maquinaSel != null) {
               _maquinaSel = null;
@@ -457,7 +479,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
     final maquina = _maquinaSel;
     if (categoria == null || maquina == null) return false;
     return _maquinas.any(
-          (m) => m.categoria == categoria && m.codigo == maquina,
+      (m) => m.categoria == categoria && m.codigo == maquina,
     );
   }
 
@@ -498,6 +520,10 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
     _osCtrl.removeListener(_osSyncListener);
     _partCtrl.removeListener(_partSyncListener);
     _opCtrl.removeListener(_opSyncListener);
+    _reFocusNode.dispose();
+    _osFocusNode.dispose();
+    _partFocusNode.dispose();
+    _opFocusNode.dispose();
     _reCtrl.dispose();
     _osCtrl.dispose();
     _partCtrl.dispose();
@@ -798,13 +824,13 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                 children: motivos
                     .map(
                       (m) => RadioListTile<String>(
-                    title: Text(m),
-                    value: m,
-                    groupValue: selecionado,
-                    onChanged: (value) =>
-                        setState(() => selecionado = value),
-                  ),
-                )
+                        title: Text(m),
+                        value: m,
+                        groupValue: selecionado,
+                        onChanged: (value) =>
+                            setState(() => selecionado = value),
+                      ),
+                    )
                     .toList(),
               ),
             ),
@@ -916,7 +942,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
         title: const Text('Troca de O.S.'),
         content: const Text(
           'Deseja pausar a O.S. atual e liberar o fluxo para iniciar outra? '
-              'Será necessária nova liberação para retomar a produção desta O.S.',
+          'Será necessária nova liberação para retomar a produção desta O.S.',
         ),
         actions: [
           TextButton(
@@ -968,9 +994,9 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
   @override
   Widget build(BuildContext context) {
     ref.listen<SharedSearchFormState>(sharedSearchFormProvider, (
-        previous,
-        next,
-        ) {
+      previous,
+      next,
+    ) {
       _handleFlowStateChange(previous, next);
     });
 
@@ -988,43 +1014,43 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
     final reOk = _reCtrl.text.trim().isNotEmpty;
     final osOk = _osCtrl.text.trim().isNotEmpty;
     final categoriaValue =
-    (_categoriaSel != null && _categorias.contains(_categoriaSel))
+        (_categoriaSel != null && _categorias.contains(_categoriaSel))
         ? _categoriaSel
         : null;
     final maquinasDisponiveis = _maquinas
         .where((m) => m.categoria == categoriaValue)
         .toList();
     final maquinaValue =
-    (_maquinaSel != null &&
-        maquinasDisponiveis.any((m) => m.codigo == _maquinaSel))
+        (_maquinaSel != null &&
+            maquinasDisponiveis.any((m) => m.codigo == _maquinaSel))
         ? _maquinaSel
         : null;
     final maquinaOk = (maquinaValue ?? '').isNotEmpty;
     final formMatchesFlow =
         !flowLocked ||
-            flowState.matchesValues(
-              os: _osCtrl.text,
-              partNumber: _partCtrl.text,
-              operacao: _opCtrl.text,
-              categoria: categoriaValue,
-              maquina: maquinaValue,
-            );
+        flowState.matchesValues(
+          os: _osCtrl.text,
+          partNumber: _partCtrl.text,
+          operacao: _opCtrl.text,
+          categoria: categoriaValue,
+          maquina: maquinaValue,
+        );
 
     // todas respondidas?
     final todasRespondidas =
         medidas.isNotEmpty &&
-            medidas.every(
-                  (m) =>
+        medidas.every(
+          (m) =>
               m.status != StatusMedida.pendente && (m.medicao ?? '').isNotEmpty,
-            );
+        );
 
     final podeRegistrar =
         formMatchesFlow &&
-            reOk &&
-            osOk &&
-            maquinaOk &&
-            todasRespondidas &&
-            !_registrando;
+        reOk &&
+        osOk &&
+        maquinaOk &&
+        todasRespondidas &&
+        !_registrando;
 
     return Scaffold(
       appBar: WindowBar(
@@ -1049,354 +1075,395 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
       body: SafeArea(
         child: Padding(
           padding: const EdgeInsets.all(16.0),
-          child: CustomScrollView(
-            keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
-            slivers: [
-              SliverToBoxAdapter(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
-                    if (flowLocked)
-                      Container(
-                        margin: const EdgeInsets.only(bottom: 12),
-                        padding: const EdgeInsets.all(12),
-                        decoration: BoxDecoration(
-                          color: Theme.of(
-                            context,
-                          ).colorScheme.surfaceContainerHighest,
-                          borderRadius: BorderRadius.circular(8),
-                        ),
-                        child: Row(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Icon(
-                              Icons.lock,
-                              size: 18,
-                              color: Theme.of(context).colorScheme.primary,
-                            ),
-                            const SizedBox(width: 8),
-                            Expanded(
-                              child: Text(
-                                flowOs.isEmpty
-                                    ? 'Existe um fluxo de $flowProcessName em andamento. Finalize a O.S. atual para iniciar outra.'
-                                    : 'Fluxo de $flowProcessName ativo para a O.S. $flowOs. Finalize a O.S. atual para iniciar outra.',
-                                style: Theme.of(context).textTheme.bodyMedium,
+          child: FocusTraversalGroup(
+            policy: OrderedTraversalPolicy(),
+            child: CustomScrollView(
+              keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
+              slivers: [
+                SliverToBoxAdapter(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      if (flowLocked)
+                        Container(
+                          margin: const EdgeInsets.only(bottom: 12),
+                          padding: const EdgeInsets.all(12),
+                          decoration: BoxDecoration(
+                            color: Theme.of(
+                              context,
+                            ).colorScheme.surfaceContainerHighest,
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          child: Row(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Icon(
+                                Icons.lock,
+                                size: 18,
+                                color: Theme.of(context).colorScheme.primary,
                               ),
-                            ),
-                          ],
-                        ),
-                      ),
-                    if (_mostrarResumo) ...[
-                      SearchSummarySection(
-                        reLabel: 'R.E. do Preparador',
-                        reValue: _reCtrl.text,
-                        items: [
-                          SummaryInfo(label: 'O.S.', value: _osCtrl.text),
-                          SummaryInfo(label: 'Peça', value: _partCtrl.text),
-                          SummaryInfo(label: 'Operação', value: _opCtrl.text),
-                          if (dataRevisao != null)
-                            SummaryInfo(
-                              label: 'Data de revisão',
-                              value: dataRevisao,
-                            ),
-                          if ((maquinaValue ?? '').isNotEmpty)
-                            SummaryInfo(label: 'Máquina', value: maquinaValue!),
-                          if ((categoriaValue ?? '').isNotEmpty)
-                            SummaryInfo(
-                              label: 'Categoria',
-                              value: categoriaValue!,
-                            ),
-                        ],
-                        onEdit: () {
-                          FocusScope.of(context).unfocus();
-                          setState(() => _mostrarResumo = false);
-                        },
-                      ),
-                    ] else ...[
-                      Form(
-                        key: _formKey,
-                        child: Column(
-                          children: [
-                            Row(
-                              children: [
-                                Expanded(
-                                  child: TextFormField(
-                                    controller: _reCtrl,
-                                    textInputAction: TextInputAction.next,
-                                    keyboardType: TextInputType.number,
-                                    inputFormatters: [
-                                      FilteringTextInputFormatter.digitsOnly,
-                                    ],
-                                    decoration: const InputDecoration(
-                                      labelText:
-                                      'R.E. do Preparador', // ajuste o texto se for Operador
-                                      border: OutlineInputBorder(),
-                                    ),
-                                    validator: (v) {
-                                      final s = (v ?? '').trim();
-                                      if (s.isEmpty) return 'Obrigatório';
-                                      if (!RegExp(r'^[0-9]+$').hasMatch(s)) {
-                                        return 'Apenas números';
-                                      }
-                                      return null;
-                                    },
-                                  ),
+                              const SizedBox(width: 8),
+                              Expanded(
+                                child: Text(
+                                  flowOs.isEmpty
+                                      ? 'Existe um fluxo de $flowProcessName em andamento. Finalize a O.S. atual para iniciar outra.'
+                                      : 'Fluxo de $flowProcessName ativo para a O.S. $flowOs. Finalize a O.S. atual para iniciar outra.',
+                                  style: Theme.of(context).textTheme.bodyMedium,
                                 ),
-                                const SizedBox(width: 12),
-                                SizedBox(
-                                  width: 140, // igual ao campo Operação
-                                  child: TextFormField(
-                                    controller: _osCtrl,
-                                    enabled: !flowLocked,
-                                    textInputAction: TextInputAction.next,
-                                    keyboardType: TextInputType.number,
-                                    inputFormatters: [
-                                      FilteringTextInputFormatter.digitsOnly,
-                                    ],
-                                    decoration: const InputDecoration(
-                                      labelText: 'O.S.',
-                                      border: OutlineInputBorder(),
-                                    ),
-                                    validator: (v) {
-                                      final s = (v ?? '').trim();
-                                      if (s.isEmpty) return 'Obrigatório';
-                                      if (!RegExp(r'^[0-9]+$').hasMatch(s)) {
-                                        return 'Apenas números';
-                                      }
-                                      return null;
-                                    },
-                                  ),
-                                ),
-                              ],
-                            ),
-                            const SizedBox(height: 12),
-
-                            Row(
-                              children: [
-                                Expanded(
-                                  child: DropdownButtonFormField<String>(
-                                    value: categoriaValue,
-                                    decoration: const InputDecoration(
-                                      labelText: 'Grupo de máquina',
-                                      border: OutlineInputBorder(),
-                                    ),
-                                    items: _categorias
-                                        .map(
-                                          (c) => DropdownMenuItem(
-                                        value: c,
-                                        child: Text(c),
-                                      ),
-                                    )
-                                        .toList(),
-                                    onChanged: flowLocked
-                                        ? null
-                                        : (v) {
-                                      ref
-                                          .read(
-                                        sharedSearchFormProvider
-                                            .notifier,
-                                      )
-                                          .setCategoria(v);
-                                      setState(() {
-                                        _categoriaSel = v;
-                                        _maquinaSel = null;
-                                      });
-                                    },
-                                    validator: (v) => (v == null || v.isEmpty)
-                                        ? 'Obrigatório'
-                                        : null,
-                                  ),
-                                ),
-                                const SizedBox(width: 12),
-                                Expanded(
-                                  child: DropdownButtonFormField<String>(
-                                    value: maquinaValue,
-                                    decoration: const InputDecoration(
-                                      labelText: 'Código da máquina',
-                                      border: OutlineInputBorder(),
-                                    ),
-                                    items: maquinasDisponiveis
-                                        .map(
-                                          (m) => DropdownMenuItem(
-                                        value: m.codigo,
-                                        child: Text(m.codigo),
-                                      ),
-                                    )
-                                        .toList(),
-                                    onChanged: flowLocked
-                                        ? null
-                                        : (v) {
-                                      ref
-                                          .read(
-                                        sharedSearchFormProvider
-                                            .notifier,
-                                      )
-                                          .setMaquina(v);
-                                      setState(() => _maquinaSel = v);
-                                    },
-                                    validator: (v) => (v == null || v.isEmpty)
-                                        ? 'Obrigatório'
-                                        : null,
-                                  ),
-                                ),
-                              ],
-                            ),
-
-                            const SizedBox(height: 12),
-
-                            Row(
-                              children: [
-                                Expanded(
-                                  child: TextFormField(
-                                    controller: _partCtrl,
-                                    enabled: !flowLocked,
-                                    textInputAction: TextInputAction.next,
-                                    decoration: const InputDecoration(
-                                      labelText: 'Código da peça',
-                                      border: OutlineInputBorder(),
-                                    ),
-                                    validator: (v) =>
-                                    (v == null || v.trim().isEmpty)
-                                        ? 'Obrigatório'
-                                        : null,
-                                  ),
-                                ),
-                                const SizedBox(width: 12),
-                                SizedBox(
-                                  width: 140,
-                                  child: TextFormField(
-                                    controller: _opCtrl,
-                                    enabled: !flowLocked,
-                                    keyboardType: TextInputType.number,
-                                    inputFormatters: [
-                                      FilteringTextInputFormatter.digitsOnly,
-                                    ],
-                                    decoration: const InputDecoration(
-                                      labelText: 'Operação',
-                                      border: OutlineInputBorder(),
-                                    ),
-                                    validator: (v) {
-                                      final s = (v ?? '').trim();
-                                      if (s.isEmpty) return 'Obrigatório';
-                                      if (!RegExp(r'^[0-9]+$').hasMatch(s)) {
-                                        return 'Apenas números';
-                                      }
-                                      return null;
-                                    },
-                                  ),
-                                ),
-                              ],
-                            ),
-
-                            const SizedBox(height: 12),
-                            SizedBox(
-                              width: double.infinity,
-                              child: FilledButton.icon(
-                                onPressed: () async {
-                                  if (_formKey.currentState!.validate()) {
-                                    if (!_ensureFlowConsistency()) return;
-                                    FocusScope.of(context).unfocus();
-                                    await ref
-                                        .read(
-                                      medidasOperadorControllerProvider
-                                          .notifier,
-                                    )
-                                        .carregar(
-                                      os: _osCtrl.text.trim(),
-                                      partnumber: normalizeCode(
-                                        _partCtrl.text,
-                                      ),
-                                      operacao: normalizeCode(_opCtrl.text),
-                                    );
-                                    if (mounted) {
-                                      setState(() => _mostrarResumo = true);
-                                    }
-                                  }
-                                },
-                                icon: const Icon(Icons.search),
-                                label: const Text('Carregar medidas'),
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                    ],
-                    const SizedBox(height: 16),
-                  ],
-                ),
-              ),
-              ..._buildMedidasSlivers(medidasAsync),
-              SliverFillRemaining(
-                hasScrollBody: false,
-                child: AnimatedPadding(
-                  duration: const Duration(milliseconds: 200),
-                  curve: Curves.easeOut,
-                  padding: EdgeInsets.only(bottom: actionBottomPadding),
-                  child: SafeArea(
-                    top: false,
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.end,
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                      children: [
-                        Align(
-                          alignment: Alignment.centerRight,
-                          child: PopupMenuButton<String>(
-                            onSelected: (value) {
-                              if (value == 'ferramenta') {
-                                _iniciarTrocaFerramenta();
-                              } else if (value == 'fim') {
-                                _showFimJornadaDialog();
-                              } else if (value == 'troca') {
-                                _confirmTrocaOs();
-                              } else if (value == 'encerrar') {
-                                _confirmEncerrarProducao();
-                              }
-                            },
-                            itemBuilder: (context) => const [
-                              PopupMenuItem(
-                                value: 'ferramenta',
-                                child: Text('Troca de ferramenta'),
-                              ),
-                              PopupMenuItem(
-                                value: 'fim',
-                                child: Text('Pausa de Jornada'),
-                              ),
-                              PopupMenuItem(
-                                value: 'troca',
-                                child: Text('Troca de O.S.'),
-                              ),
-                              PopupMenuItem(
-                                value: 'encerrar',
-                                child: Text('Encerrar produção'),
                               ),
                             ],
                           ),
                         ),
-                        const SizedBox(height: 10),
-                        SizedBox(
-                          width: double.infinity,
-                          child: FilledButton.icon(
-                            onPressed: podeRegistrar
-                                ? _registrarAmostragem
-                                : null,
-                            icon: _registrando
-                                ? const SizedBox(
-                              width: 18,
-                              height: 18,
-                              child: CircularProgressIndicator(
-                                strokeWidth: 2,
+                      if (_mostrarResumo) ...[
+                        SearchSummarySection(
+                          reLabel: 'R.E. do Preparador',
+                          reValue: _reCtrl.text,
+                          items: [
+                            SummaryInfo(label: 'O.S.', value: _osCtrl.text),
+                            SummaryInfo(label: 'Peça', value: _partCtrl.text),
+                            SummaryInfo(label: 'Operação', value: _opCtrl.text),
+                            if (dataRevisao != null)
+                              SummaryInfo(
+                                label: 'Data de revisão',
+                                value: dataRevisao,
                               ),
-                            )
-                                : const Icon(Icons.save_outlined),
-                            label: const Text('Registrar amostragem'),
+                            if ((maquinaValue ?? '').isNotEmpty)
+                              SummaryInfo(
+                                label: 'Máquina',
+                                value: maquinaValue!,
+                              ),
+                            if ((categoriaValue ?? '').isNotEmpty)
+                              SummaryInfo(
+                                label: 'Categoria',
+                                value: categoriaValue!,
+                              ),
+                          ],
+                          onEdit: () {
+                            FocusScope.of(context).unfocus();
+                            setState(() => _mostrarResumo = false);
+                          },
+                        ),
+                      ] else ...[
+                        Form(
+                          key: _formKey,
+                          child: Column(
+                            children: [
+                              Row(
+                                children: [
+                                  Expanded(
+                                    child: TextFormField(
+                                      controller: _reCtrl,
+                                      focusNode: _reFocusNode,
+                                      textInputAction: TextInputAction.next,
+                                      keyboardType: TextInputType.number,
+                                      inputFormatters: [
+                                        FilteringTextInputFormatter.digitsOnly,
+                                      ],
+                                      decoration: const InputDecoration(
+                                        labelText:
+                                            'R.E. do Preparador', // ajuste o texto se for Operador
+                                        border: OutlineInputBorder(),
+                                      ),
+                                      onEditingComplete: () => _submitField(
+                                        flowLocked: flowLocked,
+                                        next: _osFocusNode,
+                                      ),
+                                      onFieldSubmitted: (_) => _submitField(
+                                        flowLocked: flowLocked,
+                                        next: _osFocusNode,
+                                      ),
+                                      validator: (v) {
+                                        final s = (v ?? '').trim();
+                                        if (s.isEmpty) return 'Obrigatório';
+                                        if (!RegExp(r'^[0-9]+$').hasMatch(s)) {
+                                          return 'Apenas números';
+                                        }
+                                        return null;
+                                      },
+                                    ),
+                                  ),
+                                  const SizedBox(width: 12),
+                                  SizedBox(
+                                    width: 140, // igual ao campo Operação
+                                    child: TextFormField(
+                                      controller: _osCtrl,
+                                      enabled: !flowLocked,
+                                      focusNode: _osFocusNode,
+                                      textInputAction: TextInputAction.next,
+                                      keyboardType: TextInputType.number,
+                                      inputFormatters: [
+                                        FilteringTextInputFormatter.digitsOnly,
+                                      ],
+                                      decoration: const InputDecoration(
+                                        labelText: 'O.S.',
+                                        border: OutlineInputBorder(),
+                                      ),
+                                      onEditingComplete: () => _submitField(
+                                        flowLocked: flowLocked,
+                                        next: _partFocusNode,
+                                      ),
+                                      onFieldSubmitted: (_) => _submitField(
+                                        flowLocked: flowLocked,
+                                        next: _partFocusNode,
+                                      ),
+                                      validator: (v) {
+                                        final s = (v ?? '').trim();
+                                        if (s.isEmpty) return 'Obrigatório';
+                                        if (!RegExp(r'^[0-9]+$').hasMatch(s)) {
+                                          return 'Apenas números';
+                                        }
+                                        return null;
+                                      },
+                                    ),
+                                  ),
+                                ],
+                              ),
+                              const SizedBox(height: 12),
+
+                              Row(
+                                children: [
+                                  Expanded(
+                                    child: DropdownButtonFormField<String>(
+                                      value: categoriaValue,
+                                      decoration: const InputDecoration(
+                                        labelText: 'Grupo de máquina',
+                                        border: OutlineInputBorder(),
+                                      ),
+                                      items: _categorias
+                                          .map(
+                                            (c) => DropdownMenuItem(
+                                              value: c,
+                                              child: Text(c),
+                                            ),
+                                          )
+                                          .toList(),
+                                      onChanged: flowLocked
+                                          ? null
+                                          : (v) {
+                                              ref
+                                                  .read(
+                                                    sharedSearchFormProvider
+                                                        .notifier,
+                                                  )
+                                                  .setCategoria(v);
+                                              setState(() {
+                                                _categoriaSel = v;
+                                                _maquinaSel = null;
+                                              });
+                                            },
+                                      validator: (v) => (v == null || v.isEmpty)
+                                          ? 'Obrigatório'
+                                          : null,
+                                    ),
+                                  ),
+                                  const SizedBox(width: 12),
+                                  Expanded(
+                                    child: DropdownButtonFormField<String>(
+                                      value: maquinaValue,
+                                      decoration: const InputDecoration(
+                                        labelText: 'Código da máquina',
+                                        border: OutlineInputBorder(),
+                                      ),
+                                      items: maquinasDisponiveis
+                                          .map(
+                                            (m) => DropdownMenuItem(
+                                              value: m.codigo,
+                                              child: Text(m.codigo),
+                                            ),
+                                          )
+                                          .toList(),
+                                      onChanged: flowLocked
+                                          ? null
+                                          : (v) {
+                                              ref
+                                                  .read(
+                                                    sharedSearchFormProvider
+                                                        .notifier,
+                                                  )
+                                                  .setMaquina(v);
+                                              setState(() => _maquinaSel = v);
+                                            },
+                                      validator: (v) => (v == null || v.isEmpty)
+                                          ? 'Obrigatório'
+                                          : null,
+                                    ),
+                                  ),
+                                ],
+                              ),
+
+                              const SizedBox(height: 12),
+
+                              Row(
+                                children: [
+                                  Expanded(
+                                    child: TextFormField(
+                                      controller: _partCtrl,
+                                      enabled: !flowLocked,
+                                      focusNode: _partFocusNode,
+                                      textInputAction: TextInputAction.next,
+                                      decoration: const InputDecoration(
+                                        labelText: 'Código da peça',
+                                        border: OutlineInputBorder(),
+                                      ),
+                                      onEditingComplete: () => _submitField(
+                                        flowLocked: flowLocked,
+                                        next: _opFocusNode,
+                                      ),
+                                      onFieldSubmitted: (_) => _submitField(
+                                        flowLocked: flowLocked,
+                                        next: _opFocusNode,
+                                      ),
+                                      validator: (v) =>
+                                          (v == null || v.trim().isEmpty)
+                                          ? 'Obrigatório'
+                                          : null,
+                                    ),
+                                  ),
+                                  const SizedBox(width: 12),
+                                  SizedBox(
+                                    width: 140,
+                                    child: TextFormField(
+                                      controller: _opCtrl,
+                                      enabled: !flowLocked,
+                                      focusNode: _opFocusNode,
+                                      textInputAction: TextInputAction.done,
+                                      keyboardType: TextInputType.number,
+                                      inputFormatters: [
+                                        FilteringTextInputFormatter.digitsOnly,
+                                      ],
+                                      decoration: const InputDecoration(
+                                        labelText: 'Operação',
+                                        border: OutlineInputBorder(),
+                                      ),
+                                      onEditingComplete: () =>
+                                          _submitField(flowLocked: flowLocked),
+                                      onFieldSubmitted: (_) =>
+                                          _submitField(flowLocked: flowLocked),
+                                      validator: (v) {
+                                        final s = (v ?? '').trim();
+                                        if (s.isEmpty) return 'Obrigatório';
+                                        if (!RegExp(r'^[0-9]+$').hasMatch(s)) {
+                                          return 'Apenas números';
+                                        }
+                                        return null;
+                                      },
+                                    ),
+                                  ),
+                                ],
+                              ),
+
+                              const SizedBox(height: 12),
+                              SizedBox(
+                                width: double.infinity,
+                                child: FilledButton.icon(
+                                  onPressed: () async {
+                                    if (_formKey.currentState!.validate()) {
+                                      if (!_ensureFlowConsistency()) return;
+                                      FocusScope.of(context).unfocus();
+                                      await ref
+                                          .read(
+                                            medidasOperadorControllerProvider
+                                                .notifier,
+                                          )
+                                          .carregar(
+                                            os: _osCtrl.text.trim(),
+                                            partnumber: normalizeCode(
+                                              _partCtrl.text,
+                                            ),
+                                            operacao: normalizeCode(
+                                              _opCtrl.text,
+                                            ),
+                                          );
+                                      if (mounted) {
+                                        setState(() => _mostrarResumo = true);
+                                      }
+                                    }
+                                  },
+                                  icon: const Icon(Icons.search),
+                                  label: const Text('Carregar medidas'),
+                                ),
+                              ),
+                            ],
                           ),
                         ),
                       ],
+                      const SizedBox(height: 16),
+                    ],
+                  ),
+                ),
+                ..._buildMedidasSlivers(medidasAsync),
+                SliverFillRemaining(
+                  hasScrollBody: false,
+                  child: AnimatedPadding(
+                    duration: const Duration(milliseconds: 200),
+                    curve: Curves.easeOut,
+                    padding: EdgeInsets.only(bottom: actionBottomPadding),
+                    child: SafeArea(
+                      top: false,
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.end,
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          Align(
+                            alignment: Alignment.centerRight,
+                            child: PopupMenuButton<String>(
+                              onSelected: (value) {
+                                if (value == 'ferramenta') {
+                                  _iniciarTrocaFerramenta();
+                                } else if (value == 'fim') {
+                                  _showFimJornadaDialog();
+                                } else if (value == 'troca') {
+                                  _confirmTrocaOs();
+                                } else if (value == 'encerrar') {
+                                  _confirmEncerrarProducao();
+                                }
+                              },
+                              itemBuilder: (context) => const [
+                                PopupMenuItem(
+                                  value: 'ferramenta',
+                                  child: Text('Troca de ferramenta'),
+                                ),
+                                PopupMenuItem(
+                                  value: 'fim',
+                                  child: Text('Pausa de Jornada'),
+                                ),
+                                PopupMenuItem(
+                                  value: 'troca',
+                                  child: Text('Troca de O.S.'),
+                                ),
+                                PopupMenuItem(
+                                  value: 'encerrar',
+                                  child: Text('Encerrar produção'),
+                                ),
+                              ],
+                            ),
+                          ),
+                          const SizedBox(height: 10),
+                          SizedBox(
+                            width: double.infinity,
+                            child: FilledButton.icon(
+                              onPressed: podeRegistrar
+                                  ? _registrarAmostragem
+                                  : null,
+                              icon: _registrando
+                                  ? const SizedBox(
+                                      width: 18,
+                                      height: 18,
+                                      child: CircularProgressIndicator(
+                                        strokeWidth: 2,
+                                      ),
+                                    )
+                                  : const Icon(Icons.save_outlined),
+                              label: const Text('Registrar amostragem'),
+                            ),
+                          ),
+                        ],
+                      ),
                     ),
                   ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/features/operador/presentation/troca_ferramenta_page.dart
+++ b/lib/features/operador/presentation/troca_ferramenta_page.dart
@@ -76,11 +76,11 @@ class _TrocaFerramentaPageState extends State<TrocaFerramentaPage> {
         final data = jsonDecode(body);
         final itens = data is List
             ? data
-            .map<MedidaItem>(
-              (e) =>
-              MedidaItem.fromMap((e as Map).cast<String, dynamic>()),
-        )
-            .toList()
+                  .map<MedidaItem>(
+                    (e) =>
+                        MedidaItem.fromMap((e as Map).cast<String, dynamic>()),
+                  )
+                  .toList()
             : <MedidaItem>[];
         final dataInclusao = itens.firstDataInclusao;
         final dataFormatada = dataInclusao != null
@@ -238,8 +238,8 @@ class _TrocaFerramentaPageState extends State<TrocaFerramentaPage> {
       return;
     }
     final pendentes = _medidasSelecionadas.where(
-          (m) =>
-      m.status == StatusMedida.pendente ||
+      (m) =>
+          m.status == StatusMedida.pendente ||
           (m.medicao == null || m.medicao!.trim().isEmpty),
     );
     if (pendentes.isNotEmpty) {
@@ -252,7 +252,7 @@ class _TrocaFerramentaPageState extends State<TrocaFerramentaPage> {
     }
 
     final naoAprovadas = _medidasSelecionadas.where(
-          (m) => m.status != StatusMedida.ok,
+      (m) => m.status != StatusMedida.ok,
     );
     if (naoAprovadas.isNotEmpty) {
       ScaffoldMessenger.of(context).showSnackBar(
@@ -365,6 +365,9 @@ class _TrocaFerramentaPageState extends State<TrocaFerramentaPage> {
               border: OutlineInputBorder(),
               isDense: true,
             ),
+            textInputAction: TextInputAction.done,
+            onEditingComplete: () => FocusScope.of(context).unfocus(),
+            onSubmitted: (_) => FocusScope.of(context).unfocus(),
           ),
         ],
       ),
@@ -410,132 +413,135 @@ class _TrocaFerramentaPageState extends State<TrocaFerramentaPage> {
               ? const Center(child: CircularProgressIndicator())
               : _erro != null
               ? Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              Text(
-                'Erro ao carregar medidas:\n${_erro!}',
-                textAlign: TextAlign.center,
-              ),
-              const SizedBox(height: 12),
-              FilledButton.icon(
-                onPressed: _carregarMedidas,
-                icon: const Icon(Icons.refresh),
-                label: const Text('Tentar novamente'),
-              ),
-            ],
-          )
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Text(
+                      'Erro ao carregar medidas:\n${_erro!}',
+                      textAlign: TextAlign.center,
+                    ),
+                    const SizedBox(height: 12),
+                    FilledButton.icon(
+                      onPressed: _carregarMedidas,
+                      icon: const Icon(Icons.refresh),
+                      label: const Text('Tentar novamente'),
+                    ),
+                  ],
+                )
               : Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Card(
-                margin: EdgeInsets.zero,
-                child: Padding(
-                  padding: const EdgeInsets.all(16.0),
-                  child: Wrap(
-                    spacing: 24,
-                    runSpacing: 12,
-                    children: [
-                      _buildEditableReChip(),
-                      _buildInfoChip('O.S.', widget.os),
-                      _buildInfoChip('Peça', widget.partnumber),
-                      _buildInfoChip('Operação', widget.operacao),
-                      if (_dataRevisao != null)
-                        _buildInfoChip('Data de revisão', _dataRevisao!),
-                      _buildInfoChip('Máquina', widget.maquina),
-                    ],
-                  ),
-                ),
-              ),
-              const SizedBox(height: 16),
-              if (!_medindo) ...[
-                Text(
-                  'Selecione as medidas impactadas pela troca da ferramenta.',
-                  style: Theme.of(context).textTheme.titleMedium,
-                ),
-                const SizedBox(height: 12),
-                Expanded(
-                  child: _todas.isEmpty
-                      ? const Center(
-                    child: Text('Nenhuma medida disponível.'),
-                  )
-                      : ListView.separated(
-                    itemCount: _todas.length,
-                    separatorBuilder: (_, __) =>
-                    const Divider(height: 1),
-                    itemBuilder: (context, index) {
-                      final item = _todas[index];
-                      final selecionado = _selecionadas.contains(
-                        index,
-                      );
-                      final subtitulo = _subtitleFor(item);
-                      return CheckboxListTile(
-                        value: selecionado,
-                        onChanged: (value) =>
-                            _toggleSelecao(index, value),
-                        title: Text(
-                          item.titulo.isEmpty
-                              ? '(sem título)'
-                              : item.titulo,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Card(
+                      margin: EdgeInsets.zero,
+                      child: Padding(
+                        padding: const EdgeInsets.all(16.0),
+                        child: Wrap(
+                          spacing: 24,
+                          runSpacing: 12,
+                          children: [
+                            _buildEditableReChip(),
+                            _buildInfoChip('O.S.', widget.os),
+                            _buildInfoChip('Peça', widget.partnumber),
+                            _buildInfoChip('Operação', widget.operacao),
+                            if (_dataRevisao != null)
+                              _buildInfoChip('Data de revisão', _dataRevisao!),
+                            _buildInfoChip('Máquina', widget.maquina),
+                          ],
                         ),
-                        subtitle: subtitulo.isEmpty
-                            ? null
-                            : Text(subtitulo),
-                      );
-                    },
-                  ),
-                ),
-                const SizedBox(height: 12),
-                Align(
-                  alignment: Alignment.centerRight,
-                  child: FilledButton.icon(
-                    onPressed: _selecionadas.isEmpty
-                        ? null
-                        : _avancarParaMedicao,
-                    icon: const Icon(Icons.playlist_add_check),
-                    label: const Text('Prosseguir para medição (FOR07)'),
-                  ),
-                ),
-              ] else ...[
-                Text(
-                  'Realize as medições selecionadas (FOR07).',
-                  style: Theme.of(context).textTheme.titleMedium,
-                ),
-                const SizedBox(height: 12),
-                Expanded(
-                  child: ListView.builder(
-                    itemCount: _medidasSelecionadas.length,
-                    itemBuilder: (context, index) {
-                      final item = _medidasSelecionadas[index];
-                      return MeasurementTile(
-                        index: index,
-                        item: item,
-                        manualEntry: true,
-                        onSelect: (status, medicao) =>
-                            _atualizarMedicao(index, status, medicao),
-                      );
-                    },
-                  ),
-                ),
-                const SizedBox(height: 12),
-                Align(
-                  alignment: Alignment.centerRight,
-                  child: FilledButton.icon(
-                    onPressed: _registrando ? null : _registrarMedicoes,
-                    icon: _registrando
-                        ? const SizedBox(
-                      width: 18,
-                      height: 18,
-                      child: CircularProgressIndicator(
-                        strokeWidth: 2,
                       ),
-                    )
-                        : const Icon(Icons.save_outlined),
-                    label: const Text('Registrar medições'),
-                  ),
+                    ),
+                    const SizedBox(height: 16),
+                    if (!_medindo) ...[
+                      Text(
+                        'Selecione as medidas impactadas pela troca da ferramenta.',
+                        style: Theme.of(context).textTheme.titleMedium,
+                      ),
+                      const SizedBox(height: 12),
+                      Expanded(
+                        child: _todas.isEmpty
+                            ? const Center(
+                                child: Text('Nenhuma medida disponível.'),
+                              )
+                            : ListView.separated(
+                                itemCount: _todas.length,
+                                separatorBuilder: (_, __) =>
+                                    const Divider(height: 1),
+                                itemBuilder: (context, index) {
+                                  final item = _todas[index];
+                                  final selecionado = _selecionadas.contains(
+                                    index,
+                                  );
+                                  final subtitulo = _subtitleFor(item);
+                                  return CheckboxListTile(
+                                    value: selecionado,
+                                    onChanged: (value) =>
+                                        _toggleSelecao(index, value),
+                                    title: Text(
+                                      item.titulo.isEmpty
+                                          ? '(sem título)'
+                                          : item.titulo,
+                                    ),
+                                    subtitle: subtitulo.isEmpty
+                                        ? null
+                                        : Text(subtitulo),
+                                  );
+                                },
+                              ),
+                      ),
+                      const SizedBox(height: 12),
+                      Align(
+                        alignment: Alignment.centerRight,
+                        child: FilledButton.icon(
+                          onPressed: _selecionadas.isEmpty
+                              ? null
+                              : _avancarParaMedicao,
+                          icon: const Icon(Icons.playlist_add_check),
+                          label: const Text('Prosseguir para medição (FOR07)'),
+                        ),
+                      ),
+                    ] else ...[
+                      Text(
+                        'Realize as medições selecionadas (FOR07).',
+                        style: Theme.of(context).textTheme.titleMedium,
+                      ),
+                      const SizedBox(height: 12),
+                      Expanded(
+                        child: FocusTraversalGroup(
+                          policy: OrderedTraversalPolicy(),
+                          child: ListView.builder(
+                            itemCount: _medidasSelecionadas.length,
+                            itemBuilder: (context, index) {
+                              final item = _medidasSelecionadas[index];
+                              return MeasurementTile(
+                                index: index,
+                                item: item,
+                                manualEntry: true,
+                                onSelect: (status, medicao) =>
+                                    _atualizarMedicao(index, status, medicao),
+                              );
+                            },
+                          ),
+                        ),
+                      ),
+                      const SizedBox(height: 12),
+                      Align(
+                        alignment: Alignment.centerRight,
+                        child: FilledButton.icon(
+                          onPressed: _registrando ? null : _registrarMedicoes,
+                          icon: _registrando
+                              ? const SizedBox(
+                                  width: 18,
+                                  height: 18,
+                                  child: CircularProgressIndicator(
+                                    strokeWidth: 2,
+                                  ),
+                                )
+                              : const Icon(Icons.save_outlined),
+                          label: const Text('Registrar medições'),
+                        ),
+                      ),
+                    ],
+                  ],
                 ),
-              ],
-            ],
-          ),
         ),
       ),
     );

--- a/lib/features/operador/presentation/widgets/measurement_tile.dart
+++ b/lib/features/operador/presentation/widgets/measurement_tile.dart
@@ -38,6 +38,9 @@ class _MeasurementTileState extends State<MeasurementTile> {
   TextEditingController? _chanfroAngCtrl;
   TextEditingController? _chanfroMedCtrl;
   String? _roscaSelection;
+  FocusNode? _manualFocusNode;
+  FocusNode? _chanfroAngleFocusNode;
+  FocusNode? _chanfroMedFocusNode;
 
   @override
   void initState() {
@@ -46,9 +49,13 @@ class _MeasurementTileState extends State<MeasurementTile> {
     if (widget.manualEntry) {
       if (_isChanfro(widget.item)) {
         _ensureChanfroControllers();
+        _ensureChanfroFocusNodes();
         _syncChanfroControllers(widget.item.medicao);
       } else {
         _manualCtrl = TextEditingController(text: widget.item.medicao ?? '');
+        if (_usesManualTextField(widget.item)) {
+          _ensureManualFocusNode();
+        }
       }
     }
   }
@@ -62,13 +69,21 @@ class _MeasurementTileState extends State<MeasurementTile> {
     if (widget.manualEntry) {
       if (isChanfro) {
         _disposeManualController();
+        _disposeManualFocusNode();
         _ensureChanfroControllers();
+        _ensureChanfroFocusNodes();
         if (!wasChanfro || oldWidget.item.medicao != widget.item.medicao) {
           _syncChanfroControllers(widget.item.medicao);
         }
       } else {
         _disposeChanfroControllers();
+        _disposeChanfroFocusNodes();
         _manualCtrl ??= TextEditingController();
+        if (_usesManualTextField(widget.item)) {
+          _ensureManualFocusNode();
+        } else {
+          _disposeManualFocusNode();
+        }
         final newText = widget.item.medicao ?? '';
         if (oldWidget.item.medicao != widget.item.medicao &&
             _manualCtrl!.text != newText) {
@@ -82,6 +97,8 @@ class _MeasurementTileState extends State<MeasurementTile> {
     } else {
       _disposeManualController();
       _disposeChanfroControllers();
+      _disposeManualFocusNode();
+      _disposeChanfroFocusNodes();
     }
 
     if (oldWidget.item.medicao != widget.item.medicao) {
@@ -93,6 +110,8 @@ class _MeasurementTileState extends State<MeasurementTile> {
   void dispose() {
     _disposeManualController();
     _disposeChanfroControllers();
+    _disposeManualFocusNode();
+    _disposeChanfroFocusNodes();
     super.dispose();
   }
 
@@ -104,6 +123,27 @@ class _MeasurementTileState extends State<MeasurementTile> {
   void _ensureChanfroControllers() {
     _chanfroAngCtrl ??= TextEditingController();
     _chanfroMedCtrl ??= TextEditingController();
+  }
+
+  void _ensureManualFocusNode() {
+    _manualFocusNode ??= FocusNode();
+  }
+
+  void _disposeManualFocusNode() {
+    _manualFocusNode?.dispose();
+    _manualFocusNode = null;
+  }
+
+  void _ensureChanfroFocusNodes() {
+    _chanfroAngleFocusNode ??= FocusNode();
+    _chanfroMedFocusNode ??= FocusNode();
+  }
+
+  void _disposeChanfroFocusNodes() {
+    _chanfroAngleFocusNode?.dispose();
+    _chanfroAngleFocusNode = null;
+    _chanfroMedFocusNode?.dispose();
+    _chanfroMedFocusNode = null;
   }
 
   void _disposeChanfroControllers() {
@@ -142,10 +182,10 @@ class _MeasurementTileState extends State<MeasurementTile> {
       final segundo = rawParts[1];
       final primeiroEhAngulo =
           _looksLikeAngleToken(primeiro) ||
-              _valueMatchesAngleRange(primeiro, faixa);
+          _valueMatchesAngleRange(primeiro, faixa);
       final segundoEhAngulo =
           _looksLikeAngleToken(segundo) ||
-              _valueMatchesAngleRange(segundo, faixa);
+          _valueMatchesAngleRange(segundo, faixa);
 
       if (!primeiroEhAngulo && segundoEhAngulo) {
         medida = primeiro;
@@ -200,9 +240,9 @@ class _MeasurementTileState extends State<MeasurementTile> {
   }
 
   bool _tokenLooksLikeAngleRange(
-      String token,
-      ({double? min, double? max})? range,
-      ) {
+    String token,
+    ({double? min, double? max})? range,
+  ) {
     final normalized = token.replaceAll(',', '.').trim();
     if (normalized.isEmpty) return false;
 
@@ -241,9 +281,9 @@ class _MeasurementTileState extends State<MeasurementTile> {
   }
 
   bool _valueMatchesAngleRange(
-      String token,
-      ({double? min, double? max})? range,
-      ) {
+    String token,
+    ({double? min, double? max})? range,
+  ) {
     if (range == null) return false;
     final value = _parseAngleInput(token);
     if (value == null) return false;
@@ -309,16 +349,16 @@ class _MeasurementTileState extends State<MeasurementTile> {
     final t = _norm(item.titulo);
     final inst = _norm(item.instrumento);
     return _containsAny(t, [
-      'visual',
-      'rug',
-      'paralelismo',
-      'anel de rosca',
-      'anel rosca',
-      'anel de rosca passa',
-      'cqf',
-      'simetria',
-      'concentricidade',
-    ]) ||
+          'visual',
+          'rug',
+          'paralelismo',
+          'anel de rosca',
+          'anel rosca',
+          'anel de rosca passa',
+          'cqf',
+          'simetria',
+          'concentricidade',
+        ]) ||
         _containsAny(inst, [
           'visual',
           'rug',
@@ -367,16 +407,16 @@ class _MeasurementTileState extends State<MeasurementTile> {
 
     final mentionsChanfro =
         _containsAny(t, ['chanfro']) ||
-            _containsAny(faixa, ['chanfro']) ||
-            _containsAny(inst, ['chanfro']) ||
-            _containsAny(obs, ['chanfro']);
+        _containsAny(faixa, ['chanfro']) ||
+        _containsAny(inst, ['chanfro']) ||
+        _containsAny(obs, ['chanfro']);
     if (mentionsChanfro) return true;
 
     final mentionsCantosVivos =
         _containsAny(t, cantoTokens) ||
-            _containsAny(faixa, cantoTokens) ||
-            _containsAny(inst, cantoTokens) ||
-            _containsAny(obs, cantoTokens);
+        _containsAny(faixa, cantoTokens) ||
+        _containsAny(inst, cantoTokens) ||
+        _containsAny(obs, cantoTokens);
     if (!mentionsCantosVivos) return false;
 
     final context = _nfd('$t $faixa $inst $obs'.toLowerCase());
@@ -387,7 +427,7 @@ class _MeasurementTileState extends State<MeasurementTile> {
     final angleRange = _resolveItemAngleRange(item);
     final hasAngleRange =
         angleRange != null &&
-            (angleRange.min != null || angleRange.max != null);
+        (angleRange.min != null || angleRange.max != null);
     if (!hasAngleRange) return false;
 
     final hasAngleHint = _hasAngleHint(context, angleRange);
@@ -458,8 +498,8 @@ class _MeasurementTileState extends State<MeasurementTile> {
 
   Color _fgOn(Color bg) =>
       ThemeData.estimateBrightnessForColor(bg) == Brightness.dark
-          ? Colors.white
-          : Colors.black87;
+      ? Colors.white
+      : Colors.black87;
 
   Widget _pill({
     required String text,
@@ -488,12 +528,12 @@ class _MeasurementTileState extends State<MeasurementTile> {
           border: Border.all(color: effectiveBorder, width: selected ? 2 : 1),
           boxShadow: selected
               ? [
-            BoxShadow(
-              color: border.withValues(alpha: 0.35),
-              blurRadius: 10,
-              offset: const Offset(0, 4),
-            ),
-          ]
+                  BoxShadow(
+                    color: border.withValues(alpha: 0.35),
+                    blurRadius: 10,
+                    offset: const Offset(0, 4),
+                  ),
+                ]
               : null,
         ),
         child: Text.rich(
@@ -655,8 +695,12 @@ class _MeasurementTileState extends State<MeasurementTile> {
     TextEditingController? ctrl;
     if (!isChanfro) {
       ctrl = _manualCtrl ??= TextEditingController(text: item.medicao ?? '');
+      if (!isRosca && !_isRepetirTresPontos(item)) {
+        _ensureManualFocusNode();
+      }
     } else {
       _ensureChanfroControllers();
+      _ensureChanfroFocusNodes();
     }
 
     final roscaSelection = (_roscaSelection ?? item.medicao ?? '')
@@ -667,6 +711,7 @@ class _MeasurementTileState extends State<MeasurementTile> {
         ? _chanfroMedCtrl!.text.trim()
         : (ctrl != null ? ctrl.text : '');
     final isRepetir3 = !isChanfro && !isRosca && _isRepetirTresPontos(item);
+    final double baseOrder = widget.index * 10.0;
 
     double? valor;
     if (isRosca || isRepetir3) {
@@ -733,14 +778,14 @@ class _MeasurementTileState extends State<MeasurementTile> {
         ? _roscaHelper(status)
         : isChanfro
         ? _chanfroHelper(
-      status: status,
-      hasAngle: hasAngle,
-      hasMedida: hasMedida,
-      medidaValida: medidaValida,
-      anguloValido: anguloValido,
-      medidaStatus: medidaStatus,
-      anguloStatus: anguloStatus,
-    )
+            status: status,
+            hasAngle: hasAngle,
+            hasMedida: hasMedida,
+            medidaValida: medidaValida,
+            anguloValido: anguloValido,
+            medidaStatus: medidaStatus,
+            anguloStatus: anguloStatus,
+          )
         : isRepetir3
         ? _repetirHelper(status)
         : _statusHelper(status);
@@ -830,35 +875,71 @@ class _MeasurementTileState extends State<MeasurementTile> {
               const SizedBox(height: 6),
               Text(helper, style: TextStyle(color: helperColor)),
             ] else if (isChanfro) ...[
-              TextField(
-                controller: _chanfroAngCtrl,
-                keyboardType: TextInputType.text,
-                decoration: const InputDecoration(
-                  labelText: 'Ângulo (°)',
-                  border: OutlineInputBorder(),
+              _wrapSubmitTraversal(
+                order: baseOrder,
+                focusNode: _chanfroAngleFocusNode,
+                child: TextField(
+                  controller: _chanfroAngCtrl,
+                  focusNode: _chanfroAngleFocusNode,
+                  keyboardType: TextInputType.text,
+                  decoration: const InputDecoration(
+                    labelText: 'Ângulo (°)',
+                    border: OutlineInputBorder(),
+                  ),
+                  inputFormatters: [
+                    FilteringTextInputFormatter.deny(RegExp(r'\s')),
+                  ],
+                  onChanged: (_) => _handleChanfroChanged(),
+                  textInputAction: TextInputAction.next,
+                  onEditingComplete: () {
+                    final node = _chanfroAngleFocusNode;
+                    if (node != null) {
+                      _handleManualSubmit(node);
+                    }
+                  },
+                  onSubmitted: (_) {
+                    final node = _chanfroAngleFocusNode;
+                    if (node != null) {
+                      _handleManualSubmit(node);
+                    }
+                  },
                 ),
-                inputFormatters: [
-                  FilteringTextInputFormatter.deny(RegExp(r'\s')),
-                ],
-                onChanged: (_) => _handleChanfroChanged(),
               ),
               const SizedBox(height: 10),
-              TextField(
-                controller: _chanfroMedCtrl,
-                keyboardType: const TextInputType.numberWithOptions(
-                  decimal: true,
-                  signed: false,
+              _wrapSubmitTraversal(
+                order: baseOrder + 0.5,
+                focusNode: _chanfroMedFocusNode,
+                child: TextField(
+                  controller: _chanfroMedCtrl,
+                  focusNode: _chanfroMedFocusNode,
+                  keyboardType: const TextInputType.numberWithOptions(
+                    decimal: true,
+                    signed: false,
+                  ),
+                  decoration: InputDecoration(
+                    labelText: 'Medida$unidadeLabel',
+                    border: const OutlineInputBorder(),
+                    helperText: helper,
+                    helperStyle: TextStyle(color: helperColor),
+                  ),
+                  inputFormatters: [
+                    FilteringTextInputFormatter.deny(RegExp(r'\s')),
+                  ],
+                  onChanged: (_) => _handleChanfroChanged(),
+                  textInputAction: TextInputAction.next,
+                  onEditingComplete: () {
+                    final node = _chanfroMedFocusNode;
+                    if (node != null) {
+                      _handleManualSubmit(node);
+                    }
+                  },
+                  onSubmitted: (_) {
+                    final node = _chanfroMedFocusNode;
+                    if (node != null) {
+                      _handleManualSubmit(node);
+                    }
+                  },
                 ),
-                decoration: InputDecoration(
-                  labelText: 'Medida$unidadeLabel',
-                  border: const OutlineInputBorder(),
-                  helperText: helper,
-                  helperStyle: TextStyle(color: helperColor),
-                ),
-                inputFormatters: [
-                  FilteringTextInputFormatter.deny(RegExp(r'\s')),
-                ],
-                onChanged: (_) => _handleChanfroChanged(),
               ),
             ] else if (isRepetir3) ...[
               Wrap(
@@ -871,14 +952,14 @@ class _MeasurementTileState extends State<MeasurementTile> {
                     border: Colors.green.shade600,
                     fg: Colors.green.shade900,
                     selected:
-                    item.status == StatusMedida.ok &&
+                        item.status == StatusMedida.ok &&
                         (item.medicao ?? '').trim().toLowerCase() == 'ok',
                     count: _countFor('OK'),
                     onTap: () {
                       FocusScope.of(context).unfocus();
                       final alreadyOk =
                           item.status == StatusMedida.ok &&
-                              (item.medicao ?? '').trim().toLowerCase() == 'ok';
+                          (item.medicao ?? '').trim().toLowerCase() == 'ok';
                       widget.onSelect(
                         alreadyOk ? StatusMedida.pendente : StatusMedida.ok,
                         alreadyOk ? null : 'OK',
@@ -891,33 +972,119 @@ class _MeasurementTileState extends State<MeasurementTile> {
               const SizedBox(height: 6),
               Text(helper, style: TextStyle(color: helperColor)),
             ] else ...[
-              TextField(
-                controller: ctrl,
-                keyboardType: const TextInputType.numberWithOptions(
-                  decimal: true,
-                  signed: false,
+              _wrapSubmitTraversal(
+                order: baseOrder,
+                focusNode: _manualFocusNode,
+                child: TextField(
+                  controller: ctrl,
+                  focusNode: _manualFocusNode,
+                  keyboardType: const TextInputType.numberWithOptions(
+                    decimal: true,
+                    signed: false,
+                  ),
+                  decoration: InputDecoration(
+                    labelText: 'Medição$unidadeLabel',
+                    border: const OutlineInputBorder(),
+                    helperText: helper,
+                    helperStyle: TextStyle(color: helperColor),
+                  ),
+                  inputFormatters: [
+                    FilteringTextInputFormatter.deny(RegExp(r'\s')),
+                  ],
+                  onChanged: (txt) {
+                    final v = _parseManualValue(txt);
+                    final novoStatus = item.avaliarStatus(v);
+                    widget.onSelect(novoStatus, txt);
+                    setState(() {});
+                  },
+                  textInputAction: TextInputAction.next,
+                  onEditingComplete: () {
+                    final node = _manualFocusNode;
+                    if (node != null) {
+                      _handleManualSubmit(node);
+                    }
+                  },
+                  onSubmitted: (_) {
+                    final node = _manualFocusNode;
+                    if (node != null) {
+                      _handleManualSubmit(node);
+                    }
+                  },
                 ),
-                decoration: InputDecoration(
-                  labelText: 'Medição$unidadeLabel',
-                  border: const OutlineInputBorder(),
-                  helperText: helper,
-                  helperStyle: TextStyle(color: helperColor),
-                ),
-                inputFormatters: [
-                  FilteringTextInputFormatter.deny(RegExp(r'\s')),
-                ],
-                onChanged: (txt) {
-                  final v = _parseManualValue(txt);
-                  final novoStatus = item.avaliarStatus(v);
-                  widget.onSelect(novoStatus, txt);
-                  setState(() {});
-                },
               ),
             ],
           ],
         ),
       ),
     );
+  }
+
+  Widget _wrapSubmitTraversal({
+    required double order,
+    required FocusNode? focusNode,
+    required Widget child,
+  }) {
+    final node = focusNode;
+    if (node == null) {
+      return child;
+    }
+    return FocusTraversalOrder(
+      order: NumericFocusOrder(order),
+      child: Shortcuts(
+        shortcuts: const <ShortcutActivator, Intent>{
+          SingleActivator(LogicalKeyboardKey.enter): NextFocusIntent(),
+          SingleActivator(LogicalKeyboardKey.numpadEnter): NextFocusIntent(),
+        },
+        child: Actions(
+          actions: <Type, Action<Intent>>{
+            NextFocusIntent: CallbackAction<NextFocusIntent>(
+              onInvoke: (intent) {
+                _handleManualSubmit(node);
+                return null;
+              },
+            ),
+          },
+          child: child,
+        ),
+      ),
+    );
+  }
+
+  bool _handleManualSubmit(FocusNode currentNode) {
+    if (!currentNode.hasFocus) {
+      return false;
+    }
+    final scope = FocusScope.of(context);
+    final before = scope.focusedChild;
+    scope.nextFocus();
+    FocusNode? after = scope.focusedChild;
+    var hops = 0;
+    while (after != null &&
+        after != before &&
+        !identical(after, currentNode) &&
+        after.context?.widget is! EditableText) {
+      scope.nextFocus();
+      hops++;
+      if (hops > 20) {
+        break;
+      }
+      final candidate = scope.focusedChild;
+      if (candidate == after) {
+        break;
+      }
+      after = candidate;
+    }
+    final moved =
+        after != null &&
+        after != before &&
+        !identical(after, currentNode) &&
+        after.context?.widget is EditableText;
+
+    if (!moved) {
+      scope.unfocus();
+    }
+
+    return moved;
   }
 
   void _handleChanfroChanged() {
@@ -953,6 +1120,13 @@ class _MeasurementTileState extends State<MeasurementTile> {
 
     widget.onSelect(novoStatus, combined.isEmpty ? null : combined);
     setState(() {});
+  }
+
+  bool _usesManualTextField(MedidaItem item) {
+    if (_isChanfro(item)) return true;
+    if (_isRosca(item)) return false;
+    if (_isRepetirTresPontos(item)) return false;
+    return true;
   }
 
   Widget _buildAutomaticEntry(BuildContext context) {
@@ -998,7 +1172,7 @@ class _MeasurementTileState extends State<MeasurementTile> {
                     border: Colors.green.shade600,
                     fg: Colors.green.shade900,
                     selected:
-                    item.medicao == 'Aprovado' &&
+                        item.medicao == 'Aprovado' &&
                         item.status == StatusMedida.ok,
                     count: _countFor('Aprovado'),
                     onTap: () => widget.onSelect(StatusMedida.ok, 'Aprovado'),
@@ -1008,7 +1182,7 @@ class _MeasurementTileState extends State<MeasurementTile> {
                     bg: Colors.red.shade100,
                     border: Colors.red.shade400,
                     selected:
-                    item.medicao == 'Reprovado' &&
+                        item.medicao == 'Reprovado' &&
                         item.status == StatusMedida.reprovadaAcima,
                     count: _countFor('Reprovado'),
                     onTap: () => widget.onSelect(
@@ -1146,7 +1320,7 @@ class _MeasurementTileState extends State<MeasurementTile> {
                       border: Colors.green.shade600,
                       fg: Colors.green.shade900,
                       selected:
-                      item.medicao == 'OK' &&
+                          item.medicao == 'OK' &&
                           item.status == StatusMedida.ok,
                       count: _countFor('OK'),
                       onTap: () => widget.onSelect(StatusMedida.ok, 'OK'),

--- a/lib/features/preparacao/presentation/preparacao_page.dart
+++ b/lib/features/preparacao/presentation/preparacao_page.dart
@@ -144,6 +144,11 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
   final _partCtrl = TextEditingController();
   final _opCtrl = TextEditingController();
 
+  final _reFocusNode = FocusNode();
+  final _osFocusNode = FocusNode();
+  final _partFocusNode = FocusNode();
+  final _opFocusNode = FocusNode();
+
   final List<Machine> _maquinas = [];
   final List<String> _categorias = [];
   String? _categoriaSel;
@@ -156,6 +161,23 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
   late final VoidCallback _osSyncListener;
   late final VoidCallback _partSyncListener;
   late final VoidCallback _opSyncListener;
+
+  void _unfocusKeyboard() {
+    FocusManager.instance.primaryFocus?.unfocus();
+  }
+
+  void _submitField({required bool flowLocked, FocusNode? next}) {
+    if (flowLocked) {
+      _unfocusKeyboard();
+      return;
+    }
+
+    if (next != null) {
+      next.requestFocus();
+    } else {
+      _unfocusKeyboard();
+    }
+  }
 
   void _resetLiberada() {
     if (_osLiberada) setState(() => _osLiberada = false);
@@ -305,6 +327,10 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
     _osCtrl.removeListener(_osSyncListener);
     _partCtrl.removeListener(_partSyncListener);
     _opCtrl.removeListener(_opSyncListener);
+    _reFocusNode.dispose();
+    _osFocusNode.dispose();
+    _partFocusNode.dispose();
+    _opFocusNode.dispose();
     _reCtrl.dispose();
     _osCtrl.dispose();
     _partCtrl.dispose();
@@ -542,383 +568,429 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
       body: SafeArea(
         child: Padding(
           padding: const EdgeInsets.all(16.0),
-          child: CustomScrollView(
-            keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
-            slivers: [
-              SliverToBoxAdapter(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
-                    if (flowLocked)
-                      Container(
-                        margin: const EdgeInsets.only(bottom: 12),
-                        padding: const EdgeInsets.all(12),
-                        decoration: BoxDecoration(
-                          color: Theme.of(
-                            context,
-                          ).colorScheme.surfaceContainerHighest,
-                          borderRadius: BorderRadius.circular(8),
-                        ),
-                        child: Row(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Icon(
-                              Icons.lock,
-                              size: 18,
-                              color: Theme.of(context).colorScheme.primary,
-                            ),
-                            const SizedBox(width: 8),
-                            Expanded(
-                              child: Text(
-                                flowOs.isEmpty
-                                    ? 'Existe um fluxo de $flowProcessName em andamento. Finalize a O.S. atual para iniciar outra.'
-                                    : 'Fluxo de $flowProcessName ativo para a O.S. $flowOs. Finalize a O.S. atual para iniciar outra.',
-                                style: Theme.of(context).textTheme.bodyMedium,
+          child: FocusTraversalGroup(
+            policy: OrderedTraversalPolicy(),
+            child: CustomScrollView(
+              keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
+              slivers: [
+                SliverToBoxAdapter(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      if (flowLocked)
+                        Container(
+                          margin: const EdgeInsets.only(bottom: 12),
+                          padding: const EdgeInsets.all(12),
+                          decoration: BoxDecoration(
+                            color: Theme.of(
+                              context,
+                            ).colorScheme.surfaceContainerHighest,
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          child: Row(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Icon(
+                                Icons.lock,
+                                size: 18,
+                                color: Theme.of(context).colorScheme.primary,
                               ),
-                            ),
+                              const SizedBox(width: 8),
+                              Expanded(
+                                child: Text(
+                                  flowOs.isEmpty
+                                      ? 'Existe um fluxo de $flowProcessName em andamento. Finalize a O.S. atual para iniciar outra.'
+                                      : 'Fluxo de $flowProcessName ativo para a O.S. $flowOs. Finalize a O.S. atual para iniciar outra.',
+                                  style: Theme.of(context).textTheme.bodyMedium,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      if (_mostrarResumo) ...[
+                        SearchSummaryCard(
+                          reLabel: 'R.E. do Preparador',
+                          reValue: _reCtrl.text,
+                          items: [
+                            SummaryInfo(label: 'O.S.', value: _osCtrl.text),
+                            SummaryInfo(label: 'Peça', value: _partCtrl.text),
+                            SummaryInfo(label: 'Operação', value: _opCtrl.text),
+                            if (dataRevisao != null)
+                              SummaryInfo(
+                                label: 'Data de revisão',
+                                value: dataRevisao,
+                              ),
+                            if ((maquinaValue ?? '').isNotEmpty)
+                              SummaryInfo(
+                                label: 'Máquina',
+                                value: maquinaValue!,
+                              ),
+                            if ((categoriaValue ?? '').isNotEmpty)
+                              SummaryInfo(
+                                label: 'Grupo de máquina',
+                                value: categoriaValue!,
+                              ),
                           ],
                         ),
-                      ),
-                    if (_mostrarResumo) ...[
-                      SearchSummaryCard(
-                        reLabel: 'R.E. do Preparador',
-                        reValue: _reCtrl.text,
-                        items: [
-                          SummaryInfo(label: 'O.S.', value: _osCtrl.text),
-                          SummaryInfo(label: 'Peça', value: _partCtrl.text),
-                          SummaryInfo(label: 'Operação', value: _opCtrl.text),
-                          if (dataRevisao != null)
-                            SummaryInfo(
-                              label: 'Data de revisão',
-                              value: dataRevisao,
-                            ),
-                          if ((maquinaValue ?? '').isNotEmpty)
-                            SummaryInfo(label: 'Máquina', value: maquinaValue!),
-                          if ((categoriaValue ?? '').isNotEmpty)
-                            SummaryInfo(
-                              label: 'Grupo de máquina',
-                              value: categoriaValue!,
-                            ),
-                        ],
-                      ),
-                      const SizedBox(height: 8),
-                      Align(
-                        alignment: Alignment.centerRight,
-                        child: TextButton.icon(
-                          onPressed: () {
-                            FocusScope.of(context).unfocus();
-                            setState(() => _mostrarResumo = false);
-                          },
-                          icon: const Icon(Icons.edit_outlined),
-                          label: const Text('Alterar dados da busca'),
+                        const SizedBox(height: 8),
+                        Align(
+                          alignment: Alignment.centerRight,
+                          child: TextButton.icon(
+                            onPressed: () {
+                              FocusScope.of(context).unfocus();
+                              setState(() => _mostrarResumo = false);
+                            },
+                            icon: const Icon(Icons.edit_outlined),
+                            label: const Text('Alterar dados da busca'),
+                          ),
                         ),
-                      ),
-                    ] else ...[
-                      Form(
-                        key: _formKey,
-                        child: Column(
-                          children: [
-                            LayoutBuilder(
-                              builder: (context, constraints) {
-                                final isCompact =
-                                    constraints.maxWidth <
-                                    _compactFormBreakpoint;
-                                final reField = TextFormField(
-                                  controller: _reCtrl,
-                                  textInputAction: TextInputAction.next,
-                                  keyboardType: TextInputType.number,
-                                  inputFormatters: [
-                                    FilteringTextInputFormatter.digitsOnly,
-                                  ],
-                                  decoration: const InputDecoration(
-                                    labelText: 'R.E. do Preparador',
-                                    border: OutlineInputBorder(),
-                                  ),
-                                  validator: (v) {
-                                    final s = (v ?? '').trim();
-                                    if (s.isEmpty) return 'Obrigatório';
-                                    if (!RegExp(r'^[0-9]+$').hasMatch(s)) {
-                                      return 'Apenas números';
-                                    }
-                                    return null;
-                                  },
-                                );
-                                final osField = TextFormField(
-                                  controller: _osCtrl,
-                                  enabled: !flowLocked,
-                                  textInputAction: TextInputAction.next,
-                                  keyboardType: TextInputType.number,
-                                  inputFormatters: [
-                                    FilteringTextInputFormatter.digitsOnly,
-                                  ],
-                                  decoration: const InputDecoration(
-                                    labelText: 'O.S.',
-                                    border: OutlineInputBorder(),
-                                  ),
-                                  validator: (v) {
-                                    final s = (v ?? '').trim();
-                                    if (s.isEmpty) return 'Obrigatório';
-                                    if (!RegExp(r'^[0-9]+$').hasMatch(s)) {
-                                      return 'Apenas números';
-                                    }
-                                    return null;
-                                  },
-                                );
-                                if (isCompact) {
-                                  return Column(
-                                    crossAxisAlignment:
-                                        CrossAxisAlignment.stretch,
-                                    children: [
-                                      reField,
-                                      const SizedBox(height: 12),
-                                      osField,
+                      ] else ...[
+                        Form(
+                          key: _formKey,
+                          child: Column(
+                            children: [
+                              LayoutBuilder(
+                                builder: (context, constraints) {
+                                  final isCompact =
+                                      constraints.maxWidth <
+                                      _compactFormBreakpoint;
+                                  final reField = TextFormField(
+                                    controller: _reCtrl,
+                                    focusNode: _reFocusNode,
+                                    textInputAction: TextInputAction.next,
+                                    keyboardType: TextInputType.number,
+                                    inputFormatters: [
+                                      FilteringTextInputFormatter.digitsOnly,
                                     ],
-                                  );
-                                }
-
-                                return Row(
-                                  children: [
-                                    Expanded(child: reField),
-                                    const SizedBox(width: 12),
-                                    SizedBox(
-                                      width: 140, // igual ao campo Operação
-                                      child: osField,
+                                    decoration: const InputDecoration(
+                                      labelText: 'R.E. do Preparador',
+                                      border: OutlineInputBorder(),
                                     ),
-                                  ],
-                                );
-                              },
-                            ),
-
-                            const SizedBox(height: 12),
-
-                            LayoutBuilder(
-                              builder: (context, constraints) {
-                                final isCompact =
-                                    constraints.maxWidth <
-                                    _compactFormBreakpoint;
-                                final categoriaDropdown =
-                                    DropdownButtonFormField<String>(
-                                      value: categoriaValue,
-                                      decoration: const InputDecoration(
-                                        labelText: 'Grupo de máquina',
-                                        border: OutlineInputBorder(),
-                                      ),
-                                      items: _categorias
-                                          .map(
-                                            (c) => DropdownMenuItem(
-                                              value: c,
-                                              child: Text(c),
-                                            ),
-                                          )
-                                          .toList(),
-                                      onChanged: flowLocked
-                                          ? null
-                                          : (v) {
-                                              ref
-                                                  .read(
-                                                    sharedSearchFormProvider
-                                                        .notifier,
-                                                  )
-                                                  .setCategoria(v);
-                                              setState(() {
-                                                _categoriaSel = v;
-                                                _maquinaSel = null;
-                                              });
-                                            },
-                                      validator: (v) => (v == null || v.isEmpty)
-                                          ? 'Obrigatório'
-                                          : null,
-                                    );
-                                final maquinaDropdown =
-                                    DropdownButtonFormField<String>(
-                                      value: maquinaValue,
-                                      decoration: const InputDecoration(
-                                        labelText: 'Código da máquina',
-                                        border: OutlineInputBorder(),
-                                      ),
-                                      items: maquinasDisponiveis
-                                          .map(
-                                            (m) => DropdownMenuItem(
-                                              value: m.codigo,
-                                              child: Text(m.codigo),
-                                            ),
-                                          )
-                                          .toList(),
-                                      onChanged: flowLocked
-                                          ? null
-                                          : (v) {
-                                              ref
-                                                  .read(
-                                                    sharedSearchFormProvider
-                                                        .notifier,
-                                                  )
-                                                  .setMaquina(v);
-                                              setState(() => _maquinaSel = v);
-                                            },
-                                      validator: (v) => (v == null || v.isEmpty)
-                                          ? 'Obrigatório'
-                                          : null,
-                                    );
-
-                                if (isCompact) {
-                                  return Column(
-                                    crossAxisAlignment:
-                                        CrossAxisAlignment.stretch,
-                                    children: [
-                                      categoriaDropdown,
-                                      const SizedBox(height: 12),
-                                      maquinaDropdown,
-                                    ],
+                                    onEditingComplete: () => _submitField(
+                                      flowLocked: flowLocked,
+                                      next: _osFocusNode,
+                                    ),
+                                    onFieldSubmitted: (_) => _submitField(
+                                      flowLocked: flowLocked,
+                                      next: _osFocusNode,
+                                    ),
+                                    validator: (v) {
+                                      final s = (v ?? '').trim();
+                                      if (s.isEmpty) return 'Obrigatório';
+                                      if (!RegExp(r'^[0-9]+$').hasMatch(s)) {
+                                        return 'Apenas números';
+                                      }
+                                      return null;
+                                    },
                                   );
-                                }
-
-                                return Row(
-                                  children: [
-                                    Expanded(child: categoriaDropdown),
-                                    const SizedBox(width: 12),
-                                    Expanded(child: maquinaDropdown),
-                                  ],
-                                );
-                              },
-                            ),
-
-                            const SizedBox(height: 12),
-
-                            // ---------- PartNumber + Operação (Operação só números) ----------
-                            LayoutBuilder(
-                              builder: (context, constraints) {
-                                final isCompact =
-                                    constraints.maxWidth <
-                                    _compactFormBreakpoint;
-                                final partField = TextFormField(
-                                  controller: _partCtrl,
-                                  enabled: !flowLocked,
-                                  textInputAction: TextInputAction.next,
-                                  decoration: const InputDecoration(
-                                    labelText: 'Código da peça',
-                                    border: OutlineInputBorder(),
-                                  ),
-                                  validator: (v) =>
-                                      (v == null || v.trim().isEmpty)
-                                      ? 'Obrigatório'
-                                      : null,
-                                );
-                                final operacaoField = TextFormField(
-                                  controller: _opCtrl,
-                                  enabled: !flowLocked,
-                                  keyboardType: TextInputType.number,
-                                  inputFormatters: [
-                                    FilteringTextInputFormatter.digitsOnly,
-                                  ],
-                                  decoration: const InputDecoration(
-                                    labelText: 'Operação',
-                                    border: OutlineInputBorder(),
-                                  ),
-                                  validator: (v) {
-                                    final s = (v ?? '').trim();
-                                    if (s.isEmpty) return 'Obrigatório';
-                                    if (!RegExp(r'^[0-9]+$').hasMatch(s)) {
-                                      return 'Apenas números';
-                                    }
-                                    return null;
-                                  },
-                                );
-
-                                if (isCompact) {
-                                  return Column(
-                                    crossAxisAlignment:
-                                        CrossAxisAlignment.stretch,
-                                    children: [
-                                      partField,
-                                      const SizedBox(height: 12),
-                                      operacaoField,
+                                  final osField = TextFormField(
+                                    controller: _osCtrl,
+                                    enabled: !flowLocked,
+                                    focusNode: _osFocusNode,
+                                    textInputAction: TextInputAction.next,
+                                    keyboardType: TextInputType.number,
+                                    inputFormatters: [
+                                      FilteringTextInputFormatter.digitsOnly,
                                     ],
+                                    decoration: const InputDecoration(
+                                      labelText: 'O.S.',
+                                      border: OutlineInputBorder(),
+                                    ),
+                                    onEditingComplete: () => _submitField(
+                                      flowLocked: flowLocked,
+                                      next: _partFocusNode,
+                                    ),
+                                    onFieldSubmitted: (_) => _submitField(
+                                      flowLocked: flowLocked,
+                                      next: _partFocusNode,
+                                    ),
+                                    validator: (v) {
+                                      final s = (v ?? '').trim();
+                                      if (s.isEmpty) return 'Obrigatório';
+                                      if (!RegExp(r'^[0-9]+$').hasMatch(s)) {
+                                        return 'Apenas números';
+                                      }
+                                      return null;
+                                    },
                                   );
-                                }
-
-                                return Row(
-                                  children: [
-                                    Expanded(child: partField),
-                                    const SizedBox(width: 12),
-                                    SizedBox(width: 140, child: operacaoField),
-                                  ],
-                                );
-                              },
-                            ),
-
-                            const SizedBox(height: 12),
-                            SizedBox(
-                              width: double.infinity,
-                              child: FilledButton.icon(
-                                onPressed: () async {
-                                  if (_formKey.currentState!.validate()) {
-                                    if (!_ensureFlowConsistency()) return;
-                                    FocusScope.of(context).unfocus();
-                                    await ref
-                                        .read(
-                                          medidasPreparadorControllerProvider
-                                              .notifier,
-                                        )
-                                        .carregar(
-                                          partnumber: normalizeCode(
-                                            _partCtrl.text,
-                                          ),
-                                          operacao: normalizeCode(_opCtrl.text),
-                                        );
-                                    if (mounted) {
-                                      setState(() => _mostrarResumo = true);
-                                    }
+                                  if (isCompact) {
+                                    return Column(
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.stretch,
+                                      children: [
+                                        reField,
+                                        const SizedBox(height: 12),
+                                        osField,
+                                      ],
+                                    );
                                   }
+
+                                  return Row(
+                                    children: [
+                                      Expanded(child: reField),
+                                      const SizedBox(width: 12),
+                                      SizedBox(
+                                        width: 140, // igual ao campo Operação
+                                        child: osField,
+                                      ),
+                                    ],
+                                  );
                                 },
-                                icon: const Icon(Icons.search),
-                                label: const Text('Carregar medidas'),
                               ),
-                            ),
-                          ],
-                        ),
-                      ),
-                    ],
-                    const SizedBox(height: 16),
-                  ],
-                ),
-              ),
-              ..._buildMedidasSlivers(medidasAsync),
-              SliverFillRemaining(
-                hasScrollBody: false,
-                child: AnimatedPadding(
-                  duration: const Duration(milliseconds: 200),
-                  curve: Curves.easeOut,
-                  padding: EdgeInsets.only(bottom: actionBottomPadding),
-                  child: SafeArea(
-                    top: false,
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.end,
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                      children: [
-                        SizedBox(
-                          width: double.infinity,
-                          child: FilledButton.icon(
-                            onPressed: podeRegistrar
-                                ? _registrarResultado
-                                : null,
-                            icon: _registrando
-                                ? const SizedBox(
-                                    width: 18,
-                                    height: 18,
-                                    child: CircularProgressIndicator(
-                                      strokeWidth: 2,
+
+                              const SizedBox(height: 12),
+
+                              LayoutBuilder(
+                                builder: (context, constraints) {
+                                  final isCompact =
+                                      constraints.maxWidth <
+                                      _compactFormBreakpoint;
+                                  final categoriaDropdown =
+                                      DropdownButtonFormField<String>(
+                                        value: categoriaValue,
+                                        decoration: const InputDecoration(
+                                          labelText: 'Grupo de máquina',
+                                          border: OutlineInputBorder(),
+                                        ),
+                                        items: _categorias
+                                            .map(
+                                              (c) => DropdownMenuItem(
+                                                value: c,
+                                                child: Text(c),
+                                              ),
+                                            )
+                                            .toList(),
+                                        onChanged: flowLocked
+                                            ? null
+                                            : (v) {
+                                                ref
+                                                    .read(
+                                                      sharedSearchFormProvider
+                                                          .notifier,
+                                                    )
+                                                    .setCategoria(v);
+                                                setState(() {
+                                                  _categoriaSel = v;
+                                                  _maquinaSel = null;
+                                                });
+                                              },
+                                        validator: (v) =>
+                                            (v == null || v.isEmpty)
+                                            ? 'Obrigatório'
+                                            : null,
+                                      );
+                                  final maquinaDropdown =
+                                      DropdownButtonFormField<String>(
+                                        value: maquinaValue,
+                                        decoration: const InputDecoration(
+                                          labelText: 'Código da máquina',
+                                          border: OutlineInputBorder(),
+                                        ),
+                                        items: maquinasDisponiveis
+                                            .map(
+                                              (m) => DropdownMenuItem(
+                                                value: m.codigo,
+                                                child: Text(m.codigo),
+                                              ),
+                                            )
+                                            .toList(),
+                                        onChanged: flowLocked
+                                            ? null
+                                            : (v) {
+                                                ref
+                                                    .read(
+                                                      sharedSearchFormProvider
+                                                          .notifier,
+                                                    )
+                                                    .setMaquina(v);
+                                                setState(() => _maquinaSel = v);
+                                              },
+                                        validator: (v) =>
+                                            (v == null || v.isEmpty)
+                                            ? 'Obrigatório'
+                                            : null,
+                                      );
+
+                                  if (isCompact) {
+                                    return Column(
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.stretch,
+                                      children: [
+                                        categoriaDropdown,
+                                        const SizedBox(height: 12),
+                                        maquinaDropdown,
+                                      ],
+                                    );
+                                  }
+
+                                  return Row(
+                                    children: [
+                                      Expanded(child: categoriaDropdown),
+                                      const SizedBox(width: 12),
+                                      Expanded(child: maquinaDropdown),
+                                    ],
+                                  );
+                                },
+                              ),
+
+                              const SizedBox(height: 12),
+
+                              // ---------- PartNumber + Operação (Operação só números) ----------
+                              LayoutBuilder(
+                                builder: (context, constraints) {
+                                  final isCompact =
+                                      constraints.maxWidth <
+                                      _compactFormBreakpoint;
+                                  final partField = TextFormField(
+                                    controller: _partCtrl,
+                                    enabled: !flowLocked,
+                                    focusNode: _partFocusNode,
+                                    textInputAction: TextInputAction.next,
+                                    decoration: const InputDecoration(
+                                      labelText: 'Código da peça',
+                                      border: OutlineInputBorder(),
                                     ),
-                                  )
-                                : const Icon(Icons.save_outlined),
-                            label: const Text('Registrar resultado'),
+                                    onEditingComplete: () => _submitField(
+                                      flowLocked: flowLocked,
+                                      next: _opFocusNode,
+                                    ),
+                                    onFieldSubmitted: (_) => _submitField(
+                                      flowLocked: flowLocked,
+                                      next: _opFocusNode,
+                                    ),
+                                    validator: (v) =>
+                                        (v == null || v.trim().isEmpty)
+                                        ? 'Obrigatório'
+                                        : null,
+                                  );
+                                  final operacaoField = TextFormField(
+                                    controller: _opCtrl,
+                                    enabled: !flowLocked,
+                                    focusNode: _opFocusNode,
+                                    textInputAction: TextInputAction.done,
+                                    keyboardType: TextInputType.number,
+                                    inputFormatters: [
+                                      FilteringTextInputFormatter.digitsOnly,
+                                    ],
+                                    decoration: const InputDecoration(
+                                      labelText: 'Operação',
+                                      border: OutlineInputBorder(),
+                                    ),
+                                    onEditingComplete: () =>
+                                        _submitField(flowLocked: flowLocked),
+                                    onFieldSubmitted: (_) =>
+                                        _submitField(flowLocked: flowLocked),
+                                    validator: (v) {
+                                      final s = (v ?? '').trim();
+                                      if (s.isEmpty) return 'Obrigatório';
+                                      if (!RegExp(r'^[0-9]+$').hasMatch(s)) {
+                                        return 'Apenas números';
+                                      }
+                                      return null;
+                                    },
+                                  );
+
+                                  if (isCompact) {
+                                    return Column(
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.stretch,
+                                      children: [
+                                        partField,
+                                        const SizedBox(height: 12),
+                                        operacaoField,
+                                      ],
+                                    );
+                                  }
+
+                                  return Row(
+                                    children: [
+                                      Expanded(child: partField),
+                                      const SizedBox(width: 12),
+                                      SizedBox(
+                                        width: 140,
+                                        child: operacaoField,
+                                      ),
+                                    ],
+                                  );
+                                },
+                              ),
+
+                              const SizedBox(height: 12),
+                              SizedBox(
+                                width: double.infinity,
+                                child: FilledButton.icon(
+                                  onPressed: () async {
+                                    if (_formKey.currentState!.validate()) {
+                                      if (!_ensureFlowConsistency()) return;
+                                      FocusScope.of(context).unfocus();
+                                      await ref
+                                          .read(
+                                            medidasPreparadorControllerProvider
+                                                .notifier,
+                                          )
+                                          .carregar(
+                                            partnumber: normalizeCode(
+                                              _partCtrl.text,
+                                            ),
+                                            operacao: normalizeCode(
+                                              _opCtrl.text,
+                                            ),
+                                          );
+                                      if (mounted) {
+                                        setState(() => _mostrarResumo = true);
+                                      }
+                                    }
+                                  },
+                                  icon: const Icon(Icons.search),
+                                  label: const Text('Carregar medidas'),
+                                ),
+                              ),
+                            ],
                           ),
                         ),
                       ],
+                      const SizedBox(height: 16),
+                    ],
+                  ),
+                ),
+                ..._buildMedidasSlivers(medidasAsync),
+                SliverFillRemaining(
+                  hasScrollBody: false,
+                  child: AnimatedPadding(
+                    duration: const Duration(milliseconds: 200),
+                    curve: Curves.easeOut,
+                    padding: EdgeInsets.only(bottom: actionBottomPadding),
+                    child: SafeArea(
+                      top: false,
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.end,
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          SizedBox(
+                            width: double.infinity,
+                            child: FilledButton.icon(
+                              onPressed: podeRegistrar
+                                  ? _registrarResultado
+                                  : null,
+                              icon: _registrando
+                                  ? const SizedBox(
+                                      width: 18,
+                                      height: 18,
+                                      child: CircularProgressIndicator(
+                                        strokeWidth: 2,
+                                      ),
+                                    )
+                                  : const Icon(Icons.save_outlined),
+                              label: const Text('Registrar resultado'),
+                            ),
+                          ),
+                        ],
+                      ),
                     ),
                   ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
## Summary
- wrap measurement lists in a FocusTraversalGroup so measurements advance in order across the preparation, finalization, operador, and troca de ferramenta flows
- wrap manual measurement text fields with focus traversal helpers and shortcuts so Enter goes to the next field or dismisses the keyboard on the last input

## Testing
- flutter test

------
https://chatgpt.com/codex/tasks/task_e_68dbfc24b7108331b578f361e7e8b58e