### PR TITLE
Improve measurement field traversal

### DIFF
--- a/lib/features/operador/presentation/widgets/measurement_tile.dart
+++ b/lib/features/operador/presentation/widgets/measurement_tile.dart
@@ -1065,14 +1065,10 @@ class _MeasurementTileState extends State<MeasurementTile> {
         after.context?.widget is! EditableText) {
       scope.nextFocus();
       hops++;
-      if (hops > 20) {
+      if (hops > 50) {
         break;
       }
-      final candidate = scope.focusedChild;
-      if (candidate == after) {
-        break;
-      }
-      after = candidate;
+      after = scope.focusedChild;
     }
     final moved =
         after != null &&
@@ -1081,7 +1077,7 @@ class _MeasurementTileState extends State<MeasurementTile> {
         after.context?.widget is EditableText;
 
     if (!moved) {
-      scope.unfocus();
+      currentNode.requestFocus();
     }
 
     return moved;


### PR DESCRIPTION
## Summary
- keep the focus within measurement inputs when the user submits a value with Enter
- adjust the focus traversal logic so the next editable field is always targeted instead of closing the keyboard

## Testing
- flutter analyze

------
https://chatgpt.com/codex/tasks/task_e_68dc0f652e2c8331b064bf8e7b01bfe5