### PR TITLE
Ensure Enter advances to next measurement field

### DIFF
--- a/lib/features/operador/presentation/widgets/measurement_tile.dart
+++ b/lib/features/operador/presentation/widgets/measurement_tile.dart
@@ -1054,38 +1054,32 @@ class _MeasurementTileState extends State<MeasurementTile> {
     if (!currentNode.hasFocus) {
       return false;
     }
-    final scope = FocusScope.of(context);
-    final before = scope.focusedChild;
-    scope.nextFocus();
-    FocusNode? after = scope.focusedChild;
+
+    final nodeContext = currentNode.context;
+    if (nodeContext == null) {
+      return false;
+    }
+
+    final scope = FocusScope.of(nodeContext);
+    final focusManager = WidgetsBinding.instance.focusManager;
+    final before = focusManager.primaryFocus;
+
+    FocusNode? after;
     var hops = 0;
-    while (after != null &&
-        after != before &&
-        !identical(after, currentNode) &&
-        after.context?.widget is! EditableText) {
+    do {
       scope.nextFocus();
+      after = focusManager.primaryFocus ?? scope.focusedChild;
+      if (after == null || identical(after, before) || identical(after, currentNode)) {
+        break;
+      }
+      if (after.context?.widget is EditableText) {
+        return true;
+      }
       hops++;
-      if (hops > 20) {
-        break;
-      }
-      final candidate = scope.focusedChild;
-      if (candidate == after) {
-        break;
-      }
-      after = candidate;
-    }
-    final moved =
-        after != null &&
-        after != before &&
-        !identical(after, currentNode) &&
-        after.context?.widget is EditableText;
+    } while (hops <= 50);
 
-    if (!moved) {
-      scope.unfocus();
-    }
-
-    return moved;
-
+    currentNode.requestFocus();
+    return false;
   }
 
   void _handleChanfroChanged() {


### PR DESCRIPTION
## Summary
- use the active field's focus scope to advance to the next editable measurement input when Enter is pressed
- keep focus on the current field when there are no further editable inputs available

## Testing
- flutter analyze

------
https://chatgpt.com/codex/tasks/task_e_68dc0f652e2c8331b064bf8e7b01bfe5