### PR TITLE
Add dashboard checklist de liberacao page

### DIFF
--- a/lib/features/checklist_liberacao/presentation/checklist_liberacao_page.dart
+++ b/lib/features/checklist_liberacao/presentation/checklist_liberacao_page.dart
@@ -1,0 +1,157 @@
+import 'package:flutter/material.dart';
+
+import '../../../screens/main/components/side_menu.dart';
+import '../../../widgets/window_bar.dart';
+
+enum ChecklistAnswer { sim, nao, naoAplica }
+
+class ChecklistLiberacaoPage extends StatefulWidget {
+  const ChecklistLiberacaoPage({super.key});
+
+  @override
+  State<ChecklistLiberacaoPage> createState() => _ChecklistLiberacaoPageState();
+}
+
+class _ChecklistLiberacaoPageState extends State<ChecklistLiberacaoPage> {
+  final _reController = TextEditingController();
+  final _maquinaController = TextEditingController();
+
+  final _questions = const [
+    'Todos recursos de medição necessários estão disponível na maquina ?',
+    'Para dispositivos com relógio centesimal esta partindo do 70 ?',
+    'Para dispositivos com relógio milesimal está partindo do 0 com o padrão?',
+    'Local dos instrumentos de controle está limpo?',
+  ];
+
+  final Map<int, ChecklistAnswer?> _answers = {};
+
+  @override
+  void dispose() {
+    _reController.dispose();
+    _maquinaController.dispose();
+    super.dispose();
+  }
+
+  void _updateAnswer(int index, ChecklistAnswer value) {
+    setState(() {
+      _answers[index] = value;
+    });
+  }
+
+  Widget _buildAnswerOption(int index, ChecklistAnswer value, String label) {
+    return RadioListTile<ChecklistAnswer>(
+      value: value,
+      groupValue: _answers[index],
+      dense: true,
+      contentPadding: EdgeInsets.zero,
+      title: Text(label),
+      onChanged: (answer) {
+        if (answer != null) {
+          _updateAnswer(index, answer);
+        }
+      },
+    );
+  }
+
+  DataRow _buildQuestionRow(int index, String question) {
+    return DataRow(
+      cells: [
+        DataCell(Text(question)),
+        DataCell(_buildAnswerOption(index, ChecklistAnswer.sim, 'Sim')),
+        DataCell(_buildAnswerOption(index, ChecklistAnswer.nao, 'Não')),
+        DataCell(_buildAnswerOption(index, ChecklistAnswer.naoAplica, 'N/A')),
+      ],
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: const WindowBar(title: 'Checklist de liberação', showMenu: true),
+      drawer: const SideMenu(current: SideMenuSection.dashboard),
+      body: LayoutBuilder(
+        builder: (context, constraints) {
+          final isWide = constraints.maxWidth > 800;
+          return SingleChildScrollView(
+            padding: const EdgeInsets.all(24),
+            child: Center(
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 900),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Wrap(
+                      spacing: 24,
+                      runSpacing: 16,
+                      children: [
+                        SizedBox(
+                          width: isWide ? 250 : double.infinity,
+                          child: TextField(
+                            controller: _reController,
+                            decoration: const InputDecoration(
+                              labelText: 'RE',
+                              border: OutlineInputBorder(),
+                            ),
+                          ),
+                        ),
+                        SizedBox(
+                          width: isWide ? 250 : double.infinity,
+                          child: TextField(
+                            controller: _maquinaController,
+                            decoration: const InputDecoration(
+                              labelText: 'Máquina',
+                              border: OutlineInputBorder(),
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 32),
+                    Card(
+                      elevation: 2,
+                      clipBehavior: Clip.antiAlias,
+                      child: Padding(
+                        padding: const EdgeInsets.all(16),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              'Instrumentos e Medição',
+                              style: Theme.of(context).textTheme.titleMedium,
+                            ),
+                            const SizedBox(height: 16),
+                            SingleChildScrollView(
+                              scrollDirection: Axis.horizontal,
+                              child: DataTable(
+                                columns: const [
+                                  DataColumn(label: Text('Pergunta')),
+                                  DataColumn(label: Text('Sim')),
+                                  DataColumn(label: Text('Não')),
+                                  DataColumn(label: Text('N/A')),
+                                ],
+                                rows: [
+                                  for (var i = 0; i < _questions.length; i++)
+                                    _buildQuestionRow(i, _questions[i]),
+                                ],
+                                headingRowColor:
+                                    MaterialStateProperty.resolveWith(
+                                      (states) => Theme.of(
+                                        context,
+                                      ).colorScheme.surfaceVariant,
+                                    ),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/screens/main/components/side_menu.dart
+++ b/lib/screens/main/components/side_menu.dart
@@ -17,6 +17,7 @@ import 'package:admin/features/login/login_page.dart';
 import 'package:admin/features/users/users_page.dart';
 import 'package:admin/services/auth_service.dart';
 import 'package:admin/features/shared/providers/search_flow_form_provider.dart';
+import 'package:admin/features/checklist_liberacao/presentation/checklist_liberacao_page.dart';
 
 enum SideMenuSection { mainMenu, dashboard, preparador, operador, finalizar }
 
@@ -39,20 +40,20 @@ class SideMenu extends ConsumerWidget {
   }
 
   void _showFlowLockedMessage(
-      BuildContext context,
-      SharedSearchFormState shared,
-      ) {
+    BuildContext context,
+    SharedSearchFormState shared,
+  ) {
     ScaffoldMessenger.of(
       context,
     ).showSnackBar(SnackBar(content: Text(_flowLockedMessage(shared))));
   }
 
   void _navigate(
-      BuildContext context,
-      WidgetRef ref,
-      Widget page, {
-        bool allowDuringActiveFlow = false,
-      }) {
+    BuildContext context,
+    WidgetRef ref,
+    Widget page, {
+    bool allowDuringActiveFlow = false,
+  }) {
     final navigator = Navigator.of(context, rootNavigator: true);
     final shared = ref.read(sharedSearchFormProvider);
     final hasActiveFlow = shared.isActive;
@@ -108,6 +109,11 @@ class SideMenu extends ConsumerWidget {
           title: 'Exportar relatórios',
           svgSrc: 'assets/icons/menu_doc.svg',
           press: () => _navigate(context, ref, const ExportRelatoriosPage()),
+        ),
+        DrawerListTile(
+          title: 'Checklist de liberação',
+          svgSrc: 'assets/icons/menu_task.svg',
+          press: () => _navigate(context, ref, const ChecklistLiberacaoPage()),
         ),
         DrawerListTile(
           title: 'Tempo por OS',


### PR DESCRIPTION
## Summary
- add a standalone checklist de liberação page with RE e Máquina inputs and instrument checklist options
- expose the new screen from the dashboard side menu for quick access

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de6ad198148331ab3f81fb30ba630b