### PR TITLE
Implement checklist de liberação registration flow

### DIFF
--- a/BD.sql
+++ b/BD.sql
@@ -110,6 +110,22 @@ CREATE TABLE `preparador_liberacao_item` (
   `observacao` text DEFAULT NULL,
   `created_at` timestamp NOT NULL DEFAULT current_timestamp()
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+CREATE TABLE `checklist_liberacao` (
+  `id` bigint(20) NOT NULL,
+  `re` varchar(64) NOT NULL,
+  `grupo_maquina` varchar(128) NOT NULL,
+  `maquina` varchar(128) NOT NULL,
+  `created_at` timestamp NOT NULL DEFAULT current_timestamp()
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+CREATE TABLE `checklist_liberacao_item` (
+  `id` bigint(20) NOT NULL,
+  `checklist_id` bigint(20) NOT NULL,
+  `ordem` int(11) NOT NULL,
+  `grupo` varchar(128) NOT NULL,
+  `pergunta` text NOT NULL,
+  `resposta` varchar(16) NOT NULL,
+  `created_at` timestamp NOT NULL DEFAULT current_timestamp()
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 CREATE TABLE `preparador_registro` (
   `id` bigint(20) NOT NULL,
   `os` varchar(64) NOT NULL,
@@ -514,6 +530,22 @@ ALTER TABLE `preparador_liberacao_item`
   ADD UNIQUE KEY `uq_pl_item` (`liberacao_id`,`idx_medida`);
 
 --
+-- Índices para tabela `checklist_liberacao`
+--
+ALTER TABLE `checklist_liberacao`
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `idx_checklist_re` (`re`),
+  ADD KEY `idx_checklist_maquina` (`maquina`),
+  ADD KEY `idx_checklist_created` (`created_at`);
+
+--
+-- Índices para tabela `checklist_liberacao_item`
+--
+ALTER TABLE `checklist_liberacao_item`
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `idx_cl_item_checklist` (`checklist_id`);
+
+--
 -- Índices para tabela `preparador_registro`
 --
 ALTER TABLE `preparador_registro`
@@ -577,6 +609,18 @@ ALTER TABLE `preparador_liberacao_item`
   MODIFY `id` bigint(20) NOT NULL AUTO_INCREMENT;
 
 --
+-- AUTO_INCREMENT de tabela `checklist_liberacao`
+--
+ALTER TABLE `checklist_liberacao`
+  MODIFY `id` bigint(20) NOT NULL AUTO_INCREMENT;
+
+--
+-- AUTO_INCREMENT de tabela `checklist_liberacao_item`
+--
+ALTER TABLE `checklist_liberacao_item`
+  MODIFY `id` bigint(20) NOT NULL AUTO_INCREMENT;
+
+--
 -- AUTO_INCREMENT de tabela `preparador_registro`
 --
 ALTER TABLE `preparador_registro`
@@ -633,6 +677,12 @@ ALTER TABLE `preparador_liberacao`
 --
 ALTER TABLE `preparador_liberacao_item`
   ADD CONSTRAINT `fk_pl_item_pl` FOREIGN KEY (`liberacao_id`) REFERENCES `preparador_liberacao` (`id`) ON DELETE CASCADE;
+
+--
+-- Limitadores para a tabela `checklist_liberacao_item`
+--
+ALTER TABLE `checklist_liberacao_item`
+  ADD CONSTRAINT `fk_cl_item_checklist` FOREIGN KEY (`checklist_id`) REFERENCES `checklist_liberacao` (`id`) ON DELETE CASCADE;
 
 --
 -- Limitadores para a tabela `preparador_registro`

--- a/app_db.py
+++ b/app_db.py
@@ -383,6 +383,38 @@ def _ensure_schema():
             )
             cur.execute(
                 """
+                CREATE TABLE IF NOT EXISTS checklist_liberacao (
+                  id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                  re VARCHAR(64) NOT NULL,
+                  grupo_maquina VARCHAR(128) NOT NULL,
+                  maquina VARCHAR(128) NOT NULL,
+                  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                  KEY idx_checklist_re (re),
+                  KEY idx_checklist_maquina (maquina),
+                  KEY idx_checklist_created (created_at)
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+                """
+            )
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS checklist_liberacao_item (
+                  id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                  checklist_id BIGINT NOT NULL,
+                  ordem INT NOT NULL,
+                  grupo VARCHAR(128) NOT NULL,
+                  pergunta TEXT NOT NULL,
+                  resposta VARCHAR(16) NOT NULL,
+                  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                  KEY idx_cl_item_checklist (checklist_id),
+                  CONSTRAINT fk_cl_item_checklist
+                    FOREIGN KEY (checklist_id)
+                    REFERENCES checklist_liberacao(id)
+                    ON DELETE CASCADE
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+                """
+            )
+            cur.execute(
+                """
                   CREATE TABLE IF NOT EXISTS maquinas (
                     codigo VARCHAR(64) NOT NULL PRIMARY KEY,
                     categoria VARCHAR(128) DEFAULT NULL,
@@ -2912,6 +2944,83 @@ def update_machine(codigo: str):
             )
         c.commit()
     return jsonify({"status": "ok", "codigo": new_codigo, "categoria": categoria})
+
+
+@app.route("/checklist/liberacao", methods=["POST"])
+def registrar_checklist_liberacao():
+    data = request.get_json(silent=True) or {}
+    re = (data.get("re") or "").strip()
+    grupo_maquina = (data.get("grupo_maquina") or "").strip()
+    maquina = (data.get("maquina") or "").strip()
+    respostas_raw = data.get("respostas")
+
+    if not re:
+        return jsonify({"error": "campo 're' obrigatório"}), 400
+    if not grupo_maquina:
+        return jsonify({"error": "campo 'grupo_maquina' obrigatório"}), 400
+    if not maquina:
+        return jsonify({"error": "campo 'maquina' obrigatório"}), 400
+    if not isinstance(respostas_raw, list) or not respostas_raw:
+        return jsonify({"error": "lista de respostas obrigatória"}), 400
+    if not re.isdigit():
+        return jsonify({"error": "campo 're' deve conter apenas números"}), 400
+
+    allowed_answers = {"sim", "nao", "nao_aplica"}
+    respostas_formatadas: List[Tuple[int, str, str, str]] = []
+    for idx, raw in enumerate(respostas_raw):
+        if not isinstance(raw, dict):
+            continue
+        pergunta = (raw.get("pergunta") or "").strip()
+        grupo_resposta = (raw.get("grupo") or grupo_maquina).strip()
+        resposta = (raw.get("resposta") or "").strip().lower()
+        ordem_raw = raw.get("ordem")
+        try:
+            ordem = int(ordem_raw)
+        except (TypeError, ValueError):
+            ordem = idx
+
+        if not pergunta or resposta not in allowed_answers:
+            continue
+        if not grupo_resposta:
+            grupo_resposta = grupo_maquina
+
+        respostas_formatadas.append(
+            (
+                ordem,
+                grupo_resposta[:128],
+                pergunta[:1024],
+                resposta,
+            )
+        )
+
+    if not respostas_formatadas:
+        return jsonify({"error": "nenhuma resposta válida informada"}), 400
+
+    respostas_formatadas.sort(key=lambda item: item[0])
+    with _conn_db(DB_NAME) as c:
+        with c.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO checklist_liberacao (re, grupo_maquina, maquina)
+                VALUES (%s, %s, %s)
+                """,
+                (re[:64], grupo_maquina[:128], maquina[:128]),
+            )
+            checklist_id = cur.lastrowid
+            cur.executemany(
+                """
+                INSERT INTO checklist_liberacao_item
+                  (checklist_id, ordem, grupo, pergunta, resposta)
+                VALUES (%s, %s, %s, %s, %s)
+                """,
+                [
+                    (checklist_id, ordem, grupo, pergunta, resposta)
+                    for ordem, grupo, pergunta, resposta in respostas_formatadas
+                ],
+            )
+        c.commit()
+
+    return jsonify({"status": "ok", "id": checklist_id})
 
 
 @app.route("/relatorios/sql")

--- a/lib/features/checklist_liberacao/presentation/checklist_liberacao_page.dart
+++ b/lib/features/checklist_liberacao/presentation/checklist_liberacao_page.dart
@@ -1,0 +1,576 @@
+import 'dart:collection';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../../../screens/main/components/side_menu.dart';
+import '../../../services/checklist_liberacao_service.dart';
+import '../../../services/machine_service.dart';
+import '../../../widgets/window_bar.dart';
+
+enum ChecklistAnswer { sim, nao, naoAplica }
+
+extension ChecklistAnswerLabel on ChecklistAnswer {
+  String get label {
+    switch (this) {
+      case ChecklistAnswer.sim:
+        return 'Sim';
+      case ChecklistAnswer.nao:
+        return 'Não';
+      case ChecklistAnswer.naoAplica:
+        return 'N/A';
+    }
+  }
+
+  String get apiValue {
+    switch (this) {
+      case ChecklistAnswer.sim:
+        return 'sim';
+      case ChecklistAnswer.nao:
+        return 'nao';
+      case ChecklistAnswer.naoAplica:
+        return 'nao_aplica';
+    }
+  }
+}
+
+class ChecklistQuestion {
+  const ChecklistQuestion({required this.id, required this.text});
+
+  final String id;
+  final String text;
+}
+
+class ChecklistGroup {
+  const ChecklistGroup({
+    required this.id,
+    required this.title,
+    required this.questions,
+  });
+
+  final String id;
+  final String title;
+  final List<ChecklistQuestion> questions;
+}
+
+const List<ChecklistGroup> _checklistGroups = [
+  ChecklistGroup(
+    id: 'setor_organizacao',
+    title: 'Setor e organização',
+    questions: [
+      ChecklistQuestion(
+        id: 'setor_organizacao_limpeza',
+        text: 'O setor está organizado e limpo? 5S',
+      ),
+      ChecklistQuestion(
+        id: 'setor_organizacao_iluminacao',
+        text: 'A iluminação está adequada?',
+      ),
+      ChecklistQuestion(
+        id: 'setor_organizacao_identificacao',
+        text: 'Entrada e saída de processo está identificada?',
+      ),
+      ChecklistQuestion(
+        id: 'setor_organizacao_segregacao',
+        text: 'Pessoal para segregar produção não conforme?',
+      ),
+      ChecklistQuestion(
+        id: 'setor_organizacao_materiais',
+        text: 'Possui material necessário para rotina operacional?',
+      ),
+    ],
+  ),
+  ChecklistGroup(
+    id: 'produto_documentos',
+    title: 'Produto e Documentos',
+    questions: [
+      ChecklistQuestion(
+        id: 'produto_documentos_disponivel',
+        text: 'A documentação está disponível? (FOR08, FOR09, FOR13, FOR31)',
+      ),
+      ChecklistQuestion(
+        id: 'produto_documentos_placa',
+        text: 'A placa de liberação está no recipiente?',
+      ),
+      ChecklistQuestion(
+        id: 'produto_documentos_dados',
+        text: 'Possui todos os dados na ordem?',
+      ),
+      ChecklistQuestion(
+        id: 'produto_documentos_estado',
+        text: 'Os documentos estão em bom estado?',
+      ),
+    ],
+  ),
+  ChecklistGroup(
+    id: 'maquinas_equipamentos',
+    title: 'Máquinas e Equipamentos',
+    questions: [
+      ChecklistQuestion(
+        id: 'maquinas_ruidos',
+        text: 'Possui ruídos estranhos na máquina?',
+      ),
+      ChecklistQuestion(
+        id: 'maquinas_vazamento_ar',
+        text: 'Existem vazamentos de ar/óleo nas mangueiras e engates rápidos?',
+      ),
+      ChecklistQuestion(
+        id: 'maquinas_vazamento_outros',
+        text: 'Existe vazamento de óleo/água/hidráulico e pneumático?',
+      ),
+      ChecklistQuestion(
+        id: 'maquinas_mangueiras',
+        text: 'As mangueiras estão em bom estado?',
+      ),
+      ChecklistQuestion(
+        id: 'maquinas_nivel_oleo',
+        text: 'O nível de óleo está correto?',
+      ),
+      ChecklistQuestion(
+        id: 'maquinas_filtros',
+        text: 'Os filtros estão limpos?',
+      ),
+      ChecklistQuestion(
+        id: 'maquinas_itens_emergencia',
+        text:
+            'Os itens de emergência (botão, seta, luz gira-gira) estão funcionando?',
+      ),
+      ChecklistQuestion(
+        id: 'maquinas_comandos_protecao',
+        text: 'Os comandos estão com proteção e identificação?',
+      ),
+      ChecklistQuestion(
+        id: 'maquinas_comandos_ruidos',
+        text: 'Os comandos apresentam ruídos ou estão com problemas?',
+      ),
+      ChecklistQuestion(
+        id: 'maquinas_leds',
+        text: 'Os leds de sinalização estão funcionando?',
+      ),
+    ],
+  ),
+  ChecklistGroup(
+    id: 'instrumentos_medicao',
+    title: 'Instrumentos e Medição',
+    questions: [
+      ChecklistQuestion(
+        id: 'instrumentos_recursos',
+        text:
+            'Todos os recursos de medição necessários estão disponíveis na máquina?',
+      ),
+      ChecklistQuestion(
+        id: 'instrumentos_centesimal',
+        text: 'Para dispositivos com relógio centesimal está partindo do 70?',
+      ),
+      ChecklistQuestion(
+        id: 'instrumentos_milesimal',
+        text:
+            'Para dispositivos com relógio milesimal está partindo do 0 com o padrão?',
+      ),
+      ChecklistQuestion(
+        id: 'instrumentos_local_limpo',
+        text: 'O local dos instrumentos de controle está limpo?',
+      ),
+      ChecklistQuestion(
+        id: 'instrumentos_local_identificado',
+        text: 'O local dos instrumentos de controle está identificado?',
+      ),
+    ],
+  ),
+];
+
+class ChecklistLiberacaoPage extends StatefulWidget {
+  const ChecklistLiberacaoPage({super.key});
+
+  @override
+  State<ChecklistLiberacaoPage> createState() => _ChecklistLiberacaoPageState();
+}
+
+class _ChecklistLiberacaoPageState extends State<ChecklistLiberacaoPage> {
+  final _formKey = GlobalKey<FormState>();
+  final _reController = TextEditingController();
+  final Map<String, ChecklistAnswer?> _answers = {};
+
+  AutovalidateMode _autovalidateMode = AutovalidateMode.disabled;
+  bool _loadingMaquinas = false;
+  bool _salvando = false;
+
+  List<String> _grupos = const [];
+  Map<String, List<String>> _maquinasPorGrupo = const {};
+
+  String? _grupoSelecionado;
+  String? _maquinaSelecionada;
+
+  @override
+  void initState() {
+    super.initState();
+    _carregarMaquinas();
+  }
+
+  @override
+  void dispose() {
+    _reController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _carregarMaquinas() async {
+    setState(() => _loadingMaquinas = true);
+    try {
+      final lista = await MachineService().fetchMaquinas();
+      final maquinasPorGrupo = <String, SplayTreeSet<String>>{};
+      for (final maquina in lista) {
+        final categoria = maquina.categoria.trim();
+        if (categoria.isEmpty) continue;
+        final codigo = maquina.codigo.trim();
+        if (codigo.isEmpty) continue;
+        maquinasPorGrupo.putIfAbsent(categoria, SplayTreeSet.new).add(codigo);
+      }
+
+      final gruposOrdenados = maquinasPorGrupo.keys.toList()..sort();
+      final mapaOrdenado = {
+        for (final entry in maquinasPorGrupo.entries)
+          entry.key: entry.value.toList(growable: false),
+      };
+
+      setState(() {
+        _grupos = gruposOrdenados;
+        _maquinasPorGrupo = mapaOrdenado;
+        if (_grupoSelecionado != null &&
+            !_maquinasPorGrupo.containsKey(_grupoSelecionado)) {
+          _grupoSelecionado = null;
+          _maquinaSelecionada = null;
+        } else if (_grupoSelecionado != null) {
+          final maquinas = _maquinasPorGrupo[_grupoSelecionado];
+          if (maquinas == null || !maquinas.contains(_maquinaSelecionada)) {
+            _maquinaSelecionada = null;
+          }
+        }
+      });
+    } catch (error) {
+      if (!mounted) return;
+      _showSnackBar('Falha ao carregar máquinas: ${error.toString()}');
+    } finally {
+      if (mounted) {
+        setState(() => _loadingMaquinas = false);
+      }
+    }
+  }
+
+  void _showSnackBar(String message, {bool erro = true}) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(message),
+        backgroundColor: erro ? Theme.of(context).colorScheme.error : null,
+      ),
+    );
+  }
+
+  void _atualizarResposta(String questionId, ChecklistAnswer value) {
+    setState(() {
+      _answers[questionId] = value;
+    });
+  }
+
+  Widget _buildRadioCell(String questionId, ChecklistAnswer value) {
+    return Center(
+      child: Radio<ChecklistAnswer>(
+        value: value,
+        groupValue: _answers[questionId],
+        onChanged: (answer) {
+          if (answer != null) {
+            _atualizarResposta(questionId, answer);
+          }
+        },
+        materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+        visualDensity: VisualDensity.compact,
+      ),
+    );
+  }
+
+  DataRow _buildQuestionRow(ChecklistQuestion question) {
+    return DataRow(
+      cells: [
+        DataCell(
+          ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 520),
+            child: Text(question.text),
+          ),
+        ),
+        DataCell(_buildRadioCell(question.id, ChecklistAnswer.sim)),
+        DataCell(_buildRadioCell(question.id, ChecklistAnswer.nao)),
+        DataCell(_buildRadioCell(question.id, ChecklistAnswer.naoAplica)),
+      ],
+    );
+  }
+
+  Widget _buildGroupCard(ChecklistGroup group, BuildContext context) {
+    return Card(
+      elevation: 2,
+      clipBehavior: Clip.antiAlias,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(group.title, style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 16),
+            SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: DataTable(
+                columns: const [
+                  DataColumn(label: Text('Pergunta')),
+                  DataColumn(label: Text('Sim')),
+                  DataColumn(label: Text('Não')),
+                  DataColumn(label: Text('N/A')),
+                ],
+                rows: group.questions.map(_buildQuestionRow).toList(),
+                headingRowColor: MaterialStateProperty.resolveWith(
+                  (states) => Theme.of(context).colorScheme.surfaceVariant,
+                ),
+                horizontalMargin: 12,
+                columnSpacing: 24,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  List<String> get _maquinasDisponiveis {
+    if (_grupoSelecionado == null) return const [];
+    return _maquinasPorGrupo[_grupoSelecionado] ?? const [];
+  }
+
+  Future<void> _salvar() async {
+    final form = _formKey.currentState;
+    if (form == null) return;
+    setState(() => _autovalidateMode = AutovalidateMode.always);
+    if (!form.validate()) {
+      _showSnackBar('Preencha os dados obrigatórios antes de salvar.');
+      return;
+    }
+
+    final unanswered = _checklistGroups
+        .expand((group) => group.questions)
+        .where((question) => _answers[question.id] == null);
+
+    if (unanswered.isNotEmpty) {
+      _showSnackBar('Responda todas as perguntas do checklist.');
+      return;
+    }
+
+    final respostas = <Map<String, dynamic>>[];
+    var ordem = 0;
+    for (final group in _checklistGroups) {
+      for (final question in group.questions) {
+        final answer = _answers[question.id];
+        if (answer == null) continue;
+        respostas.add({
+          'grupo': group.title,
+          'pergunta': question.text,
+          'resposta': answer.apiValue,
+          'ordem': ordem,
+        });
+        ordem++;
+      }
+    }
+
+    if (respostas.isEmpty) {
+      _showSnackBar('Não há respostas válidas para salvar.');
+      return;
+    }
+
+    setState(() => _salvando = true);
+    try {
+      await ChecklistLiberacaoService().registrarChecklist(
+        re: _reController.text.trim(),
+        grupoMaquina: _grupoSelecionado!,
+        maquina: _maquinaSelecionada!,
+        respostas: respostas,
+      );
+      if (!mounted) return;
+      _showSnackBar('Checklist registrado com sucesso!', erro: false);
+      setState(() {
+        _answers.clear();
+        _reController.clear();
+        _grupoSelecionado = null;
+        _maquinaSelecionada = null;
+        _autovalidateMode = AutovalidateMode.disabled;
+      });
+      form.reset();
+    } catch (error) {
+      if (!mounted) return;
+      final message = error.toString().replaceFirst('Exception: ', '');
+      _showSnackBar('Falha ao registrar checklist: $message');
+    } finally {
+      if (mounted) {
+        setState(() => _salvando = false);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: const WindowBar(title: 'Checklist de liberação', showMenu: true),
+      drawer: const SideMenu(current: SideMenuSection.dashboard),
+      body: LayoutBuilder(
+        builder: (context, constraints) {
+          final isWide = constraints.maxWidth > 880;
+          return SingleChildScrollView(
+            padding: const EdgeInsets.all(24),
+            child: Center(
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 1000),
+                child: Form(
+                  key: _formKey,
+                  autovalidateMode: _autovalidateMode,
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Wrap(
+                        spacing: 24,
+                        runSpacing: 16,
+                        children: [
+                          SizedBox(
+                            width: isWide ? 240 : double.infinity,
+                            child: TextFormField(
+                              controller: _reController,
+                              decoration: const InputDecoration(
+                                labelText: 'RE',
+                                border: OutlineInputBorder(),
+                              ),
+                              textInputAction: TextInputAction.next,
+                              keyboardType: TextInputType.number,
+                              inputFormatters: [
+                                FilteringTextInputFormatter.digitsOnly,
+                              ],
+                              validator: (value) {
+                                final texto = (value ?? '').trim();
+                                if (texto.isEmpty) {
+                                  return 'Informe o RE';
+                                }
+                                if (!RegExp(r'^[0-9]+$').hasMatch(texto)) {
+                                  return 'Informe apenas números';
+                                }
+                                return null;
+                              },
+                            ),
+                          ),
+                          SizedBox(
+                            width: isWide ? 240 : double.infinity,
+                            child: DropdownButtonFormField<String>(
+                              value: _grupoSelecionado,
+                              decoration: InputDecoration(
+                                labelText: 'Grupo de máquinas',
+                                border: const OutlineInputBorder(),
+                                suffixIcon: _loadingMaquinas
+                                    ? const Padding(
+                                        padding: EdgeInsets.all(8),
+                                        child: SizedBox(
+                                          height: 20,
+                                          width: 20,
+                                          child: CircularProgressIndicator(
+                                            strokeWidth: 2,
+                                          ),
+                                        ),
+                                      )
+                                    : null,
+                              ),
+                              items: _grupos
+                                  .map(
+                                    (grupo) => DropdownMenuItem(
+                                      value: grupo,
+                                      child: Text(grupo),
+                                    ),
+                                  )
+                                  .toList(),
+                              onChanged: _loadingMaquinas
+                                  ? null
+                                  : (value) {
+                                      setState(() {
+                                        _grupoSelecionado = value;
+                                        _maquinaSelecionada = null;
+                                      });
+                                    },
+                              validator: (value) {
+                                if ((_grupos.isNotEmpty ||
+                                        _grupoSelecionado != null) &&
+                                    (value == null || value.isEmpty)) {
+                                  return 'Selecione um grupo de máquinas';
+                                }
+                                return null;
+                              },
+                            ),
+                          ),
+                          SizedBox(
+                            width: isWide ? 240 : double.infinity,
+                            child: DropdownButtonFormField<String>(
+                              value: _maquinaSelecionada,
+                              decoration: const InputDecoration(
+                                labelText: 'Máquina',
+                                border: OutlineInputBorder(),
+                              ),
+                              items: _maquinasDisponiveis
+                                  .map(
+                                    (maquina) => DropdownMenuItem(
+                                      value: maquina,
+                                      child: Text(maquina),
+                                    ),
+                                  )
+                                  .toList(),
+                              onChanged: _maquinasDisponiveis.isEmpty
+                                  ? null
+                                  : (value) {
+                                      setState(
+                                        () => _maquinaSelecionada = value,
+                                      );
+                                    },
+                              validator: (value) {
+                                if (_maquinasDisponiveis.isEmpty) {
+                                  return 'Selecione um grupo para listar as máquinas';
+                                }
+                                if (value == null || value.isEmpty) {
+                                  return 'Selecione a máquina';
+                                }
+                                return null;
+                              },
+                            ),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 32),
+                      for (final group in _checklistGroups) ...[
+                        _buildGroupCard(group, context),
+                        const SizedBox(height: 24),
+                      ],
+                      Align(
+                        alignment: Alignment.centerRight,
+                        child: FilledButton.icon(
+                          onPressed: _salvando ? null : _salvar,
+                          icon: _salvando
+                              ? const SizedBox(
+                                  width: 18,
+                                  height: 18,
+                                  child: CircularProgressIndicator(
+                                    strokeWidth: 2,
+                                  ),
+                                )
+                              : const Icon(Icons.save_outlined),
+                          label: Text(
+                            _salvando ? 'Salvando...' : 'Salvar checklist',
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/screens/main/components/side_menu.dart
+++ b/lib/screens/main/components/side_menu.dart
@@ -17,6 +17,7 @@ import 'package:admin/features/login/login_page.dart';
 import 'package:admin/features/users/users_page.dart';
 import 'package:admin/services/auth_service.dart';
 import 'package:admin/features/shared/providers/search_flow_form_provider.dart';
+import 'package:admin/features/checklist_liberacao/presentation/checklist_liberacao_page.dart';
 
 enum SideMenuSection { mainMenu, dashboard, preparador, operador, finalizar }
 
@@ -39,20 +40,20 @@ class SideMenu extends ConsumerWidget {
   }
 
   void _showFlowLockedMessage(
-      BuildContext context,
-      SharedSearchFormState shared,
-      ) {
+    BuildContext context,
+    SharedSearchFormState shared,
+  ) {
     ScaffoldMessenger.of(
       context,
     ).showSnackBar(SnackBar(content: Text(_flowLockedMessage(shared))));
   }
 
   void _navigate(
-      BuildContext context,
-      WidgetRef ref,
-      Widget page, {
-        bool allowDuringActiveFlow = false,
-      }) {
+    BuildContext context,
+    WidgetRef ref,
+    Widget page, {
+    bool allowDuringActiveFlow = false,
+  }) {
     final navigator = Navigator.of(context, rootNavigator: true);
     final shared = ref.read(sharedSearchFormProvider);
     final hasActiveFlow = shared.isActive;
@@ -108,6 +109,11 @@ class SideMenu extends ConsumerWidget {
           title: 'Exportar relatórios',
           svgSrc: 'assets/icons/menu_doc.svg',
           press: () => _navigate(context, ref, const ExportRelatoriosPage()),
+        ),
+        DrawerListTile(
+          title: 'Checklist de liberação',
+          svgSrc: 'assets/icons/menu_task.svg',
+          press: () => _navigate(context, ref, const ChecklistLiberacaoPage()),
         ),
         DrawerListTile(
           title: 'Tempo por OS',

--- a/lib/services/checklist_liberacao_service.dart
+++ b/lib/services/checklist_liberacao_service.dart
@@ -1,0 +1,46 @@
+import 'dart:convert';
+
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:http/http.dart' as http;
+
+class ChecklistLiberacaoService {
+  ChecklistLiberacaoService({http.Client? client, String? baseUrl})
+    : _client = client ?? http.Client(),
+      _baseUrl =
+          baseUrl ?? dotenv.env['API_BASE_URL'] ?? 'http://localhost:5000';
+
+  final http.Client _client;
+  final String _baseUrl;
+
+  Future<void> registrarChecklist({
+    required String re,
+    required String grupoMaquina,
+    required String maquina,
+    required List<Map<String, dynamic>> respostas,
+  }) async {
+    final uri = Uri.parse('$_baseUrl/checklist/liberacao');
+    final resp = await _client.post(
+      uri,
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode({
+        're': re,
+        'grupo_maquina': grupoMaquina,
+        'maquina': maquina,
+        'respostas': respostas,
+      }),
+    );
+
+    if (resp.statusCode != 200) {
+      var message = 'Falha ao registrar checklist';
+      try {
+        final decoded = jsonDecode(resp.body);
+        if (decoded is Map && decoded['error'] is String) {
+          message = decoded['error'] as String;
+        }
+      } catch (_) {
+        // Ignora erros de parse e mantém a mensagem padrão.
+      }
+      throw Exception(message);
+    }
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -263,26 +263,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -500,10 +500,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.6"
   typed_data:
     dependency: transitive
     description:
@@ -540,10 +540,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary
- expand the checklist de liberação page with full grouped questions, validation, and machine filtering tied to the registered machine catalog
- add a ChecklistLiberacaoService and backend route plus schema to persist checklist submissions
- extend BD.sql with the checklist tables, indexes, and constraints

## Testing
- flutter analyze

------
https://chatgpt.com/codex/tasks/task_e_68de6ad198148331ab3f81fb30ba630b