### PR TITLE
Fill checklist cards with full-width grid layout

### DIFF
--- a/lib/features/checklist_liberacao/presentation/checklist_liberacao_page.dart
+++ b/lib/features/checklist_liberacao/presentation/checklist_liberacao_page.dart
@@ -1,4 +1,5 @@
 import 'dart:collection';
+import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -53,6 +54,8 @@ class ChecklistGroup {
   final String title;
   final List<ChecklistQuestion> questions;
 }
+
+const double _answerColumnWidth = 88;
 
 const List<ChecklistGroup> _checklistGroups = [
   ChecklistGroup(
@@ -208,7 +211,6 @@ class _ChecklistLiberacaoPageState extends State<ChecklistLiberacaoPage> {
     _carregarMaquinas();
   }
 
-
   @override
   void dispose() {
     _reController.dispose();
@@ -274,33 +276,123 @@ class _ChecklistLiberacaoPageState extends State<ChecklistLiberacaoPage> {
   }
 
   Widget _buildRadioCell(String questionId, ChecklistAnswer value) {
-    return Center(
-      child: Radio<ChecklistAnswer>(
-        value: value,
-        groupValue: _answers[questionId],
-        onChanged: (answer) {
-          if (answer != null) {
-            _atualizarResposta(questionId, answer);
-          }
-        },
-        materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-        visualDensity: VisualDensity.compact,
+    final selectedAnswer = _answers[questionId];
+    final isSelected = selectedAnswer == value;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Center(
+        child: InkResponse(
+          onTap: () => _atualizarResposta(questionId, value),
+          customBorder: const CircleBorder(),
+          radius: 24,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 4),
+            child: _buildAnswerIcon(
+              questionId: questionId,
+              answer: value,
+              isSelected: isSelected,
+            ),
+          ),
+        ),
       ),
     );
   }
 
-  DataRow _buildQuestionRow(ChecklistQuestion question) {
-    return DataRow(
-      cells: [
-        DataCell(
-          ConstrainedBox(
-            constraints: const BoxConstraints(maxWidth: 520),
-            child: Text(question.text),
-          ),
+  Widget _buildAnswerIcon({
+    required String questionId,
+    required ChecklistAnswer answer,
+    required bool isSelected,
+  }) {
+    final iconData = _iconDataForAnswer(answer);
+    final activeColor = _colorForAnswer(answer);
+    final inactiveColor = Colors.blueGrey.shade500;
+
+    return AnimatedContainer(
+      key: ValueKey('${questionId}_${answer.name}'),
+      duration: const Duration(milliseconds: 180),
+      curve: Curves.easeOutCubic,
+      padding: const EdgeInsets.all(4),
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        boxShadow: isSelected
+            ? [
+                BoxShadow(
+                  color: activeColor.withOpacity(0.4),
+                  blurRadius: 12,
+                  spreadRadius: 1,
+                ),
+              ]
+            : null,
+      ),
+      child: Icon(
+        iconData,
+        color: isSelected ? activeColor : inactiveColor,
+        size: 26,
+      ),
+    );
+  }
+
+  IconData _iconDataForAnswer(ChecklistAnswer answer) {
+    switch (answer) {
+      case ChecklistAnswer.sim:
+        return Icons.check_circle_rounded;
+      case ChecklistAnswer.nao:
+        return Icons.cancel_rounded;
+      case ChecklistAnswer.naoAplica:
+        return Icons.help_center_rounded;
+    }
+  }
+
+  Color _colorForAnswer(ChecklistAnswer answer) {
+    switch (answer) {
+      case ChecklistAnswer.sim:
+        return Colors.greenAccent.shade400;
+      case ChecklistAnswer.nao:
+        return Colors.redAccent.shade200;
+      case ChecklistAnswer.naoAplica:
+        return Colors.blueAccent.shade200;
+    }
+  }
+
+  TableRow _buildQuestionRow(ChecklistQuestion question) {
+    return TableRow(
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+          child: Text(question.text),
         ),
-        DataCell(_buildRadioCell(question.id, ChecklistAnswer.sim)),
-        DataCell(_buildRadioCell(question.id, ChecklistAnswer.nao)),
-        DataCell(_buildRadioCell(question.id, ChecklistAnswer.naoAplica)),
+        _buildRadioCell(question.id, ChecklistAnswer.sim),
+        _buildRadioCell(question.id, ChecklistAnswer.nao),
+        _buildRadioCell(question.id, ChecklistAnswer.naoAplica),
+      ],
+    );
+  }
+
+  TableRow _buildHeaderRow(BuildContext context) {
+    final textStyle = Theme.of(context)
+        .textTheme
+        .labelLarge
+        ?.copyWith(fontWeight: FontWeight.w600);
+    return TableRow(
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surfaceVariant,
+      ),
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+          child: Text('Pergunta', style: textStyle),
+        ),
+        for (final answer in ChecklistAnswer.values)
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 12),
+            child: Center(
+              child: Text(
+                answer.label,
+                style: textStyle,
+              ),
+            ),
+          ),
       ],
     );
   }
@@ -316,21 +408,41 @@ class _ChecklistLiberacaoPageState extends State<ChecklistLiberacaoPage> {
           children: [
             Text(group.title, style: Theme.of(context).textTheme.titleMedium),
             const SizedBox(height: 16),
-            SingleChildScrollView(
-              scrollDirection: Axis.horizontal,
-              child: DataTable(
-                columns: const [
-                  DataColumn(label: Text('Pergunta')),
-                  DataColumn(label: Text('Sim')),
-                  DataColumn(label: Text('Não')),
-                  DataColumn(label: Text('N/A')),
-                ],
-                rows: group.questions.map(_buildQuestionRow).toList(),
-                headingRowColor: MaterialStateProperty.resolveWith(
-                  (states) => Theme.of(context).colorScheme.surfaceVariant,
+            SizedBox(
+              width: double.infinity,
+              child: Table(
+                columnWidths: const {
+                  0: FlexColumnWidth(),
+                  1: FixedColumnWidth(_answerColumnWidth),
+                  2: FixedColumnWidth(_answerColumnWidth),
+                  3: FixedColumnWidth(_answerColumnWidth),
+                },
+                defaultVerticalAlignment: TableCellVerticalAlignment.middle,
+                border: TableBorder(
+                  top: BorderSide(
+                    color: Theme.of(context).dividerColor.withOpacity(0.4),
+                  ),
+                  left: BorderSide(
+                    color: Theme.of(context).dividerColor.withOpacity(0.4),
+                  ),
+                  right: BorderSide(
+                    color: Theme.of(context).dividerColor.withOpacity(0.4),
+                  ),
+                  bottom: BorderSide(
+                    color: Theme.of(context).dividerColor.withOpacity(0.4),
+                  ),
+                  horizontalInside: BorderSide(
+                    color: Theme.of(context).dividerColor.withOpacity(0.2),
+                  ),
+                  verticalInside: BorderSide(
+                    color: Theme.of(context).dividerColor.withOpacity(0.2),
+                  ),
                 ),
-                horizontalMargin: 12,
-                columnSpacing: 24,
+                children: [
+                  _buildHeaderRow(context),
+                  for (final question in group.questions)
+                    _buildQuestionRow(question),
+                ],
               ),
             ),
           ],
@@ -412,7 +524,6 @@ class _ChecklistLiberacaoPageState extends State<ChecklistLiberacaoPage> {
     }
   }
 
-
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -421,6 +532,13 @@ class _ChecklistLiberacaoPageState extends State<ChecklistLiberacaoPage> {
       body: LayoutBuilder(
         builder: (context, constraints) {
           final isWide = constraints.maxWidth > 880;
+          final double availableWidth = math.max(
+            0,
+            math.min(constraints.maxWidth - 48, 1000),
+          );
+          final double fieldWidth = isWide
+              ? math.min((availableWidth - 48) / 3, 280)
+              : double.infinity;
           return SingleChildScrollView(
             padding: const EdgeInsets.all(24),
             child: Center(
@@ -437,7 +555,7 @@ class _ChecklistLiberacaoPageState extends State<ChecklistLiberacaoPage> {
                         runSpacing: 16,
                         children: [
                           SizedBox(
-                            width: isWide ? 240 : double.infinity,
+                            width: isWide ? fieldWidth : null,
                             child: TextFormField(
                               controller: _reController,
                               decoration: const InputDecoration(
@@ -462,7 +580,7 @@ class _ChecklistLiberacaoPageState extends State<ChecklistLiberacaoPage> {
                             ),
                           ),
                           SizedBox(
-                            width: isWide ? 240 : double.infinity,
+                            width: isWide ? fieldWidth : null,
                             child: DropdownButtonFormField<String>(
                               value: _grupoSelecionado,
                               decoration: InputDecoration(
@@ -508,7 +626,7 @@ class _ChecklistLiberacaoPageState extends State<ChecklistLiberacaoPage> {
                             ),
                           ),
                           SizedBox(
-                            width: isWide ? 240 : double.infinity,
+                            width: isWide ? fieldWidth : null,
                             child: DropdownButtonFormField<String>(
                               value: _maquinaSelecionada,
                               decoration: const InputDecoration(
@@ -568,7 +686,6 @@ class _ChecklistLiberacaoPageState extends State<ChecklistLiberacaoPage> {
                       ),
                     ],
                   ),
-
                 ),
               ),
             ),


### PR DESCRIPTION
## Summary
- replace the checklist DataTable with a full-width Table layout that keeps the answer columns aligned across the card
- style the header row and answer cells with consistent padding so the grid remains visually balanced

## Testing
- flutter test

------
https://chatgpt.com/codex/tasks/task_e_68de7781e68c8331b14e9a9102341e63