### PR TITLE
Fix OS status reset and return to menu after key flows

### DIFF
--- a/app_db.py
+++ b/app_db.py
@@ -2062,6 +2062,12 @@ def operador_troca_os():
                             409,
                         )
 
+                cur.execute(
+                    "INSERT INTO ordem_servico (os) VALUES (%s)"
+                    " ON DUPLICATE KEY UPDATE os = VALUES(os)",
+                    (os_num,),
+                )
+
                 _registrar_pausa_operador(cur, os_num, re_op, part, op, motivo)
                 cur.execute(
                     "UPDATE ordem_servico SET status=%s WHERE os=%s",

--- a/lib/features/checklist_liberacao/presentation/checklist_liberacao_page.dart
+++ b/lib/features/checklist_liberacao/presentation/checklist_liberacao_page.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:collection';
 import 'dart:math' as math;
 
@@ -137,7 +138,7 @@ const List<ChecklistGroup> _checklistGroups = [
       ChecklistQuestion(
         id: 'maquinas_itens_emergencia',
         text:
-        'Os itens de emergência (botão, seta, luz gira-gira) estão funcionando?',
+            'Os itens de emergência (botão, seta, luz gira-gira) estão funcionando?',
       ),
       ChecklistQuestion(
         id: 'maquinas_comandos_protecao',
@@ -160,7 +161,7 @@ const List<ChecklistGroup> _checklistGroups = [
       ChecklistQuestion(
         id: 'instrumentos_recursos',
         text:
-        'Todos os recursos de medição necessários estão disponíveis na máquina?',
+            'Todos os recursos de medição necessários estão disponíveis na máquina?',
       ),
       ChecklistQuestion(
         id: 'instrumentos_centesimal',
@@ -169,7 +170,7 @@ const List<ChecklistGroup> _checklistGroups = [
       ChecklistQuestion(
         id: 'instrumentos_milesimal',
         text:
-        'Para dispositivos com relógio milesimal está partindo do 0 com o padrão?',
+            'Para dispositivos com relógio milesimal está partindo do 0 com o padrão?',
       ),
       ChecklistQuestion(
         id: 'instrumentos_local_limpo',
@@ -260,6 +261,16 @@ class _ChecklistLiberacaoPageState extends State<ChecklistLiberacaoPage> {
     }
   }
 
+  Future<void> _voltarParaMenuPrincipal() async {
+    if (!mounted) return;
+    await Future.delayed(const Duration(milliseconds: 350));
+    if (!mounted) return;
+    Navigator.of(
+      context,
+      rootNavigator: true,
+    ).popUntil((route) => route.isFirst);
+  }
+
   void _showSnackBar(String message, {bool erro = true}) {
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
@@ -317,12 +328,12 @@ class _ChecklistLiberacaoPageState extends State<ChecklistLiberacaoPage> {
         shape: BoxShape.circle,
         boxShadow: isSelected
             ? [
-          BoxShadow(
-            color: activeColor.withOpacity(0.4),
-            blurRadius: 12,
-            spreadRadius: 1,
-          ),
-        ]
+                BoxShadow(
+                  color: activeColor.withOpacity(0.4),
+                  blurRadius: 12,
+                  spreadRadius: 1,
+                ),
+              ]
             : null,
       ),
       child: Icon(
@@ -370,10 +381,9 @@ class _ChecklistLiberacaoPageState extends State<ChecklistLiberacaoPage> {
   }
 
   TableRow _buildHeaderRow(BuildContext context) {
-    final textStyle = Theme.of(context)
-        .textTheme
-        .labelLarge
-        ?.copyWith(fontWeight: FontWeight.w600);
+    final textStyle = Theme.of(
+      context,
+    ).textTheme.labelLarge?.copyWith(fontWeight: FontWeight.w600);
     return TableRow(
       decoration: BoxDecoration(
         color: Theme.of(context).colorScheme.surfaceVariant,
@@ -386,12 +396,7 @@ class _ChecklistLiberacaoPageState extends State<ChecklistLiberacaoPage> {
         for (final answer in ChecklistAnswer.values)
           Padding(
             padding: const EdgeInsets.symmetric(vertical: 12),
-            child: Center(
-              child: Text(
-                answer.label,
-                style: textStyle,
-              ),
-            ),
+            child: Center(child: Text(answer.label, style: textStyle)),
           ),
       ],
     );
@@ -513,6 +518,7 @@ class _ChecklistLiberacaoPageState extends State<ChecklistLiberacaoPage> {
         _autovalidateMode = AutovalidateMode.disabled;
       });
       form.reset();
+      unawaited(_voltarParaMenuPrincipal());
     } catch (error) {
       if (!mounted) return;
       final message = error.toString().replaceFirst('Exception: ', '');
@@ -588,36 +594,36 @@ class _ChecklistLiberacaoPageState extends State<ChecklistLiberacaoPage> {
                                 border: const OutlineInputBorder(),
                                 suffixIcon: _loadingMaquinas
                                     ? const Padding(
-                                  padding: EdgeInsets.all(8),
-                                  child: SizedBox(
-                                    height: 20,
-                                    width: 20,
-                                    child: CircularProgressIndicator(
-                                      strokeWidth: 2,
-                                    ),
-                                  ),
-                                )
+                                        padding: EdgeInsets.all(8),
+                                        child: SizedBox(
+                                          height: 20,
+                                          width: 20,
+                                          child: CircularProgressIndicator(
+                                            strokeWidth: 2,
+                                          ),
+                                        ),
+                                      )
                                     : null,
                               ),
                               items: _grupos
                                   .map(
                                     (grupo) => DropdownMenuItem(
-                                  value: grupo,
-                                  child: Text(grupo),
-                                ),
-                              )
+                                      value: grupo,
+                                      child: Text(grupo),
+                                    ),
+                                  )
                                   .toList(),
                               onChanged: _loadingMaquinas
                                   ? null
                                   : (value) {
-                                setState(() {
-                                  _grupoSelecionado = value;
-                                  _maquinaSelecionada = null;
-                                });
-                              },
+                                      setState(() {
+                                        _grupoSelecionado = value;
+                                        _maquinaSelecionada = null;
+                                      });
+                                    },
                               validator: (value) {
                                 if ((_grupos.isNotEmpty ||
-                                    _grupoSelecionado != null) &&
+                                        _grupoSelecionado != null) &&
                                     (value == null || value.isEmpty)) {
                                   return 'Selecione um grupo de máquinas';
                                 }
@@ -636,18 +642,18 @@ class _ChecklistLiberacaoPageState extends State<ChecklistLiberacaoPage> {
                               items: _maquinasDisponiveis
                                   .map(
                                     (maquina) => DropdownMenuItem(
-                                  value: maquina,
-                                  child: Text(maquina),
-                                ),
-                              )
+                                      value: maquina,
+                                      child: Text(maquina),
+                                    ),
+                                  )
                                   .toList(),
                               onChanged: _maquinasDisponiveis.isEmpty
                                   ? null
                                   : (value) {
-                                setState(
-                                      () => _maquinaSelecionada = value,
-                                );
-                              },
+                                      setState(
+                                        () => _maquinaSelecionada = value,
+                                      );
+                                    },
                               validator: (value) {
                                 if (_maquinasDisponiveis.isEmpty) {
                                   return 'Selecione um grupo para listar as máquinas';
@@ -672,12 +678,12 @@ class _ChecklistLiberacaoPageState extends State<ChecklistLiberacaoPage> {
                           onPressed: _salvando ? null : _salvar,
                           icon: _salvando
                               ? const SizedBox(
-                            width: 18,
-                            height: 18,
-                            child: CircularProgressIndicator(
-                              strokeWidth: 2,
-                            ),
-                          )
+                                  width: 18,
+                                  height: 18,
+                                  child: CircularProgressIndicator(
+                                    strokeWidth: 2,
+                                  ),
+                                )
                               : const Icon(Icons.save_outlined),
                           label: Text(
                             _salvando ? 'Salvando...' : 'Salvar checklist',

--- a/lib/features/operador/presentation/operador_page.dart
+++ b/lib/features/operador/presentation/operador_page.dart
@@ -514,6 +514,16 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
     return false;
   }
 
+  Future<void> _retornarAoMenuPrincipal() async {
+    if (!mounted) return;
+    await Future.delayed(const Duration(milliseconds: 350));
+    if (!mounted) return;
+    Navigator.of(
+      context,
+      rootNavigator: true,
+    ).popUntil((route) => route.isFirst);
+  }
+
   @override
   void dispose() {
     _cancelAmostragemMonitor();
@@ -684,6 +694,8 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
           SnackBar(content: Text('Jornada pausada. Motivo: $motivo')),
         );
         if (motivo == 'Fim do Turno') {
+          ref.read(sharedSearchFormProvider.notifier).clear();
+          unawaited(_retornarAoMenuPrincipal());
           setState(() {
             _reCtrl.clear();
           });
@@ -738,6 +750,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
             ),
           ),
         );
+        unawaited(_retornarAoMenuPrincipal());
       } else {
         String mensagem = 'Falha: ${resp.statusCode} ${resp.body}';
         try {


### PR DESCRIPTION
## Summary
- ensure ordem_servico rows exist before marking an OS as pausada during troca de OS
- return to the main menu after saving the checklist or completing troca de OS / fim de turno flows
- clear active flow state when ending a shift to avoid stale form data

## Testing
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_68dea822892083318485cfba28ec1301