### PR TITLE
Enforce checklist requirement after fim de turno pauses

### DIFF
--- a/app_db.py
+++ b/app_db.py
@@ -1469,6 +1469,12 @@ def resultado_preparador():
                         ),
                     )
 
+                novo_status_os = "liberada" if all_ok else "aberta"
+                cur.execute(
+                    "UPDATE ordem_servico SET status=%s WHERE os=%s",
+                    (novo_status_os, os_num),
+                )
+
                 if contexto_tipo == "troca_ferramenta":
                     cur.execute(
                         """
@@ -2012,6 +2018,28 @@ def _registrar_pausa_operador(
         (os_num, part or None, op or None, re_op, motivo or None),
     )
 
+    motivo_norm = (motivo or "").strip().lower()
+    if motivo_norm in {
+        "troca de os",
+        "troca_os",
+        "troca os",
+    }:
+        cur.execute(
+            "UPDATE ordem_servico SET status=%s WHERE os=%s",
+            ("pausada", os_num),
+        )
+        cur.execute(
+            """
+            UPDATE preparador_liberacao
+               SET status_geral=%s
+             WHERE os=%s
+               AND LOWER(COALESCE(status_geral, '')) IN (
+                   'liberada', 'liberado', 'ok', 'aprovada', 'aprovado'
+               )
+            """,
+            ("Pausada", os_num),
+        )
+
 
 @app.route("/operador/fim_jornada", methods=["POST"])
 def operador_fim_jornada():
@@ -2061,6 +2089,12 @@ def operador_troca_os():
                             }),
                             409,
                         )
+
+                cur.execute(
+                    "INSERT INTO ordem_servico (os) VALUES (%s)"
+                    " ON DUPLICATE KEY UPDATE os = VALUES(os)",
+                    (os_num,),
+                )
 
                 _registrar_pausa_operador(cur, os_num, re_op, part, op, motivo)
                 cur.execute(

--- a/lib/features/checklist_liberacao/presentation/checklist_liberacao_page.dart
+++ b/lib/features/checklist_liberacao/presentation/checklist_liberacao_page.dart
@@ -1,12 +1,15 @@
+import 'dart:async';
 import 'dart:collection';
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../screens/main/components/side_menu.dart';
 import '../../../services/checklist_liberacao_service.dart';
 import '../../../services/machine_service.dart';
+import '../../shared/providers/search_flow_form_provider.dart';
 
 import '../../../widgets/window_bar.dart';
 
@@ -137,7 +140,7 @@ const List<ChecklistGroup> _checklistGroups = [
       ChecklistQuestion(
         id: 'maquinas_itens_emergencia',
         text:
-        'Os itens de emergência (botão, seta, luz gira-gira) estão funcionando?',
+            'Os itens de emergência (botão, seta, luz gira-gira) estão funcionando?',
       ),
       ChecklistQuestion(
         id: 'maquinas_comandos_protecao',
@@ -160,7 +163,7 @@ const List<ChecklistGroup> _checklistGroups = [
       ChecklistQuestion(
         id: 'instrumentos_recursos',
         text:
-        'Todos os recursos de medição necessários estão disponíveis na máquina?',
+            'Todos os recursos de medição necessários estão disponíveis na máquina?',
       ),
       ChecklistQuestion(
         id: 'instrumentos_centesimal',
@@ -169,7 +172,7 @@ const List<ChecklistGroup> _checklistGroups = [
       ChecklistQuestion(
         id: 'instrumentos_milesimal',
         text:
-        'Para dispositivos com relógio milesimal está partindo do 0 com o padrão?',
+            'Para dispositivos com relógio milesimal está partindo do 0 com o padrão?',
       ),
       ChecklistQuestion(
         id: 'instrumentos_local_limpo',
@@ -183,14 +186,16 @@ const List<ChecklistGroup> _checklistGroups = [
   ),
 ];
 
-class ChecklistLiberacaoPage extends StatefulWidget {
+class ChecklistLiberacaoPage extends ConsumerStatefulWidget {
   const ChecklistLiberacaoPage({super.key});
 
   @override
-  State<ChecklistLiberacaoPage> createState() => _ChecklistLiberacaoPageState();
+  ConsumerState<ChecklistLiberacaoPage> createState() =>
+      _ChecklistLiberacaoPageState();
 }
 
-class _ChecklistLiberacaoPageState extends State<ChecklistLiberacaoPage> {
+class _ChecklistLiberacaoPageState
+    extends ConsumerState<ChecklistLiberacaoPage> {
   final _formKey = GlobalKey<FormState>();
   final _reController = TextEditingController();
   final Map<String, ChecklistAnswer?> _answers = {};
@@ -260,6 +265,16 @@ class _ChecklistLiberacaoPageState extends State<ChecklistLiberacaoPage> {
     }
   }
 
+  Future<void> _voltarParaMenuPrincipal() async {
+    if (!mounted) return;
+    await Future.delayed(const Duration(milliseconds: 350));
+    if (!mounted) return;
+    Navigator.of(
+      context,
+      rootNavigator: true,
+    ).popUntil((route) => route.isFirst);
+  }
+
   void _showSnackBar(String message, {bool erro = true}) {
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
@@ -317,12 +332,12 @@ class _ChecklistLiberacaoPageState extends State<ChecklistLiberacaoPage> {
         shape: BoxShape.circle,
         boxShadow: isSelected
             ? [
-          BoxShadow(
-            color: activeColor.withOpacity(0.4),
-            blurRadius: 12,
-            spreadRadius: 1,
-          ),
-        ]
+                BoxShadow(
+                  color: activeColor.withOpacity(0.4),
+                  blurRadius: 12,
+                  spreadRadius: 1,
+                ),
+              ]
             : null,
       ),
       child: Icon(
@@ -370,10 +385,9 @@ class _ChecklistLiberacaoPageState extends State<ChecklistLiberacaoPage> {
   }
 
   TableRow _buildHeaderRow(BuildContext context) {
-    final textStyle = Theme.of(context)
-        .textTheme
-        .labelLarge
-        ?.copyWith(fontWeight: FontWeight.w600);
+    final textStyle = Theme.of(
+      context,
+    ).textTheme.labelLarge?.copyWith(fontWeight: FontWeight.w600);
     return TableRow(
       decoration: BoxDecoration(
         color: Theme.of(context).colorScheme.surfaceVariant,
@@ -386,12 +400,7 @@ class _ChecklistLiberacaoPageState extends State<ChecklistLiberacaoPage> {
         for (final answer in ChecklistAnswer.values)
           Padding(
             padding: const EdgeInsets.symmetric(vertical: 12),
-            child: Center(
-              child: Text(
-                answer.label,
-                style: textStyle,
-              ),
-            ),
+            child: Center(child: Text(answer.label, style: textStyle)),
           ),
       ],
     );
@@ -504,6 +513,7 @@ class _ChecklistLiberacaoPageState extends State<ChecklistLiberacaoPage> {
         respostas: respostas,
       );
       if (!mounted) return;
+      ref.read(sharedSearchFormProvider.notifier).completeChecklist();
       _showSnackBar('Checklist registrado com sucesso!', erro: false);
       setState(() {
         _answers.clear();
@@ -513,6 +523,7 @@ class _ChecklistLiberacaoPageState extends State<ChecklistLiberacaoPage> {
         _autovalidateMode = AutovalidateMode.disabled;
       });
       form.reset();
+      unawaited(_voltarParaMenuPrincipal());
     } catch (error) {
       if (!mounted) return;
       final message = error.toString().replaceFirst('Exception: ', '');
@@ -588,36 +599,36 @@ class _ChecklistLiberacaoPageState extends State<ChecklistLiberacaoPage> {
                                 border: const OutlineInputBorder(),
                                 suffixIcon: _loadingMaquinas
                                     ? const Padding(
-                                  padding: EdgeInsets.all(8),
-                                  child: SizedBox(
-                                    height: 20,
-                                    width: 20,
-                                    child: CircularProgressIndicator(
-                                      strokeWidth: 2,
-                                    ),
-                                  ),
-                                )
+                                        padding: EdgeInsets.all(8),
+                                        child: SizedBox(
+                                          height: 20,
+                                          width: 20,
+                                          child: CircularProgressIndicator(
+                                            strokeWidth: 2,
+                                          ),
+                                        ),
+                                      )
                                     : null,
                               ),
                               items: _grupos
                                   .map(
                                     (grupo) => DropdownMenuItem(
-                                  value: grupo,
-                                  child: Text(grupo),
-                                ),
-                              )
+                                      value: grupo,
+                                      child: Text(grupo),
+                                    ),
+                                  )
                                   .toList(),
                               onChanged: _loadingMaquinas
                                   ? null
                                   : (value) {
-                                setState(() {
-                                  _grupoSelecionado = value;
-                                  _maquinaSelecionada = null;
-                                });
-                              },
+                                      setState(() {
+                                        _grupoSelecionado = value;
+                                        _maquinaSelecionada = null;
+                                      });
+                                    },
                               validator: (value) {
                                 if ((_grupos.isNotEmpty ||
-                                    _grupoSelecionado != null) &&
+                                        _grupoSelecionado != null) &&
                                     (value == null || value.isEmpty)) {
                                   return 'Selecione um grupo de máquinas';
                                 }
@@ -636,18 +647,18 @@ class _ChecklistLiberacaoPageState extends State<ChecklistLiberacaoPage> {
                               items: _maquinasDisponiveis
                                   .map(
                                     (maquina) => DropdownMenuItem(
-                                  value: maquina,
-                                  child: Text(maquina),
-                                ),
-                              )
+                                      value: maquina,
+                                      child: Text(maquina),
+                                    ),
+                                  )
                                   .toList(),
                               onChanged: _maquinasDisponiveis.isEmpty
                                   ? null
                                   : (value) {
-                                setState(
-                                      () => _maquinaSelecionada = value,
-                                );
-                              },
+                                      setState(
+                                        () => _maquinaSelecionada = value,
+                                      );
+                                    },
                               validator: (value) {
                                 if (_maquinasDisponiveis.isEmpty) {
                                   return 'Selecione um grupo para listar as máquinas';
@@ -672,12 +683,12 @@ class _ChecklistLiberacaoPageState extends State<ChecklistLiberacaoPage> {
                           onPressed: _salvando ? null : _salvar,
                           icon: _salvando
                               ? const SizedBox(
-                            width: 18,
-                            height: 18,
-                            child: CircularProgressIndicator(
-                              strokeWidth: 2,
-                            ),
-                          )
+                                  width: 18,
+                                  height: 18,
+                                  child: CircularProgressIndicator(
+                                    strokeWidth: 2,
+                                  ),
+                                )
                               : const Icon(Icons.save_outlined),
                           label: Text(
                             _salvando ? 'Salvando...' : 'Salvar checklist',

--- a/lib/features/main_menu/main_menu_page.dart
+++ b/lib/features/main_menu/main_menu_page.dart
@@ -30,9 +30,26 @@ class _MainMenuPageState extends ConsumerState<MainMenuPage> {
   Widget build(BuildContext context) {
     void showFlowLockedMessage(SharedSearchFormState shared) {
       final osAtual = shared.os.trim();
-      final mensagem = osAtual.isEmpty
-          ? 'Finalize a O.S. em andamento antes de iniciar outra.'
-          : 'Finalize a O.S. $osAtual antes de iniciar outra.';
+      String mensagem;
+      if (shared.requiresChecklist) {
+        final motivo = (shared.checklistReason ?? '').trim();
+        final buffer = StringBuffer('Checklist inicial pendente');
+        if (osAtual.isNotEmpty) {
+          buffer.write(' para a O.S. $osAtual');
+        }
+        buffer.write('.');
+        if (motivo.isNotEmpty) {
+          buffer.write(' Motivo: $motivo.');
+        }
+        buffer.write(
+          ' Preencha o checklist inicial antes de retomar a amostragem.',
+        );
+        mensagem = buffer.toString();
+      } else {
+        mensagem = osAtual.isEmpty
+            ? 'Finalize a O.S. em andamento antes de iniciar outra.'
+            : 'Finalize a O.S. $osAtual antes de iniciar outra.';
+      }
       ScaffoldMessenger.of(context)
         ..clearSnackBars()
         ..showSnackBar(SnackBar(content: Text(mensagem)));
@@ -95,7 +112,7 @@ class _MainMenuPageState extends ConsumerState<MainMenuPage> {
       _MenuEntry(
         title: 'FOR07',
         description:
-        'Organize recursos, prepare itens e acompanhe o fluxo inicial.',
+            'Organize recursos, prepare itens e acompanhe o fluxo inicial.',
         iconAsset: 'assets/icons/FOR007.svg',
         accentColor: primaryColor,
         onTap: () => openFlowPage(const PreparacaoPage()),
@@ -103,7 +120,7 @@ class _MainMenuPageState extends ConsumerState<MainMenuPage> {
       _MenuEntry(
         title: 'FOR09-14',
         description:
-        'Registre atividades de produção e mantenha o time sincronizado.',
+            'Registre atividades de produção e mantenha o time sincronizado.',
         iconAsset: 'assets/icons/Amostragem.svg',
         accentColor: const Color(0xFFF6A560),
         onTap: () => openFlowPage(const OperadorPage()),
@@ -118,7 +135,7 @@ class _MainMenuPageState extends ConsumerState<MainMenuPage> {
       _MenuEntry(
         title: 'Área de supervisão',
         description:
-        'Realize cadastros, visualize indicadores e relatórios estratégicos em tempo real.',
+            'Realize cadastros, visualize indicadores e relatórios estratégicos em tempo real.',
         iconAsset: 'assets/icons/Dashboard.svg',
         accentColor: accentColor,
         onTap: () => openAdmin(),
@@ -158,20 +175,20 @@ class _MainMenuPageState extends ConsumerState<MainMenuPage> {
               ),
 
               // Logos flutuando sobre as bolhas (Opção 2)
-                Positioned(
-                  top: isPhonePortrait ? 20 : 20,
-                  left: isPhonePortrait ? 5 : 10,
-                  child: IgnorePointer(
-                    ignoring: true,
-                    child: Opacity(
-                      opacity: 1,
-                      child: Image.asset(
-                        'assets/images/logotuptech1.png',
-                        width: isTabletWidth ? 150 : 150,
-                      ),
+              Positioned(
+                top: isPhonePortrait ? 20 : 20,
+                left: isPhonePortrait ? 5 : 10,
+                child: IgnorePointer(
+                  ignoring: true,
+                  child: Opacity(
+                    opacity: 1,
+                    child: Image.asset(
+                      'assets/images/logotuptech1.png',
+                      width: isTabletWidth ? 150 : 150,
                     ),
                   ),
                 ),
+              ),
               Positioned(
                 right: isPhonePortrait ? 20 : 20,
                 bottom: isPhonePortrait ? 20 : 30,
@@ -273,10 +290,10 @@ class _MainMenuPageState extends ConsumerState<MainMenuPage> {
   }
 
   Widget _buildIntroSection(
-      ThemeData theme, {
-        bool forceCenter = false,
-        bool showSubtitle = true,
-      }) {
+    ThemeData theme, {
+    bool forceCenter = false,
+    bool showSubtitle = true,
+  }) {
     return LayoutBuilder(
       builder: (context, constraints) {
         final shouldCenter = forceCenter || constraints.maxWidth < 500;
@@ -451,7 +468,8 @@ class _MenuGrid extends StatelessWidget {
                   isCompact: forceColumn,
                   density: density,
                   minDensityFloor: minDensity,
-                  hideDescription: alwaysHideDescriptions ||
+                  hideDescription:
+                      alwaysHideDescriptions ||
                       (hideDescriptionsWhenTight &&
                           density <= minDensity + 0.04),
                 ),
@@ -471,10 +489,10 @@ class _MenuGrid extends StatelessWidget {
           children: entries
               .map(
                 (entry) => _MenuCard(
-              entry: entry,
-              maxWidth: cardWidth.clamp(260.0, 360.0).toDouble(),
-            ),
-          )
+                  entry: entry,
+                  maxWidth: cardWidth.clamp(260.0, 360.0).toDouble(),
+                ),
+              )
               .toList(),
         );
       },
@@ -568,9 +586,9 @@ class _MenuCardState extends State<_MenuCard> {
             duration: const Duration(milliseconds: 220),
             constraints: widget.minHeight != null
                 ? BoxConstraints(
-              minHeight: widget.minHeight!,
-              maxHeight: widget.minHeight!,
-            )
+                    minHeight: widget.minHeight!,
+                    maxHeight: widget.minHeight!,
+                  )
                 : const BoxConstraints(),
             decoration: BoxDecoration(
               borderRadius: BorderRadius.circular(22),
@@ -581,13 +599,13 @@ class _MenuCardState extends State<_MenuCard> {
               ),
               gradient: _hovering
                   ? LinearGradient(
-                colors: [
-                  accent.withOpacity(0.22),
-                  theme.colorScheme.surface.withOpacity(0.85),
-                ],
-                begin: Alignment.topLeft,
-                end: Alignment.bottomRight,
-              )
+                      colors: [
+                        accent.withOpacity(0.22),
+                        theme.colorScheme.surface.withOpacity(0.85),
+                      ],
+                      begin: Alignment.topLeft,
+                      end: Alignment.bottomRight,
+                    )
                   : null,
               color: _hovering
                   ? null

--- a/lib/features/operador/presentation/operador_page.dart
+++ b/lib/features/operador/presentation/operador_page.dart
@@ -505,6 +505,24 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
     ).showSnackBar(SnackBar(content: Text(mensagem)));
   }
 
+  void _showChecklistRequiredSnackBar(SharedSearchFormState shared) {
+    if (!mounted) return;
+    final osAtual = shared.os.trim();
+    final motivo = (shared.checklistReason ?? '').trim();
+    final buffer = StringBuffer('Checklist inicial pendente');
+    if (osAtual.isNotEmpty) {
+      buffer.write(' para a O.S. $osAtual');
+    }
+    buffer.write('.');
+    if (motivo.isNotEmpty) {
+      buffer.write(' Motivo: $motivo.');
+    }
+    buffer.write(' Preencha o checklist antes de retomar a amostragem.');
+    ScaffoldMessenger.of(context)
+      ..clearSnackBars()
+      ..showSnackBar(SnackBar(content: Text(buffer.toString())));
+  }
+
   bool _ensureFlowConsistency() {
     final shared = ref.read(sharedSearchFormProvider);
     if (_flowMatchesCurrentForm(shared)) {
@@ -512,6 +530,16 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
     }
     _showFlowBlockedSnackBar(shared);
     return false;
+  }
+
+  Future<void> _retornarAoMenuPrincipal() async {
+    if (!mounted) return;
+    await Future.delayed(const Duration(milliseconds: 350));
+    if (!mounted) return;
+    Navigator.of(
+      context,
+      rootNavigator: true,
+    ).popUntil((route) => route.isFirst);
   }
 
   @override
@@ -683,10 +711,21 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text('Jornada pausada. Motivo: $motivo')),
         );
+        final motivoLower = motivo.trim().toLowerCase();
+        if (motivoLower == 'fim do turno' || motivoLower == 'fim de turno') {
+          ref
+              .read(sharedSearchFormProvider.notifier)
+              .requireChecklist(reason: motivo);
+        } else if (motivoLower == 'troca de ferramenta') {
+          ref
+              .read(sharedSearchFormProvider.notifier)
+              .requireChecklist(reason: motivo);
+        }
         if (motivo == 'Fim do Turno') {
           setState(() {
             _reCtrl.clear();
           });
+          await _retornarAoMenuPrincipal();
         }
         return true;
       } else {
@@ -738,6 +777,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
             ),
           ),
         );
+        await _retornarAoMenuPrincipal();
       } else {
         String mensagem = 'Falha: ${resp.statusCode} ${resp.body}';
         try {
@@ -1007,8 +1047,33 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
         : null;
     final flowState = ref.watch(sharedSearchFormProvider);
     final flowLocked = flowState.isActive;
+    final requiresChecklist = flowState.requiresChecklist;
+    final checklistReason = (flowState.checklistReason ?? '').trim();
     final flowProcessName = flowState.processDisplayName;
     final flowOs = flowState.os.trim();
+    String? lockMessage;
+    IconData lockIcon = Icons.lock;
+    if (flowLocked) {
+      if (requiresChecklist) {
+        final buffer = StringBuffer('Checklist inicial pendente');
+        if (flowOs.isNotEmpty) {
+          buffer.write(' para a O.S. $flowOs');
+        }
+        buffer.write('.');
+        if (checklistReason.isNotEmpty) {
+          buffer.write(' Motivo: $checklistReason.');
+        }
+        buffer.write(
+          ' Abra o menu principal e preencha o checklist antes de retomar a amostragem.',
+        );
+        lockMessage = buffer.toString();
+        lockIcon = Icons.fact_check;
+      } else {
+        lockMessage = flowOs.isEmpty
+            ? 'Existe um fluxo de $flowProcessName em andamento. Finalize a O.S. atual para iniciar outra.'
+            : 'Fluxo de $flowProcessName ativo para a O.S. $flowOs. Finalize a O.S. atual para iniciar outra.';
+      }
+    }
     final bottomInset = MediaQuery.of(context).viewInsets.bottom;
     final actionBottomPadding = bottomInset > 0 ? bottomInset + 16.0 : 16.0;
     final reOk = _reCtrl.text.trim().isNotEmpty;
@@ -1050,7 +1115,8 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
         osOk &&
         maquinaOk &&
         todasRespondidas &&
-        !_registrando;
+        !_registrando &&
+        !requiresChecklist;
 
     return Scaffold(
       appBar: WindowBar(
@@ -1084,7 +1150,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.stretch,
                     children: [
-                      if (flowLocked)
+                      if (lockMessage != null)
                         Container(
                           margin: const EdgeInsets.only(bottom: 12),
                           padding: const EdgeInsets.all(12),
@@ -1098,16 +1164,14 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
                               Icon(
-                                Icons.lock,
+                                lockIcon,
                                 size: 18,
                                 color: Theme.of(context).colorScheme.primary,
                               ),
                               const SizedBox(width: 8),
                               Expanded(
                                 child: Text(
-                                  flowOs.isEmpty
-                                      ? 'Existe um fluxo de $flowProcessName em andamento. Finalize a O.S. atual para iniciar outra.'
-                                      : 'Fluxo de $flowProcessName ativo para a O.S. $flowOs. Finalize a O.S. atual para iniciar outra.',
+                                  lockMessage!,
                                   style: Theme.of(context).textTheme.bodyMedium,
                                 ),
                               ),
@@ -1357,6 +1421,10 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                                 width: double.infinity,
                                 child: FilledButton.icon(
                                   onPressed: () async {
+                                    if (requiresChecklist) {
+                                      _showChecklistRequiredSnackBar(flowState);
+                                      return;
+                                    }
                                     if (_formKey.currentState!.validate()) {
                                       if (!_ensureFlowConsistency()) return;
                                       FocusScope.of(context).unfocus();

--- a/lib/features/shared/providers/search_flow_form_provider.dart
+++ b/lib/features/shared/providers/search_flow_form_provider.dart
@@ -36,6 +36,8 @@ class SharedSearchFormState {
     this.categoria,
     this.maquina,
     this.process,
+    this.requiresChecklist = false,
+    this.checklistReason,
   });
 
   final bool isActive;
@@ -45,6 +47,8 @@ class SharedSearchFormState {
   final String? categoria;
   final String? maquina;
   final SearchFlowProcess? process;
+  final bool requiresChecklist;
+  final String? checklistReason;
 
   static const _sentinel = Object();
   static String? _normalizeOptional(String? value) {
@@ -52,6 +56,7 @@ class SharedSearchFormState {
     if (trimmed == null || trimmed.isEmpty) return null;
     return trimmed;
   }
+
   factory SharedSearchFormState.fromMap(Map<dynamic, dynamic> map) {
     String _readString(dynamic value) => (value ?? '').toString().trim();
     String? _readOptional(dynamic value) {
@@ -67,6 +72,8 @@ class SharedSearchFormState {
       categoria: _readOptional(map['categoria']),
       maquina: _readOptional(map['maquina']),
       process: _parseProcess(map['process']),
+      requiresChecklist: map['requiresChecklist'] == true,
+      checklistReason: _readOptional(map['checklistReason']),
     );
   }
 
@@ -79,6 +86,8 @@ class SharedSearchFormState {
       'categoria': categoria,
       'maquina': maquina,
       'process': process?.name,
+      'requiresChecklist': requiresChecklist,
+      'checklistReason': checklistReason,
     };
   }
 
@@ -90,6 +99,8 @@ class SharedSearchFormState {
     Object? categoria = _sentinel,
     Object? maquina = _sentinel,
     Object? process = _sentinel,
+    bool? requiresChecklist,
+    Object? checklistReason = _sentinel,
   }) {
     return SharedSearchFormState(
       isActive: isActive ?? this.isActive,
@@ -101,6 +112,10 @@ class SharedSearchFormState {
       process: process == _sentinel
           ? this.process
           : process as SearchFlowProcess?,
+      requiresChecklist: requiresChecklist ?? this.requiresChecklist,
+      checklistReason: checklistReason == _sentinel
+          ? this.checklistReason
+          : checklistReason as String?,
     );
   }
 
@@ -115,7 +130,9 @@ class SharedSearchFormState {
   bool equals(SharedSearchFormState other) {
     return isActive == other.isActive &&
         matches(other) &&
-        process == other.process;
+        process == other.process &&
+        requiresChecklist == other.requiresChecklist &&
+        checklistReason == other.checklistReason;
   }
 
   bool matchesValues({
@@ -143,6 +160,8 @@ extension SharedSearchFormStateDisplay on SharedSearchFormState {
       process ?? SearchFlowProcess.amostragem;
 
   String get processDisplayName => effectiveProcess.displayName;
+
+  bool get hasChecklistRequirement => requiresChecklist;
 }
 
 SharedSearchFormState _restoreInitialState(Box<Map> box) {
@@ -201,6 +220,8 @@ class SharedSearchFormController extends StateNotifier<SharedSearchFormState> {
       categoria: SharedSearchFormState._normalizeOptional(categoria),
       maquina: SharedSearchFormState._normalizeOptional(maquina),
       process: process,
+      requiresChecklist: false,
+      checklistReason: null,
     );
 
     if (_isActive && state.matches(candidate) == false) {
@@ -247,6 +268,30 @@ class SharedSearchFormController extends StateNotifier<SharedSearchFormState> {
     if (_isActive == false) return;
     if (maquina == state.maquina) return;
     _updateState(state.copyWith(maquina: maquina));
+  }
+
+  void requireChecklist({String? reason}) {
+    if (_isActive == false) return;
+    final normalizedReason = SharedSearchFormState._normalizeOptional(reason);
+    if (state.requiresChecklist && state.checklistReason == normalizedReason) {
+      return;
+    }
+    _updateState(
+      state.copyWith(
+        requiresChecklist: true,
+        checklistReason: normalizedReason,
+      ),
+    );
+  }
+
+  void completeChecklist() {
+    if (_isActive == false) return;
+    if (!state.requiresChecklist && state.checklistReason == null) {
+      return;
+    }
+    _updateState(
+      state.copyWith(requiresChecklist: false, checklistReason: null),
+    );
   }
 
   void clear() {

--- a/lib/screens/main/components/side_menu.dart
+++ b/lib/screens/main/components/side_menu.dart
@@ -34,6 +34,21 @@ class SideMenu extends ConsumerWidget {
 
   String _flowLockedMessage(SharedSearchFormState shared) {
     final osAtual = shared.os.trim();
+    if (shared.requiresChecklist) {
+      final motivo = (shared.checklistReason ?? '').trim();
+      final buffer = StringBuffer('Checklist inicial pendente');
+      if (osAtual.isNotEmpty) {
+        buffer.write(' para a O.S. $osAtual');
+      }
+      buffer.write('.');
+      if (motivo.isNotEmpty) {
+        buffer.write(' Motivo: $motivo.');
+      }
+      buffer.write(
+        ' Preencha o checklist inicial antes de retomar a amostragem.',
+      );
+      return buffer.toString();
+    }
     return osAtual.isEmpty
         ? 'Finalize a O.S. em andamento antes de iniciar outra.'
         : 'Finalize a O.S. $osAtual antes de iniciar outra.';
@@ -113,7 +128,12 @@ class SideMenu extends ConsumerWidget {
         DrawerListTile(
           title: 'Checklist de liberação',
           svgSrc: 'assets/icons/menu_task.svg',
-          press: () => _navigate(context, ref, const ChecklistLiberacaoPage()),
+          press: () => _navigate(
+            context,
+            ref,
+            const ChecklistLiberacaoPage(),
+            allowDuringActiveFlow: true,
+          ),
         ),
         DrawerListTile(
           title: 'Tempo por OS',


### PR DESCRIPTION
## Summary
- stop marking the OS as pausada for fim de turno so the preparador liberação stays valid
- track a checklist-required flag in the shared flow state, showing guidance and blocking amostragem actions until the checklist is redone
- reset the checklist requirement when the checklist page is saved and surface the new messaging in the menu and side drawer

## Testing
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_68dea822892083318485cfba28ec1301