### PR TITLE
Allow preparador flows to send checklist RE metadata

### DIFF
--- a/lib/features/finalizar_os/presentation/finalizar_os_page.dart
+++ b/lib/features/finalizar_os/presentation/finalizar_os_page.dart
@@ -410,14 +410,22 @@ class _FinalizarOsPageState extends ConsumerState<FinalizarOsPage> {
       });
     }
 
-    final body = jsonEncode({
+    final sharedFlow = ref.read(sharedSearchFormProvider);
+    final checklistRe = (sharedFlow.checklistRe ?? '').trim();
+
+    final payload = <String, dynamic>{
       're': _reCtrl.text.trim(),
       'os': _osCtrl.text.trim(),
       'partnumber': normalizeCode(_partCtrl.text),
       'operacao': normalizeCode(_opCtrl.text),
       'maquina': _maquinaSel,
       'itens': itens,
-    });
+    };
+    if (checklistRe.isNotEmpty) {
+      payload['re_checklist'] = checklistRe;
+    }
+
+    final body = jsonEncode(payload);
 
     final uri = buildApiUri('/preparador/finalizar_os');
 

--- a/lib/features/operador/presentation/operador_page.dart
+++ b/lib/features/operador/presentation/operador_page.dart
@@ -246,8 +246,10 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
   ) {
     final previousChecklistRe = previous?.normalizedChecklistRe;
     final nextChecklistRe = next.normalizedChecklistRe;
+    final shouldSyncChecklistRe =
+        next.effectiveProcess == SearchFlowProcess.amostragem;
 
-    if (previousChecklistRe != nextChecklistRe) {
+    if (shouldSyncChecklistRe && previousChecklistRe != nextChecklistRe) {
       final target = nextChecklistRe ?? '';
       if (target.isEmpty) {
         if (_reCtrl.text.trim().isNotEmpty) {
@@ -886,6 +888,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
       return;
     }
 
+    final sharedFlow = ref.read(sharedSearchFormProvider);
     final sucesso = await Navigator.of(context).push<bool>(
       MaterialPageRoute(
         builder: (_) => TrocaFerramentaPage(
@@ -894,6 +897,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
           partnumber: part,
           operacao: operacao,
           maquina: maquina,
+          checklistRe: sharedFlow.checklistRe,
         ),
       ),
     );

--- a/lib/features/operador/presentation/troca_ferramenta_page.dart
+++ b/lib/features/operador/presentation/troca_ferramenta_page.dart
@@ -17,6 +17,7 @@ class TrocaFerramentaPage extends StatefulWidget {
   final String partnumber;
   final String operacao;
   final String maquina;
+  final String? checklistRe;
 
   const TrocaFerramentaPage({
     super.key,
@@ -25,6 +26,7 @@ class TrocaFerramentaPage extends StatefulWidget {
     required this.partnumber,
     required this.operacao,
     required this.maquina,
+    this.checklistRe,
   });
 
   @override
@@ -283,7 +285,7 @@ class _TrocaFerramentaPageState extends State<TrocaFerramentaPage> {
     }
 
     final uri = buildApiUri('/preparador/resultado');
-    final body = jsonEncode({
+    final payload = <String, dynamic>{
       're': reAtual,
       'os': widget.os,
       'partnumber': normalizeCode(widget.partnumber),
@@ -291,7 +293,13 @@ class _TrocaFerramentaPageState extends State<TrocaFerramentaPage> {
       'maquina': widget.maquina,
       'contexto': 'troca_ferramenta',
       'itens': itens,
-    });
+    };
+    final checklistRe = (widget.checklistRe ?? '').trim();
+    if (checklistRe.isNotEmpty) {
+      payload['re_checklist'] = checklistRe;
+    }
+
+    final body = jsonEncode(payload);
 
     setState(() => _registrando = true);
     try {

--- a/lib/features/preparacao/presentation/preparacao_page.dart
+++ b/lib/features/preparacao/presentation/preparacao_page.dart
@@ -425,14 +425,22 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
       });
     }
 
-    final body = jsonEncode({
+    final sharedFlow = ref.read(sharedSearchFormProvider);
+    final checklistRe = (sharedFlow.checklistRe ?? '').trim();
+
+    final payload = <String, dynamic>{
       're': _reCtrl.text.trim(),
       'os': _osCtrl.text.trim(),
       'partnumber': normalizeCode(_partCtrl.text),
       'operacao': normalizeCode(_opCtrl.text),
       'maquina': _maquinaSel,
       'itens': itens,
-    });
+    };
+    if (checklistRe.isNotEmpty) {
+      payload['re_checklist'] = checklistRe;
+    }
+
+    final body = jsonEncode(payload);
 
     final uri = buildApiUri('/preparador/resultado');
 

--- a/lib/features/shared/providers/search_flow_form_provider.dart
+++ b/lib/features/shared/providers/search_flow_form_provider.dart
@@ -172,8 +172,12 @@ extension SharedSearchFormStateDisplay on SharedSearchFormState {
 
   bool get hasChecklistRequirement => requiresChecklist;
 
-  String? get normalizedChecklistRe =>
-      SharedSearchFormState._normalizeOptional(checklistRe);
+  String? get normalizedChecklistRe {
+    if (effectiveProcess != SearchFlowProcess.amostragem) {
+      return null;
+    }
+    return SharedSearchFormState._normalizeOptional(checklistRe);
+  }
 }
 
 SharedSearchFormState _restoreInitialState(Box<Map> box) {


### PR DESCRIPTION
## Summary
- include the stored checklist R.E. alongside preparador liberation, finalization, and tool-change submissions so the backend can validate against the original checklist while allowing a different active R.E.
- thread the optional checklist R.E. through the troca de ferramenta flow so all preparador API calls provide the same context

## Testing
- flutter test

------
https://chatgpt.com/codex/tasks/task_e_68dec0de44648331b10e72eefb237fd7