### PR TITLE
Adjust checklist drawer options

### DIFF
--- a/lib/features/checklist_liberacao/presentation/checklist_liberacao_page.dart
+++ b/lib/features/checklist_liberacao/presentation/checklist_liberacao_page.dart
@@ -541,7 +541,7 @@ class _ChecklistLiberacaoPageState
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: const WindowBar(title: 'Checklist de liberação', showMenu: true),
-      drawer: const SideMenu(current: SideMenuSection.dashboard),
+      drawer: const SideMenu(current: SideMenuSection.checklistLiberacao),
       body: LayoutBuilder(
         builder: (context, constraints) {
           final isWide = constraints.maxWidth > 880;

--- a/lib/screens/main/components/side_menu.dart
+++ b/lib/screens/main/components/side_menu.dart
@@ -19,7 +19,14 @@ import 'package:admin/services/auth_service.dart';
 import 'package:admin/features/shared/providers/search_flow_form_provider.dart';
 import 'package:admin/features/checklist_liberacao/presentation/checklist_liberacao_page.dart';
 
-enum SideMenuSection { mainMenu, dashboard, preparador, operador, finalizar }
+enum SideMenuSection {
+  mainMenu,
+  dashboard,
+  preparador,
+  operador,
+  finalizar,
+  checklistLiberacao,
+}
 
 class SideMenu extends ConsumerWidget {
   const SideMenu({super.key, required this.current});
@@ -262,6 +269,21 @@ class SideMenu extends ConsumerWidget {
             },
           ),
         ]);
+        break;
+      case SideMenuSection.checklistLiberacao:
+        items.addAll([
+          DrawerListTile(
+            title: 'Liberação de máquina',
+            svgSrc: 'assets/icons/liberacao.svg',
+            press: () => Navigator.of(context).pop(),
+          ),
+          DrawerListTile(
+            title: 'Amostragem',
+            svgSrc: 'assets/icons/Amostragem.svg',
+            press: () => _navigate(context, ref, const OperadorPage()),
+          ),
+        ]);
+        break;
     }
 
     return Drawer(


### PR DESCRIPTION
## Summary
- add a dedicated SideMenuSection for the checklist de liberação flow and limit its drawer entries
- update the checklist page to use the pared down side menu configuration

## Testing
- flutter test *(fails: Unable to load asset "assets/icons/Checklist.svg" in existing widget test)*

------
https://chatgpt.com/codex/tasks/task_e_68e3abc621b88331a5ccdc234f1bb671