### PR TITLE
Prevent logout from popping root route

### DIFF
--- a/lib/widgets/profile_button.dart
+++ b/lib/widgets/profile_button.dart
@@ -16,7 +16,10 @@ class ProfileButton extends ConsumerWidget {
       onSelected: (value) {
         if (value == 'logout') {
           ref.read(authServiceProvider.notifier).logout();
-          Navigator.of(context).pop();
+          final navigator = Navigator.of(context);
+          if (navigator.canPop()) {
+            navigator.pop();
+          }
         } else if (value == 'manage') {
           Navigator.of(
             context,


### PR DESCRIPTION
## Summary
- guard the logout popup action so it only pops the current route when possible
- prevent logging out from the main menu from leaving the app on a blank screen

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e3ba4643bc8331befd1730f5083501