### PR TITLE
Prefill sampling RE from checklist

### DIFF
--- a/lib/features/operador/presentation/operador_page.dart
+++ b/lib/features/operador/presentation/operador_page.dart
@@ -221,6 +221,10 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
       _categoriaSel = shared.categoria;
       _maquinaSel = shared.maquina;
     }
+    final checklistRe = shared.normalizedChecklistRe;
+    if (checklistRe != null && checklistRe.isNotEmpty) {
+      _reCtrl.text = checklistRe;
+    }
 
     _osSyncListener = () {
       ref.read(sharedSearchFormProvider.notifier).setOs(_osCtrl.text);

--- a/lib/features/preparacao/presentation/preparacao_page.dart
+++ b/lib/features/preparacao/presentation/preparacao_page.dart
@@ -194,10 +194,6 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
       _categoriaSel = shared.categoria;
       _maquinaSel = shared.maquina;
     }
-    final checklistRe = shared.normalizedChecklistRe;
-    if (checklistRe != null && checklistRe.isNotEmpty) {
-      _reCtrl.text = checklistRe;
-    }
 
     _osSyncListener = () {
       ref.read(sharedSearchFormProvider.notifier).setOs(_osCtrl.text);

--- a/lib/features/preparacao/presentation/preparacao_page.dart
+++ b/lib/features/preparacao/presentation/preparacao_page.dart
@@ -194,6 +194,10 @@ class _PreparacaoPageState extends ConsumerState<PreparacaoPage> {
       _categoriaSel = shared.categoria;
       _maquinaSel = shared.maquina;
     }
+    final checklistRe = shared.normalizedChecklistRe;
+    if (checklistRe != null && checklistRe.isNotEmpty) {
+      _reCtrl.text = checklistRe;
+    }
 
     _osSyncListener = () {
       ref.read(sharedSearchFormProvider.notifier).setOs(_osCtrl.text);

--- a/lib/features/shared/providers/search_flow_form_provider.dart
+++ b/lib/features/shared/providers/search_flow_form_provider.dart
@@ -304,8 +304,22 @@ class SharedSearchFormController extends StateNotifier<SharedSearchFormState> {
   }
 
   void completeChecklist({String? checklistRe}) {
-    if (_isActive == false) return;
     final normalizedRe = SharedSearchFormState._normalizeOptional(checklistRe);
+    if (_isActive == false) {
+      if (!state.requiresChecklist &&
+          state.checklistReason == null &&
+          normalizedRe == state.checklistRe) {
+        return;
+      }
+      _updateState(
+        state.copyWith(
+          requiresChecklist: false,
+          checklistReason: null,
+          checklistRe: normalizedRe,
+        ),
+      );
+      return;
+    }
     if (!state.requiresChecklist &&
         state.checklistReason == null &&
         normalizedRe == state.checklistRe) {


### PR DESCRIPTION
## Summary
- allow checklist completion to persist the recorded R.E. even when no flow is active
- prefill the preparação form with the R.E. collected in the checklist so it propagates to amostragem

## Testing
- flutter analyze

------
https://chatgpt.com/codex/tasks/task_e_68e3e5c88010833186224ce5e2e596fc