### PR TITLE
Add operator sampling comparison dashboard page

### DIFF
--- a/lib/features/export_relatorios/presentation/operator_report_comparison_page.dart
+++ b/lib/features/export_relatorios/presentation/operator_report_comparison_page.dart
@@ -1,0 +1,449 @@
+import 'dart:collection';
+
+import 'package:collection/collection.dart';
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+
+import '../../../screens/dashboard/components/operator_chart_data.dart';
+import '../../../screens/main/components/side_menu.dart';
+import '../../../services/report_service.dart';
+import '../../../widgets/window_bar.dart';
+
+class OperatorReportComparisonPage extends StatefulWidget {
+  const OperatorReportComparisonPage({super.key});
+
+  @override
+  State<OperatorReportComparisonPage> createState() =>
+      _OperatorReportComparisonPageState();
+}
+
+class _OperatorReportComparisonPageState
+    extends State<OperatorReportComparisonPage> {
+  final _osController = TextEditingController();
+  final ReportService _service = ReportService();
+  final List<_ComparisonEntry> _entries = <_ComparisonEntry>[];
+
+  bool _loading = false;
+
+  @override
+  void dispose() {
+    _osController.dispose();
+    super.dispose();
+  }
+
+  String? get _currentPartnumber =>
+      _entries.isEmpty ? null : _entries.first.partnumber;
+  String? get _currentOperacao =>
+      _entries.isEmpty ? null : _entries.first.operacao;
+
+  Future<void> _addOs() async {
+    final os = _osController.text.trim();
+    if (os.isEmpty || _loading) return;
+    if (_entries.any((entry) => entry.os == os)) {
+      _showSnack('A O.S. $os já foi adicionada.');
+      return;
+    }
+
+    setState(() {
+      _loading = true;
+    });
+
+    try {
+      final data = await _service.fetchOperatorReleasesByOs(os);
+      if (!mounted) return;
+      if (data.isEmpty) {
+        _showSnack('Nenhum dado encontrado para a O.S. $os.');
+        return;
+      }
+
+      final partnumber =
+          data.firstWhereOrNull((r) => r.partnumber.isNotEmpty)?.partnumber ??
+          data.first.partnumber;
+      final operacao =
+          data.firstWhereOrNull((r) => r.operacao.isNotEmpty)?.operacao ??
+          data.first.operacao;
+
+      if (partnumber.isEmpty || operacao.isEmpty) {
+        _showSnack(
+          'Não foi possível identificar partnumber/operacao da O.S. $os.',
+        );
+        return;
+      }
+
+      final expectedPart = _currentPartnumber;
+      final expectedOp = _currentOperacao;
+      if (expectedPart != null &&
+          expectedOp != null &&
+          (expectedPart != partnumber || expectedOp != operacao)) {
+        _showSnack(
+          'A O.S. $os pertence a outro partnumber/operação e não pode ser comparada.',
+        );
+        return;
+      }
+
+      final color = _pickColor();
+      final series = OperatorChartUtils.buildSeries(data, color: color, os: os);
+      if (series.isEmpty) {
+        _showSnack('A O.S. $os não possui medidas com dados para exibir.');
+        return;
+      }
+
+      final map = LinkedHashMap<int, OperatorMeasurementSeries>.fromEntries(
+        series.map((item) => MapEntry(item.measurementIndex, item)),
+      );
+
+      setState(() {
+        _entries.add(
+          _ComparisonEntry(
+            os: os,
+            partnumber: partnumber,
+            operacao: operacao,
+            color: color,
+            seriesByMeasurement: map,
+          ),
+        );
+        _osController.clear();
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _loading = false;
+        });
+      }
+    }
+  }
+
+  void _removeEntry(_ComparisonEntry entry) {
+    setState(() {
+      _entries.remove(entry);
+    });
+  }
+
+  Color _pickColor() {
+    const palette = <Color>[
+      Colors.blue,
+      Colors.orange,
+      Colors.green,
+      Colors.purple,
+      Colors.cyan,
+      Colors.pink,
+    ];
+    final used = _entries.map((e) => e.color).toSet();
+    for (final color in palette) {
+      if (!used.contains(color)) return color;
+    }
+    // Fallback: cycle through palette
+    return palette[_entries.length % palette.length];
+  }
+
+  void _showSnack(String message) {
+    ScaffoldMessenger.of(context)
+      ..clearSnackBars()
+      ..showSnackBar(SnackBar(content: Text(message)));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final measurementKeys = SplayTreeSet<int>();
+    for (final entry in _entries) {
+      measurementKeys.addAll(entry.seriesByMeasurement.keys);
+    }
+
+    return Scaffold(
+      appBar: const WindowBar(
+        title: 'Comparar amostragens (Operador)',
+        showMenu: true,
+      ),
+      drawer: const SideMenu(current: SideMenuSection.dashboard),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'Compare as curvas de amostragem por O.S.',
+                style: Theme.of(context).textTheme.titleLarge,
+              ),
+              const SizedBox(height: 8),
+              const Text(
+                'Adicione O.S. com o mesmo partnumber/operação para visualizar as curvas lado a lado.',
+              ),
+              const SizedBox(height: 16),
+              LayoutBuilder(
+                builder: (context, constraints) {
+                  final isCompact = constraints.maxWidth < 520;
+                  final field = SizedBox(
+                    width: isCompact ? double.infinity : 280,
+                    child: TextField(
+                      controller: _osController,
+                      decoration: const InputDecoration(
+                        labelText: 'Número da O.S.',
+                        border: OutlineInputBorder(),
+                      ),
+                      onSubmitted: (_) => _addOs(),
+                    ),
+                  );
+                  final button = ElevatedButton.icon(
+                    onPressed: _addOs,
+                    icon: const Icon(Icons.add),
+                    label: const Text('Adicionar O.S.'),
+                  );
+                  if (isCompact) {
+                    return Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        field,
+                        const SizedBox(height: 12),
+                        Align(alignment: Alignment.centerRight, child: button),
+                      ],
+                    );
+                  }
+                  return Row(
+                    children: [field, const SizedBox(width: 12), button],
+                  );
+                },
+              ),
+              if (_loading) const LinearProgressIndicator(),
+              const SizedBox(height: 16),
+              if (_entries.isEmpty)
+                Expanded(
+                  child: Center(
+                    child: Text(
+                      'Informe pelo menos uma O.S. para iniciar a comparação.',
+                      style: Theme.of(context).textTheme.bodyLarge,
+                    ),
+                  ),
+                )
+              else ...[
+                _ComparisonSummary(entries: _entries, onRemove: _removeEntry),
+                const SizedBox(height: 16),
+                Expanded(
+                  child: ListView(
+                    children: [
+                      for (final measurement in measurementKeys)
+                        _ComparisonChart(
+                          measurement: measurement,
+                          series: _entries
+                              .map(
+                                (entry) =>
+                                    entry.seriesByMeasurement[measurement],
+                              )
+                              .whereType<OperatorMeasurementSeries>()
+                              .toList(),
+                          missingOs: _entries
+                              .where(
+                                (entry) => !entry.seriesByMeasurement
+                                    .containsKey(measurement),
+                              )
+                              .map((entry) => entry.os)
+                              .toList(growable: false),
+                        ),
+                    ],
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ComparisonEntry {
+  _ComparisonEntry({
+    required this.os,
+    required this.partnumber,
+    required this.operacao,
+    required this.color,
+    required this.seriesByMeasurement,
+  });
+
+  final String os;
+  final String partnumber;
+  final String operacao;
+  final Color color;
+  final LinkedHashMap<int, OperatorMeasurementSeries> seriesByMeasurement;
+}
+
+class _ComparisonSummary extends StatelessWidget {
+  const _ComparisonSummary({required this.entries, required this.onRemove});
+
+  final List<_ComparisonEntry> entries;
+  final ValueChanged<_ComparisonEntry> onRemove;
+
+  @override
+  Widget build(BuildContext context) {
+    final partnumber = entries.first.partnumber;
+    final operacao = entries.first.operacao;
+
+    return Card(
+      margin: EdgeInsets.zero,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Partnumber: $partnumber | Operação: $operacao',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                for (final entry in entries)
+                  InputChip(
+                    backgroundColor: entry.color.withValues(alpha: 0.15),
+                    avatar: CircleAvatar(
+                      backgroundColor: entry.color,
+                      radius: 5,
+                    ),
+                    label: Text('O.S. ${entry.os}'),
+                    onDeleted: () => onRemove(entry),
+                    deleteIcon: const Icon(Icons.close),
+                  ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ComparisonChart extends StatelessWidget {
+  const _ComparisonChart({
+    required this.measurement,
+    required this.series,
+    required this.missingOs,
+  });
+
+  final int measurement;
+  final List<OperatorMeasurementSeries> series;
+  final List<String> missingOs;
+
+  @override
+  Widget build(BuildContext context) {
+    if (series.isEmpty) {
+      return const SizedBox.shrink();
+    }
+    final label = series.first.label;
+    final missing = List<String>.from(missingOs);
+
+    final bars = <LineChartBarData>[];
+    final tooltips = <LineChartBarData, OperatorMeasurementSeries>{};
+    for (final s in series) {
+      if (s.spots.isEmpty) {
+        missing.add(s.os);
+        continue;
+      }
+      final bar = LineChartBarData(
+        spots: s.spots,
+        isCurved: false,
+        barWidth: 3,
+        color: s.color,
+        dotData: FlDotData(show: true),
+      );
+      bars.add(bar);
+      tooltips[bar] = s;
+    }
+
+    if (bars.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    final maxLength = bars
+        .map((bar) => bar.spots.isNotEmpty ? bar.spots.last.x : 0.0)
+        .fold<double>(0, (prev, current) => current > prev ? current : prev);
+
+    final verticalLines = series.expand((s) => s.verticalLines).toList();
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 24),
+      child: Card(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(label, style: Theme.of(context).textTheme.titleMedium),
+              const SizedBox(height: 12),
+              SizedBox(
+                height: 220,
+                child: LineChart(
+                  LineChartData(
+                    minY: -2,
+                    maxY: 2,
+                    minX: 0,
+                    maxX: maxLength,
+                    lineTouchData: LineTouchData(
+                      touchTooltipData: LineTouchTooltipData(
+                        getTooltipItems: (touchedSpots) {
+                          return touchedSpots
+                              .map((spot) {
+                                final bar = bars[spot.barIndex];
+                                final currentSeries = tooltips[bar];
+                                if (currentSeries == null) {
+                                  return null;
+                                }
+                                final index = spot.x.round().clamp(
+                                  0,
+                                  currentSeries.reports.length - 1,
+                                );
+                                final label = currentSeries.tooltipLabel(index);
+                                return LineTooltipItem(
+                                  'OS ${currentSeries.os}: $label',
+                                  TextStyle(color: currentSeries.color),
+                                );
+                              })
+                              .whereType<LineTooltipItem>()
+                              .toList();
+                        },
+                      ),
+                    ),
+                    titlesData: FlTitlesData(
+                      leftTitles: AxisTitles(
+                        sideTitles: SideTitles(
+                          showTitles: true,
+                          reservedSize: 72,
+                          getTitlesWidget: (value, meta) =>
+                              OperatorChartUtils.buildStatusLegend(value),
+                        ),
+                      ),
+                      bottomTitles: AxisTitles(
+                        sideTitles: SideTitles(showTitles: false),
+                      ),
+                      topTitles: AxisTitles(
+                        sideTitles: SideTitles(showTitles: false),
+                      ),
+                      rightTitles: AxisTitles(
+                        sideTitles: SideTitles(showTitles: false),
+                      ),
+                    ),
+                    lineBarsData: bars,
+                    extraLinesData: ExtraLinesData(
+                      verticalLines: verticalLines,
+                    ),
+                  ),
+                ),
+              ),
+              if (missing.isNotEmpty)
+                Padding(
+                  padding: const EdgeInsets.only(top: 8),
+                  child: Text(
+                    'Sem dados para esta medida nas O.S.: ${missing.join(', ')}.',
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: Colors.orange.shade700,
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/models/report.dart
+++ b/lib/models/report.dart
@@ -11,6 +11,9 @@ class Report {
   /// Friendly text describing the allowed measurement range.
   final String faixaTexto;
 
+  /// Machine where the sampling or event was recorded.
+  final String maquina;
+
   /// Registration number (RE) of the preparer who handled this report.
   final String rePreparador;
 
@@ -39,6 +42,7 @@ class Report {
     required this.status,
     required this.createdAt,
     this.faixaTexto = '',
+    this.maquina = '',
     this.rePreparador = '',
     this.reOperador = '',
     this.idxMedida,
@@ -56,6 +60,7 @@ class Report {
       status: (json['status_geral'] ?? json['status'])?.toString() ?? '',
       createdAt: json['created_at']?.toString() ?? '',
       faixaTexto: (json['faixa_texto'] ?? json['faixaTexto'])?.toString() ?? '',
+      maquina: json['maquina']?.toString() ?? '',
       rePreparador: json['re_preparador']?.toString() ?? '',
       reOperador: json['re_operador']?.toString() ?? '',
       idxMedida: json['idx_medida'] != null

--- a/lib/screens/dashboard/components/operator_chart_data.dart
+++ b/lib/screens/dashboard/components/operator_chart_data.dart
@@ -1,0 +1,186 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../../../models/report.dart';
+import '../../../features/operador/data/models.dart';
+
+/// Helper utilities to prepare chart data for operator sampling charts.
+class OperatorChartUtils {
+  OperatorChartUtils._();
+
+  /// Maps a status string returned by the API to the numeric value used in the
+  /// chart's Y axis.
+  static double statusToValue(String status) {
+    switch (statusFromString(status)) {
+      case StatusMedida.reprovadaAbaixo:
+        return -2;
+      case StatusMedida.alertaAbaixo:
+        return -1;
+      case StatusMedida.ok:
+      case StatusMedida.pendente:
+        return 0;
+      case StatusMedida.alertaAcima:
+        return 1;
+      case StatusMedida.reprovadaAcima:
+        return 2;
+    }
+  }
+
+  /// Returns the color associated with a status.
+  static Color statusColor(StatusMedida status) {
+    switch (status) {
+      case StatusMedida.ok:
+        return Colors.green.shade600;
+      case StatusMedida.reprovadaAbaixo:
+      case StatusMedida.reprovadaAcima:
+        return Colors.red.shade400;
+      case StatusMedida.alertaAbaixo:
+      case StatusMedida.alertaAcima:
+        return Colors.amber.shade700;
+      case StatusMedida.pendente:
+        return Colors.grey;
+    }
+  }
+
+  /// Builds the legend widget used on the chart's Y axis for the given value.
+  static Widget buildStatusLegend(double value) {
+    late final StatusMedida status;
+    late final String text;
+    switch (value.toInt()) {
+      case -2:
+        status = StatusMedida.reprovadaAbaixo;
+        text = 'Repr. -';
+        break;
+      case -1:
+        status = StatusMedida.alertaAbaixo;
+        text = 'Alerta -';
+        break;
+      case 0:
+        status = StatusMedida.ok;
+        text = 'OK';
+        break;
+      case 1:
+        status = StatusMedida.alertaAcima;
+        text = 'Alerta +';
+        break;
+      case 2:
+        status = StatusMedida.reprovadaAcima;
+        text = 'Repr. +';
+        break;
+      default:
+        return const SizedBox.shrink();
+    }
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Container(
+          width: 10,
+          height: 10,
+          decoration: BoxDecoration(
+            color: statusColor(status),
+            shape: BoxShape.circle,
+          ),
+        ),
+        const SizedBox(width: 4),
+        Text(text),
+      ],
+    );
+  }
+
+  /// Creates a list of measurement series grouped by [Report.idxMedida].
+  static List<OperatorMeasurementSeries> buildSeries(
+    List<Report> reports, {
+    required Color color,
+    required String os,
+  }) {
+    final grouped = <int, List<Report>>{};
+    for (final report in reports) {
+      final idx = report.idxMedida;
+      if (idx == null) continue;
+      grouped.putIfAbsent(idx, () => <Report>[]).add(report);
+    }
+    final formatter = DateFormat.Hm();
+    return grouped.entries.map((entry) {
+      final sorted = entry.value
+        ..sort((a, b) {
+          final aDate = DateTime.tryParse(a.createdAt) ?? DateTime(0);
+          final bDate = DateTime.tryParse(b.createdAt) ?? DateTime(0);
+          return aDate.compareTo(bDate);
+        });
+      final spots = <FlSpot>[];
+      final verticalLines = <VerticalLine>[];
+      for (var i = 0; i < sorted.length; i++) {
+        final report = sorted[i];
+        final lowered = report.status.toLowerCase();
+        spots.add(FlSpot(i.toDouble(), statusToValue(lowered)));
+        if (lowered.contains('pausa') && lowered.contains('jornada')) {
+          verticalLines.add(
+            VerticalLine(x: i.toDouble(), color: Colors.orange, strokeWidth: 2),
+          );
+        } else if (lowered.contains('fim') && lowered.contains('jornada')) {
+          verticalLines.add(
+            VerticalLine(x: i.toDouble(), color: Colors.orange, strokeWidth: 2),
+          );
+        } else if (lowered.contains('encerrar') ||
+            lowered.contains('encerramento')) {
+          verticalLines.add(
+            VerticalLine(x: i.toDouble(), color: Colors.red, strokeWidth: 2),
+          );
+        }
+      }
+      final first = sorted.first;
+      final title = first.titulo.isNotEmpty
+          ? first.titulo
+          : 'Medida ${entry.key}';
+      final faixa = first.faixaTexto.isNotEmpty
+          ? first.faixaTexto
+          : 'faixa_texto ${entry.key}';
+      final label = faixa.isNotEmpty ? '$title - $faixa' : title;
+      return OperatorMeasurementSeries(
+        measurementIndex: entry.key,
+        label: label,
+        os: os,
+        reports: List<Report>.unmodifiable(sorted),
+        spots: List<FlSpot>.unmodifiable(spots),
+        verticalLines: List<VerticalLine>.unmodifiable(verticalLines),
+        color: color,
+        tooltipFormatter: (report) {
+          final dt = DateTime.tryParse(report.createdAt);
+          if (dt != null) {
+            return formatter.format(dt.toLocal());
+          }
+          return report.createdAt;
+        },
+      );
+    }).toList();
+  }
+}
+
+/// Represents a series in the chart for a specific measurement index.
+class OperatorMeasurementSeries {
+  OperatorMeasurementSeries({
+    required this.measurementIndex,
+    required this.label,
+    required this.os,
+    required this.reports,
+    required this.spots,
+    required this.verticalLines,
+    required this.color,
+    required String Function(Report report) tooltipFormatter,
+  }) : _tooltipFormatter = tooltipFormatter;
+
+  final int measurementIndex;
+  final String label;
+  final String os;
+  final List<Report> reports;
+  final List<FlSpot> spots;
+  final List<VerticalLine> verticalLines;
+  final Color color;
+  final String Function(Report report) _tooltipFormatter;
+
+  String tooltipLabel(int index) {
+    if (index < 0 || index >= reports.length) return '';
+    return _tooltipFormatter(reports[index]);
+  }
+}

--- a/lib/screens/dashboard/components/operator_chart_data.dart
+++ b/lib/screens/dashboard/components/operator_chart_data.dart
@@ -147,10 +147,14 @@ class OperatorChartUtils {
         color: color,
         tooltipFormatter: (report) {
           final dt = DateTime.tryParse(report.createdAt);
-          if (dt != null) {
-            return formatter.format(dt.toLocal());
+          final timeLabel = dt != null
+              ? formatter.format(dt.toLocal())
+              : report.createdAt;
+          final machine = report.maquina.trim();
+          if (machine.isEmpty) {
+            return timeLabel;
           }
-          return report.createdAt;
+          return '$timeLabel\nMáquina: $machine';
         },
       );
     }).toList();

--- a/lib/screens/dashboard/components/operator_report_chart.dart
+++ b/lib/screens/dashboard/components/operator_report_chart.dart
@@ -4,8 +4,7 @@ import 'package:flutter/material.dart';
 import '../../../constants.dart';
 import '../../../models/report.dart';
 import '../../../services/report_service.dart';
-import '../../../features/operador/data/models.dart';
-import 'package:intl/intl.dart';
+import 'operator_chart_data.dart';
 
 /// Displays a line chart showing the progression of operator samplings.
 /// The user must provide an OS number to fetch the report. End-of-shift
@@ -36,38 +35,6 @@ class _OperatorReportChartState extends State<OperatorReportChart> {
     setState(() {
       _future = service.fetchOperatorReleasesByOs(os);
     });
-  }
-
-  double _statusToValue(String status) {
-    switch (statusFromString(status)) {
-      case StatusMedida.reprovadaAbaixo:
-        return -2;
-      case StatusMedida.alertaAbaixo:
-        return -1;
-      case StatusMedida.ok:
-      case StatusMedida.pendente:
-        return 0;
-      case StatusMedida.alertaAcima:
-        return 1;
-      case StatusMedida.reprovadaAcima:
-        return 2;
-    }
-  }
-
-  Color _statusColor(StatusMedida st) {
-    switch (st) {
-      case StatusMedida.ok:
-        return Colors.green.shade600;
-      case StatusMedida.reprovadaAbaixo:
-        return Colors.red.shade400;
-      case StatusMedida.reprovadaAcima:
-        return Colors.red.shade400;
-      case StatusMedida.alertaAbaixo:
-      case StatusMedida.alertaAcima:
-        return Colors.amber.shade700;
-      case StatusMedida.pendente:
-        return Colors.grey;
-    }
   }
 
   @override
@@ -136,69 +103,19 @@ class _OperatorReportChartState extends State<OperatorReportChart> {
                 return const Text('Nenhum dado encontrado para a OS.');
               }
 
-              final grouped = <int, List<Report>>{};
-              for (final r in data) {
-                if (r.idxMedida == null) continue;
-                grouped.putIfAbsent(r.idxMedida!, () => []).add(r);
-              }
-              if (grouped.isEmpty) {
+              final series = OperatorChartUtils.buildSeries(
+                data,
+                color: Colors.blue,
+                os: data.first.os,
+              );
+              if (series.isEmpty) {
                 return const Text('Nenhum dado encontrado para a OS.');
               }
 
               return Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
-                children: grouped.entries.map((entry) {
-                  final reports = entry.value
-                    ..sort(
-                          (a, b) => (DateTime.tryParse(a.createdAt) ?? DateTime(0))
-                          .compareTo(
-                        DateTime.tryParse(b.createdAt) ?? DateTime(0),
-                      ),
-                    );
-                  final spots = <FlSpot>[];
-                  final verticalLines = <VerticalLine>[];
-                  for (var i = 0; i < reports.length; i++) {
-                    final r = reports[i];
-                    final lowered = r.status.toLowerCase();
-                    spots.add(FlSpot(i.toDouble(), _statusToValue(lowered)));
-                    if (lowered.contains('pausa') &&
-                        lowered.contains('jornada')) {
-                      verticalLines.add(
-                        VerticalLine(
-                          x: i.toDouble(),
-                          color: Colors.orange,
-                          strokeWidth: 2,
-                        ),
-                      );
-                    } else if (lowered.contains('fim') &&
-                        lowered.contains('jornada')) {
-                      verticalLines.add(
-                        VerticalLine(
-                          x: i.toDouble(),
-                          color: Colors.orange,
-                          strokeWidth: 2,
-                        ),
-                      );
-                    } else if (lowered.contains('encerrar') ||
-                        lowered.contains('encerramento')) {
-                      verticalLines.add(
-                        VerticalLine(
-                          x: i.toDouble(),
-                          color: Colors.red,
-                          strokeWidth: 2,
-                        ),
-                      );
-                    }
-                  }
-
-                  final first = reports.first;
-                  final title = first.titulo.isNotEmpty
-                      ? first.titulo
-                      : 'Medida ${entry.key}';
-                  final faixa = first.faixaTexto.isNotEmpty
-                      ? first.faixaTexto
-                      : 'faixa_texto ${entry.key}';
-                  final label = faixa.isNotEmpty ? '$title - $faixa' : title;
+                children: series.map((measurement) {
+                  final label = measurement.label;
 
                   return Padding(
                     padding: const EdgeInsets.only(bottom: defaultPadding),
@@ -221,13 +138,13 @@ class _OperatorReportChartState extends State<OperatorReportChart> {
                                 touchTooltipData: LineTouchTooltipData(
                                   getTooltipItems: (touchedSpots) {
                                     return touchedSpots.map((spot) {
-                                      final report = reports[spot.x.toInt()];
-                                      final dt = DateTime.tryParse(
-                                        report.createdAt,
+                                      final index = spot.x.round().clamp(
+                                        0,
+                                        measurement.reports.length - 1,
                                       );
-                                      final label = dt != null
-                                          ? DateFormat.Hm().format(dt.toLocal())
-                                          : report.createdAt;
+                                      final label = measurement.tooltipLabel(
+                                        index,
+                                      );
                                       return LineTooltipItem(
                                         label,
                                         const TextStyle(color: Colors.white),
@@ -241,49 +158,10 @@ class _OperatorReportChartState extends State<OperatorReportChart> {
                                   sideTitles: SideTitles(
                                     showTitles: true,
                                     reservedSize: 72,
-                                    getTitlesWidget: (value, meta) {
-                                      late final StatusMedida st;
-                                      late final String text;
-                                      switch (value.toInt()) {
-                                        case -2:
-                                          st = StatusMedida.reprovadaAbaixo;
-                                          text = 'Repr. -';
-                                          break;
-                                        case -1:
-                                          st = StatusMedida.alertaAbaixo;
-                                          text = 'Alerta -';
-                                          break;
-                                        case 0:
-                                          st = StatusMedida.ok;
-                                          text = 'OK';
-                                          break;
-                                        case 1:
-                                          st = StatusMedida.alertaAcima;
-                                          text = 'Alerta +';
-                                          break;
-                                        case 2:
-                                          st = StatusMedida.reprovadaAcima;
-                                          text = 'Repr. +';
-                                          break;
-                                        default:
-                                          return const SizedBox.shrink();
-                                      }
-                                      return Row(
-                                        mainAxisSize: MainAxisSize.min,
-                                        children: [
-                                          Container(
-                                            width: 10,
-                                            height: 10,
-                                            decoration: BoxDecoration(
-                                              color: _statusColor(st),
-                                              shape: BoxShape.circle,
-                                            ),
-                                          ),
-                                          const SizedBox(width: 4),
-                                          Text(text),
-                                        ],
-                                      );
-                                    },
+                                    getTitlesWidget: (value, meta) =>
+                                        OperatorChartUtils.buildStatusLegend(
+                                          value,
+                                        ),
                                   ),
                                 ),
                                 bottomTitles: AxisTitles(
@@ -298,15 +176,15 @@ class _OperatorReportChartState extends State<OperatorReportChart> {
                               ),
                               lineBarsData: [
                                 LineChartBarData(
-                                  spots: spots,
+                                  spots: measurement.spots,
                                   isCurved: false,
                                   barWidth: 3,
-                                  color: Colors.blue,
+                                  color: measurement.color,
                                   dotData: FlDotData(show: true),
                                 ),
                               ],
                               extraLinesData: ExtraLinesData(
-                                verticalLines: verticalLines,
+                                verticalLines: measurement.verticalLines,
                               ),
                             ),
                           ),

--- a/lib/screens/main/components/side_menu.dart
+++ b/lib/screens/main/components/side_menu.dart
@@ -11,6 +11,7 @@ import 'package:admin/features/export_relatorios/presentation/export_relatorios_
 import 'package:admin/features/export_relatorios/presentation/status_os_page.dart';
 import 'package:admin/features/export_relatorios/presentation/tempo_os_page.dart';
 import 'package:admin/features/export_relatorios/presentation/relatorios_insights_page.dart';
+import 'package:admin/features/export_relatorios/presentation/operator_report_comparison_page.dart';
 import 'package:admin/features/cadastro_maquinas/presentation/cadastro_maquinas_page.dart';
 import 'package:admin/features/login/login_page.dart';
 import 'package:admin/features/users/users_page.dart';
@@ -139,6 +140,12 @@ class SideMenu extends ConsumerWidget {
           title: 'Insights de relatórios',
           svgSrc: 'assets/icons/menu_doc.svg',
           press: () => _navigate(context, ref, const RelatoriosInsightsPage()),
+        ),
+        DrawerListTile(
+          title: 'Comparar amostragens',
+          svgSrc: 'assets/icons/menu_doc.svg',
+          press: () =>
+              _navigate(context, ref, const OperatorReportComparisonPage()),
         ),
       ]);
     }


### PR DESCRIPTION
## Summary
- add a comparison page that lets supervisors plot operator sampling curves for multiple OS with the same partnumber/operação
- extract reusable chart helpers so the existing operator report chart and the comparison page share tooltip/legend logic
- link the new comparison page from the dashboard side menu for quick access

## Testing
- flutter analyze

------
https://chatgpt.com/codex/tasks/task_e_68e6570efbbc8331b13c4c327c6dbb43