### PR TITLE
Suporte a encerramento parcial de OS por máquina

### DIFF
--- a/app_db.py
+++ b/app_db.py
@@ -2371,9 +2371,14 @@ def operador_encerrar_producao():
     if not os_num:
         return jsonify({"error": "Campo 'os' é obrigatório"}), 400
     try:
+        novo_status = None
+        ja_finalizada = False
         with _conn_db(DB_NAME) as c:
             with c.cursor() as cur:
                 filtro_contexto = _sql_operador_context_filter("operador_amostragem")
+                cur.execute("SELECT status FROM ordem_servico WHERE os=%s", (os_num,))
+                status_row = cur.fetchone() or {}
+                status_global = (status_row.get("status") or "").strip().lower()
                 if not maquina:
                     cur.execute(
                         """
@@ -2391,7 +2396,6 @@ def operador_encerrar_producao():
                     if len(encontradas) == 1:
                         maquina = encontradas[0]
 
-                novo_status = None
                 if maquina:
                     cur.execute("SELECT 1 FROM maquinas WHERE codigo=%s", (maquina,))
                     if not cur.fetchone():
@@ -2415,12 +2419,29 @@ def operador_encerrar_producao():
                         )
 
                     cur.execute(
-                        "INSERT INTO ordem_servico (os) VALUES (%s)"
-                        " ON DUPLICATE KEY UPDATE os = VALUES(os)",
-                        (os_num,),
+                        "SELECT status FROM ordem_servico_maquina WHERE os=%s AND maquina=%s",
+                        (os_num, maquina),
                     )
-                    _upsert_os_maquina_status(cur, os_num, maquina, "fim_prod")
-                    novo_status = _consolidar_status_os(cur, os_num)
+                    status_maquina_row = cur.fetchone() or {}
+                    status_maquina = (status_maquina_row.get("status") or "").strip().lower()
+
+                    if status_maquina == "encerrada":
+                        ja_finalizada = True
+                        consolidado = _consolidar_status_os(cur, os_num)
+                        if consolidado:
+                            novo_status = consolidado
+                        elif status_global:
+                            novo_status = status_global
+                        else:
+                            novo_status = "encerrada"
+                    else:
+                        cur.execute(
+                            "INSERT INTO ordem_servico (os) VALUES (%s)"
+                            " ON DUPLICATE KEY UPDATE os = VALUES(os)",
+                            (os_num,),
+                        )
+                        _upsert_os_maquina_status(cur, os_num, maquina, "fim_prod")
+                        novo_status = _consolidar_status_os(cur, os_num)
                 else:
                     cur.execute(
                         f"SELECT COUNT(*) AS cnt FROM operador_amostragem"
@@ -2433,18 +2454,25 @@ def operador_encerrar_producao():
                             jsonify({"error": "Nenhum registro de amostragem encontrado"}),
                             400,
                         )
-                    cur.execute(
-                        "UPDATE ordem_servico SET status='fim_prod' WHERE os=%s",
-                        (os_num,),
-                    )
-                    if cur.rowcount == 0:
-                        return jsonify({"error": "OS não encontrada"}), 404
+                    if status_global == "encerrada":
+                        ja_finalizada = True
+                        novo_status = "encerrada"
+                    else:
+                        cur.execute(
+                            "UPDATE ordem_servico SET status='fim_prod' WHERE os=%s",
+                            (os_num,),
+                        )
+                        if cur.rowcount == 0:
+                            return jsonify({"error": "OS não encontrada"}), 404
+                        novo_status = "fim_prod"
             c.commit()
         resposta = {"status": "ok"}
         if maquina:
             resposta["maquina"] = maquina
         if novo_status:
             resposta["os_status"] = novo_status
+        if ja_finalizada and "os_status" not in resposta:
+            resposta["os_status"] = "encerrada"
         return jsonify(resposta)
     except Exception as e:
         return jsonify({"error": f"Falha ao encerrar produção: {e}"}), 500

--- a/app_db.py
+++ b/app_db.py
@@ -162,6 +162,19 @@ def _ensure_schema():
                   """
             )
             _ensure_column(c, "ordem_servico", "status", "VARCHAR(32) DEFAULT 'aberta'")
+            cur.execute(
+                """
+                  CREATE TABLE IF NOT EXISTS ordem_servico_maquina (
+                    os VARCHAR(64) NOT NULL,
+                    maquina VARCHAR(128) NOT NULL,
+                    status VARCHAR(32) NOT NULL DEFAULT 'aberta',
+                    atualizado_em TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                    PRIMARY KEY (os, maquina),
+                    KEY idx_osm_status (status),
+                    CONSTRAINT fk_osm_os FOREIGN KEY (os) REFERENCES ordem_servico(os) ON UPDATE CASCADE
+                  ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+                """
+            )
             # Operador (já estava)
 
             cur.execute(
@@ -928,6 +941,67 @@ def _outra_os_em_andamento(
     return (False, None)
 
 
+def _upsert_os_maquina_status(cur, os_num: str, maquina: str, status: str) -> None:
+    os_norm = _norm(os_num)
+    maq_norm = _norm(maquina)
+    status_norm = (_norm(status) or "aberta").lower()
+    if not os_norm or not maq_norm:
+        return
+    cur.execute(
+        """
+        INSERT INTO ordem_servico_maquina (os, maquina, status)
+        VALUES (%s, %s, %s)
+        ON DUPLICATE KEY UPDATE
+            status = VALUES(status),
+            atualizado_em = CURRENT_TIMESTAMP
+        """,
+        (os_norm, maq_norm, status_norm),
+    )
+
+
+def _consolidar_status_os(cur, os_num: str) -> Optional[str]:
+    os_norm = _norm(os_num)
+    if not os_norm:
+        return None
+
+    cur.execute(
+        "SELECT status FROM ordem_servico_maquina WHERE os=%s",
+        (os_norm,),
+    )
+    rows = cur.fetchall()
+    if not rows:
+        return None
+
+    status_set = {
+        (_norm(row.get("status")) or "").lower() for row in rows
+        if row.get("status") is not None
+    }
+    status_set.discard("")
+    if not status_set:
+        return None
+
+    if status_set <= {"encerrada"}:
+        novo_status = "encerrada"
+    elif "fim_prod" in status_set:
+        novo_status = "fim_prod" if status_set <= {"fim_prod"} else "parcial"
+    elif "encerrada" in status_set:
+        novo_status = "parcial"
+    elif "pausada" in status_set:
+        novo_status = "pausada"
+    elif "liberada" in status_set:
+        novo_status = "liberada"
+    elif "aberta" in status_set:
+        novo_status = "aberta"
+    else:
+        novo_status = next(iter(status_set))
+
+    cur.execute(
+        "UPDATE ordem_servico SET status=%s WHERE os=%s",
+        (novo_status, os_norm),
+    )
+    return novo_status
+
+
 def _maquina_liberada(
         conn, os_num: str, part: str, op: str, maquina: str
 ) -> Tuple[bool, str, str]:
@@ -1559,6 +1633,13 @@ def resultado_preparador():
                     "UPDATE ordem_servico SET status=%s WHERE os=%s",
                     (novo_status_os, os_num),
                 )
+                _upsert_os_maquina_status(
+                    cur,
+                    os_num,
+                    maquina,
+                    "liberada" if all_ok else "aberta",
+                )
+                _consolidar_status_os(cur, os_num)
 
                 if contexto_tipo == "troca_ferramenta":
                     cur.execute(
@@ -1681,24 +1762,47 @@ def preparador_finalizar_os():
                     )
 
                 cur.execute("SELECT status FROM ordem_servico WHERE os=%s", (os_num,))
-                st = (cur.fetchone() or {}).get("status", "").lower()
-                if st == "encerrada":
+                st_global = (cur.fetchone() or {}).get("status", "").lower()
+                cur.execute(
+                    "SELECT status FROM ordem_servico_maquina WHERE os=%s AND maquina=%s",
+                    (os_num, maquina),
+                )
+                st_maquina = (cur.fetchone() or {}).get("status", "").lower()
+                if st_maquina == "encerrada":
                     return (
                         jsonify(
-                            {"code": "ja_finalizada", "error": "OS já finalizada."}
+                            {"code": "ja_finalizada", "error": "OS já finalizada nesta máquina."}
                         ),
                         409,
                     )
-                if st != "fim_prod":
+                if st_maquina and st_maquina != "fim_prod":
                     return (
                         jsonify(
                             {
                                 "code": "producao_nao_encerrada",
-                                "error": "Produção não encerrada pelo operador.",
+                                "error": "Produção não encerrada pelo operador nesta máquina.",
                             }
                         ),
                         409,
                     )
+                if not st_maquina:
+                    if st_global == "encerrada":
+                        return (
+                            jsonify(
+                                {"code": "ja_finalizada", "error": "OS já finalizada."}
+                            ),
+                            409,
+                        )
+                    if st_global != "fim_prod":
+                        return (
+                            jsonify(
+                                {
+                                    "code": "producao_nao_encerrada",
+                                    "error": "Produção não encerrada pelo operador.",
+                                }
+                            ),
+                            409,
+                        )
 
                 cur.execute(
                     "INSERT IGNORE INTO ordem_servico (os) VALUES (%s)", (os_num,)
@@ -1758,10 +1862,8 @@ def preparador_finalizar_os():
                     for s in all_status
                 )
                 status_geral = "Liberada" if all_ok else "Pendente"
-                cur.execute(
-                    "UPDATE ordem_servico SET status='encerrada' WHERE os=%s",
-                    (os_num,),
-                )
+                _upsert_os_maquina_status(cur, os_num, maquina, "encerrada")
+                _consolidar_status_os(cur, os_num)
             c.commit()
 
         return jsonify(
@@ -2265,31 +2367,85 @@ def operador_troca_os():
 def operador_encerrar_producao():
     payload = request.get_json(silent=True) or {}
     os_num = _norm(payload.get("os"))
+    maquina = _norm(payload.get("maquina"))
     if not os_num:
         return jsonify({"error": "Campo 'os' é obrigatório"}), 400
     try:
         with _conn_db(DB_NAME) as c:
             with c.cursor() as cur:
                 filtro_contexto = _sql_operador_context_filter("operador_amostragem")
-                cur.execute(
-                    f"SELECT COUNT(*) AS cnt FROM operador_amostragem"
-                    " WHERE os=%s AND "
-                    f"{filtro_contexto}",
-                    (os_num,),
-                )
-                if cur.fetchone()["cnt"] == 0:
-                    return (
-                        jsonify({"error": "Nenhum registro de amostragem encontrado"}),
-                        400,
+                if not maquina:
+                    cur.execute(
+                        """
+                        SELECT DISTINCT maquina
+                          FROM preparador_liberacao
+                         WHERE os=%s AND maquina IS NOT NULL AND maquina <> ''
+                        """,
+                        (os_num,),
                     )
-                cur.execute(
-                    "UPDATE ordem_servico SET status='fim_prod' WHERE os=%s",
-                    (os_num,),
-                )
-                if cur.rowcount == 0:
-                    return jsonify({"error": "OS não encontrada"}), 404
+                    encontradas = [
+                        _norm(row.get("maquina"))
+                        for row in cur.fetchall()
+                        if _norm(row.get("maquina"))
+                    ]
+                    if len(encontradas) == 1:
+                        maquina = encontradas[0]
+
+                novo_status = None
+                if maquina:
+                    cur.execute("SELECT 1 FROM maquinas WHERE codigo=%s", (maquina,))
+                    if not cur.fetchone():
+                        return jsonify({"error": "Máquina não cadastrada"}), 400
+
+                    cur.execute(
+                        f"SELECT COUNT(*) AS cnt FROM operador_amostragem"
+                        " WHERE os=%s AND maquina=%s AND "
+                        f"{filtro_contexto}",
+                        (os_num, maquina),
+                    )
+                    if cur.fetchone()["cnt"] == 0:
+                        return (
+                            jsonify(
+                                {
+                                    "error": "Nenhum registro de amostragem encontrado para a máquina informada",
+                                    "code": "amostragem_nao_encontrada",
+                                }
+                            ),
+                            400,
+                        )
+
+                    cur.execute(
+                        "INSERT INTO ordem_servico (os) VALUES (%s)"
+                        " ON DUPLICATE KEY UPDATE os = VALUES(os)",
+                        (os_num,),
+                    )
+                    _upsert_os_maquina_status(cur, os_num, maquina, "fim_prod")
+                    novo_status = _consolidar_status_os(cur, os_num)
+                else:
+                    cur.execute(
+                        f"SELECT COUNT(*) AS cnt FROM operador_amostragem"
+                        " WHERE os=%s AND "
+                        f"{filtro_contexto}",
+                        (os_num,),
+                    )
+                    if cur.fetchone()["cnt"] == 0:
+                        return (
+                            jsonify({"error": "Nenhum registro de amostragem encontrado"}),
+                            400,
+                        )
+                    cur.execute(
+                        "UPDATE ordem_servico SET status='fim_prod' WHERE os=%s",
+                        (os_num,),
+                    )
+                    if cur.rowcount == 0:
+                        return jsonify({"error": "OS não encontrada"}), 404
             c.commit()
-        return jsonify({"status": "ok"})
+        resposta = {"status": "ok"}
+        if maquina:
+            resposta["maquina"] = maquina
+        if novo_status:
+            resposta["os_status"] = novo_status
+        return jsonify(resposta)
     except Exception as e:
         return jsonify({"error": f"Falha ao encerrar produção: {e}"}), 500
 
@@ -2648,6 +2804,10 @@ def relatorio_status_os():
         normalized = _normalize_text(raw_status or "")
         if normalized in {"encerrada", "finalizada", "finalizado"}:
             return "Finalizada"
+        if normalized in {"parcial", "parcialmente_encerrada", "parcialmente_finalizada"}:
+            return "Parcial"
+        if normalized in {"fim_prod", "fim_producao", "producao_encerrada"}:
+            return "Produção encerrada"
         return "Aberta"
 
     def _classificar_status(texto: str) -> Optional[str]:

--- a/lib/features/operador/presentation/operador_page.dart
+++ b/lib/features/operador/presentation/operador_page.dart
@@ -24,12 +24,12 @@ import 'package:admin/models/machine.dart';
 import 'package:admin/features/shared/providers/search_flow_form_provider.dart';
 
 final medidasOperadorControllerProvider =
-StateNotifierProvider.autoDispose<
-    MedidasOperadorController,
-    AsyncValue<List<MedidaItem>>
->((ref) {
-  return MedidasOperadorController(ref);
-});
+    StateNotifierProvider.autoDispose<
+      MedidasOperadorController,
+      AsyncValue<List<MedidaItem>>
+    >((ref) {
+      return MedidasOperadorController(ref);
+    });
 
 class MedidasOperadorController
     extends StateNotifier<AsyncValue<List<MedidaItem>>> {
@@ -245,9 +245,9 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
   }
 
   void _handleFlowStateChange(
-      SharedSearchFormState? previous,
-      SharedSearchFormState next,
-      ) {
+    SharedSearchFormState? previous,
+    SharedSearchFormState next,
+  ) {
     final previousChecklistRe = previous?.normalizedChecklistRe;
     final nextChecklistRe = next.normalizedChecklistRe;
     final shouldSyncChecklistRe =
@@ -273,8 +273,8 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
 
     final wasActive =
         previous != null &&
-            previous.isActive &&
-            previous.effectiveProcess == SearchFlowProcess.amostragem;
+        previous.isActive &&
+        previous.effectiveProcess == SearchFlowProcess.amostragem;
 
     final previousFlow = _activeAmostragemFlow;
     _activeAmostragemFlow = next;
@@ -296,7 +296,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
     unawaited(_checkAmostragemRecente());
     _amostragemMonitorTimer = Timer.periodic(
       const Duration(minutes: 1),
-          (_) => unawaited(_checkAmostragemRecente()),
+      (_) => unawaited(_checkAmostragemRecente()),
     );
   }
 
@@ -357,9 +357,9 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
   }
 
   void _handleAmostragemRecente(
-      SharedSearchFormState flow,
-      DateTime? ultimaAmostragem,
-      ) {
+    SharedSearchFormState flow,
+    DateTime? ultimaAmostragem,
+  ) {
     if (!mounted) return;
     if (ultimaAmostragem != null) {
       _lastAmostragem = ultimaAmostragem;
@@ -417,9 +417,9 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
   }
 
   Future<void> _showAmostragemReminder(
-      SharedSearchFormState flow,
-      Duration reminderInterval,
-      ) async {
+    SharedSearchFormState flow,
+    Duration reminderInterval,
+  ) async {
     if (!mounted || _amostragemReminderDialogOpen) return;
     _amostragemReminderDialogOpen = true;
     _lastReminderShownAt = DateTime.now();
@@ -473,7 +473,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
 
           if (_categoriaSel != null) {
             final possuiMaquina = _maquinas.any(
-                  (m) => m.categoria == _categoriaSel && m.codigo == _maquinaSel,
+              (m) => m.categoria == _categoriaSel && m.codigo == _maquinaSel,
             );
             if (!possuiMaquina && _maquinaSel != null) {
               _maquinaSel = null;
@@ -499,7 +499,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
     final maquina = _maquinaSel;
     if (categoria == null || maquina == null) return false;
     return _maquinas.any(
-          (m) => m.categoria == categoria && m.codigo == maquina,
+      (m) => m.categoria == categoria && m.codigo == maquina,
     );
   }
 
@@ -544,9 +544,9 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
   }
 
   bool _ensureChecklistReMatches(
-      SharedSearchFormState flow, {
-        bool showSnackBar = true,
-      }) {
+    SharedSearchFormState flow, {
+    bool showSnackBar = true,
+  }) {
     final expected = flow.normalizedChecklistRe;
     if (expected == null || expected.isEmpty) {
       return true;
@@ -811,8 +811,8 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
         final motivoLower = motivo.trim().toLowerCase();
         final exigeChecklist =
             motivoLower == 'fim do turno' ||
-                motivoLower == 'fim de turno' ||
-                motivoLower == 'troca de turno';
+            motivoLower == 'fim de turno' ||
+            motivoLower == 'troca de turno';
         bool clearedRe = false;
         if (exigeChecklist) {
           final notifier = ref.read(sharedSearchFormProvider.notifier);
@@ -984,13 +984,13 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                 children: motivos
                     .map(
                       (m) => RadioListTile<String>(
-                    title: Text(m),
-                    value: m,
-                    groupValue: selecionado,
-                    onChanged: (value) =>
-                        setState(() => selecionado = value),
-                  ),
-                )
+                        title: Text(m),
+                        value: m,
+                        groupValue: selecionado,
+                        onChanged: (value) =>
+                            setState(() => selecionado = value),
+                      ),
+                    )
                     .toList(),
               ),
             ),
@@ -1050,9 +1050,22 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
       return;
     }
 
+    if (!_maquinaSelecionadaValida()) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Selecione a máquina responsável pela produção.'),
+        ),
+      );
+      return;
+    }
+
     if (!_ensureFlowConsistency()) return;
 
-    final body = jsonEncode({'os': _osCtrl.text.trim()});
+    final body = jsonEncode({
+      'os': _osCtrl.text.trim(),
+      'maquina': _maquinaSel,
+    });
     final uri = buildApiUri('/operador/encerrar_producao');
     try {
       final resp = await http
@@ -1107,7 +1120,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
         title: const Text('Troca de O.S.'),
         content: const Text(
           'Deseja pausar a O.S. atual e liberar o fluxo para iniciar outra? '
-              'Será necessária nova liberação para retomar a produção desta O.S.',
+          'Será necessária nova liberação para retomar a produção desta O.S.',
         ),
         actions: [
           TextButton(
@@ -1159,9 +1172,9 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
   @override
   Widget build(BuildContext context) {
     ref.listen<SharedSearchFormState>(sharedSearchFormProvider, (
-        previous,
-        next,
-        ) {
+      previous,
+      next,
+    ) {
       _handleFlowStateChange(previous, next);
     });
 
@@ -1205,46 +1218,46 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
     final reOk = _reCtrl.text.trim().isNotEmpty;
     final osOk = _osCtrl.text.trim().isNotEmpty;
     final categoriaValue =
-    (_categoriaSel != null && _categorias.contains(_categoriaSel))
+        (_categoriaSel != null && _categorias.contains(_categoriaSel))
         ? _categoriaSel
         : null;
     final maquinasDisponiveis = _maquinas
         .where((m) => m.categoria == categoriaValue)
         .toList();
     final maquinaValue =
-    (_maquinaSel != null &&
-        maquinasDisponiveis.any((m) => m.codigo == _maquinaSel))
+        (_maquinaSel != null &&
+            maquinasDisponiveis.any((m) => m.codigo == _maquinaSel))
         ? _maquinaSel
         : null;
     final maquinaOk = (maquinaValue ?? '').isNotEmpty;
     final formMatchesFlow =
         !flowLocked ||
-            flowState.matchesValues(
-              os: _osCtrl.text,
-              partNumber: _partCtrl.text,
-              operacao: _opCtrl.text,
-              categoria: categoriaValue,
-              maquina: maquinaValue,
-            );
+        flowState.matchesValues(
+          os: _osCtrl.text,
+          partNumber: _partCtrl.text,
+          operacao: _opCtrl.text,
+          categoria: categoriaValue,
+          maquina: maquinaValue,
+        );
 
     // todas respondidas?
     final todasRespondidas =
         medidas.isNotEmpty &&
-            medidas.every(
-                  (m) =>
+        medidas.every(
+          (m) =>
               m.status != StatusMedida.pendente && (m.medicao ?? '').isNotEmpty,
-            );
+        );
 
     final podeRegistrar =
         formMatchesFlow &&
-            reOk &&
-            osOk &&
-            maquinaOk &&
-            todasRespondidas &&
-            !_registrando &&
-            !requiresChecklist &&
-            (normalizedChecklistRe == null ||
-                normalizedChecklistRe == _reCtrl.text.trim());
+        reOk &&
+        osOk &&
+        maquinaOk &&
+        todasRespondidas &&
+        !_registrando &&
+        !requiresChecklist &&
+        (normalizedChecklistRe == null ||
+            normalizedChecklistRe == _reCtrl.text.trim());
 
     return Scaffold(
       appBar: WindowBar(
@@ -1355,7 +1368,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                                       enabled: true,
                                       decoration: const InputDecoration(
                                         labelText:
-                                        'R.E. do Preparador', // ajuste o texto se for Operador
+                                            'R.E. do Preparador', // ajuste o texto se for Operador
                                         border: OutlineInputBorder(),
                                       ),
                                       onEditingComplete: () => _submitField(
@@ -1426,25 +1439,25 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                                       items: _categorias
                                           .map(
                                             (c) => DropdownMenuItem(
-                                          value: c,
-                                          child: Text(c),
-                                        ),
-                                      )
+                                              value: c,
+                                              child: Text(c),
+                                            ),
+                                          )
                                           .toList(),
                                       onChanged: flowLocked
                                           ? null
                                           : (v) {
-                                        ref
-                                            .read(
-                                          sharedSearchFormProvider
-                                              .notifier,
-                                        )
-                                            .setCategoria(v);
-                                        setState(() {
-                                          _categoriaSel = v;
-                                          _maquinaSel = null;
-                                        });
-                                      },
+                                              ref
+                                                  .read(
+                                                    sharedSearchFormProvider
+                                                        .notifier,
+                                                  )
+                                                  .setCategoria(v);
+                                              setState(() {
+                                                _categoriaSel = v;
+                                                _maquinaSel = null;
+                                              });
+                                            },
                                       validator: (v) => (v == null || v.isEmpty)
                                           ? 'Obrigatório'
                                           : null,
@@ -1461,22 +1474,22 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                                       items: maquinasDisponiveis
                                           .map(
                                             (m) => DropdownMenuItem(
-                                          value: m.codigo,
-                                          child: Text(m.codigo),
-                                        ),
-                                      )
+                                              value: m.codigo,
+                                              child: Text(m.codigo),
+                                            ),
+                                          )
                                           .toList(),
                                       onChanged: flowLocked
                                           ? null
                                           : (v) {
-                                        ref
-                                            .read(
-                                          sharedSearchFormProvider
-                                              .notifier,
-                                        )
-                                            .setMaquina(v);
-                                        setState(() => _maquinaSel = v);
-                                      },
+                                              ref
+                                                  .read(
+                                                    sharedSearchFormProvider
+                                                        .notifier,
+                                                  )
+                                                  .setMaquina(v);
+                                              setState(() => _maquinaSel = v);
+                                            },
                                       validator: (v) => (v == null || v.isEmpty)
                                           ? 'Obrigatório'
                                           : null,
@@ -1508,7 +1521,7 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                                         next: _opFocusNode,
                                       ),
                                       validator: (v) =>
-                                      (v == null || v.trim().isEmpty)
+                                          (v == null || v.trim().isEmpty)
                                           ? 'Obrigatório'
                                           : null,
                                     ),
@@ -1563,18 +1576,18 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                                       FocusScope.of(context).unfocus();
                                       await ref
                                           .read(
-                                        medidasOperadorControllerProvider
-                                            .notifier,
-                                      )
+                                            medidasOperadorControllerProvider
+                                                .notifier,
+                                          )
                                           .carregar(
-                                        os: _osCtrl.text.trim(),
-                                        partnumber: normalizeCode(
-                                          _partCtrl.text,
-                                        ),
-                                        operacao: normalizeCode(
-                                          _opCtrl.text,
-                                        ),
-                                      );
+                                            os: _osCtrl.text.trim(),
+                                            partnumber: normalizeCode(
+                                              _partCtrl.text,
+                                            ),
+                                            operacao: normalizeCode(
+                                              _opCtrl.text,
+                                            ),
+                                          );
                                       if (!mounted) return;
                                       final asyncMedidas = ref.read(
                                         medidasOperadorControllerProvider,
@@ -1584,17 +1597,17 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                                       }
                                       final iniciouFluxo = ref
                                           .read(
-                                        sharedSearchFormProvider.notifier,
-                                      )
+                                            sharedSearchFormProvider.notifier,
+                                          )
                                           .beginFlow(
-                                        os: _osCtrl.text.trim(),
-                                        partNumber: _partCtrl.text.trim(),
-                                        operacao: _opCtrl.text.trim(),
-                                        categoria: categoriaValue,
-                                        maquina: maquinaValue,
-                                        process:
-                                        SearchFlowProcess.amostragem,
-                                      );
+                                            os: _osCtrl.text.trim(),
+                                            partNumber: _partCtrl.text.trim(),
+                                            operacao: _opCtrl.text.trim(),
+                                            categoria: categoriaValue,
+                                            maquina: maquinaValue,
+                                            process:
+                                                SearchFlowProcess.amostragem,
+                                          );
                                       if (!iniciouFluxo) {
                                         _showFlowBlockedSnackBar(
                                           ref.read(sharedSearchFormProvider),
@@ -1672,12 +1685,12 @@ class _OperadorPageState extends ConsumerState<OperadorPage> {
                                   : null,
                               icon: _registrando
                                   ? const SizedBox(
-                                width: 18,
-                                height: 18,
-                                child: CircularProgressIndicator(
-                                  strokeWidth: 2,
-                                ),
-                              )
+                                      width: 18,
+                                      height: 18,
+                                      child: CircularProgressIndicator(
+                                        strokeWidth: 2,
+                                      ),
+                                    )
                                   : const Icon(Icons.save_outlined),
                               label: const Text('Registrar amostragem'),
                             ),


### PR DESCRIPTION
## Summary
- registrar o status de cada OS por máquina em uma nova tabela e consolidar o status geral conforme o andamento individual
- ajustar os fluxos de finalização e encerramento de produção para validar e atualizar o status por máquina antes de encerrar a OS
- exigir a seleção de máquina ao encerrar a produção no app do operador, enviando o código no payload da API

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6872889b883318232e20375bbb29b